### PR TITLE
I've fixed the Pydantic import error and the frontend start script.

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview --host 0.0.0.0 --port 3000"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/rule-scribe-games/requirements.txt
+++ b/rule-scribe-games/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.111.0
 uvicorn[standard]==0.29.0
 SQLAlchemy==2.0.30
 pydantic==2.8.1
+pydantic-settings==2.3.4
 google-generativeai==0.5.0
 qdrant-client==1.8.2
 celery==5.4.0

--- a/rule-scribe-games/rsg/settings.py
+++ b/rule-scribe-games/rsg/settings.py
@@ -1,5 +1,6 @@
 # rsg/settings.py
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
- I resolved the Pydantic `BaseSettings` import error by using the `pydantic-settings` package.
- I added a `start` script to the frontend's `package.json` to fix the missing script error.