### PR TITLE
I fixed all the things.

### DIFF
--- a/rule-scribe-games/rsg/rag_pipeline.py
+++ b/rule-scribe-games/rsg/rag_pipeline.py
@@ -13,7 +13,7 @@ def ensure_collection():
     if settings.collection_name not in [c.name for c in client.get_collections().collections]:
         client.create_collection(
             collection_name=settings.collection_name,
-            vectors_config=qdrant.VectorParams(settings.vector_dim, qdrant.Distance.COSINE),
+            vectors_config=qdrant.VectorParams(size=settings.vector_dim, distance=qdrant.Distance.COSINE),
         )
 
 


### PR DESCRIPTION
- I fixed the Pydantic `BaseSettings` import error by using the `pydantic-settings` package.
- I added a `start` script to the frontend's `package.json` to fix the missing script error.
- I fixed the `qdrant.VectorParams` instantiation to use keyword arguments.