### PR TITLE
Fix invalid image entries in generated sitemap

### DIFF
--- a/.github/workflows/test-sitemap.yml
+++ b/.github/workflows/test-sitemap.yml
@@ -1,0 +1,36 @@
+name: Test sitemap
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/services/sitemap.py"
+      - "backend/tests/test_sitemap.py"
+      - ".github/workflows/test-sitemap.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/services/sitemap.py"
+      - "backend/tests/test_sitemap.py"
+      - ".github/workflows/test-sitemap.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv sync --frozen --dev
+      - name: Run sitemap regression test
+        run: uv run pytest -q backend/tests/test_sitemap.py
+        env:
+          PYTHONPATH: backend

--- a/backend/app/services/sitemap.py
+++ b/backend/app/services/sitemap.py
@@ -51,12 +51,8 @@ async def get_sitemap_xml() -> str:
         if image_url:
             if image_url.startswith("/"):
                 image_url = f"{base_url}{image_url}"
-            img = ET.SubElement(root, f"{{{NS_IMAGE}}}image")  # Correctly attached image to specific loc would be better, but keeping logic
-            # Correcting: image should be child of url_elem
-            img = ET.SubElement(url_elem, f"{{{NS_IMAGE}}}image")
-            img_loc = ET.SubElement(img, f"{{{NS_IMAGE}}}loc")
-            img_loc.text = image_url
-            img_title = ET.SubElement(img, f"{{{NS_IMAGE}}}title")
-            img_title.text = game.get("title", "")
+            image = ET.SubElement(url_elem, f"{{{NS_IMAGE}}}image")
+            image_loc = ET.SubElement(image, f"{{{NS_IMAGE}}}loc")
+            image_loc.text = image_url
     xml_str = ET.tostring(root, encoding="unicode", method="xml")
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + xml_str

--- a/backend/tests/test_sitemap.py
+++ b/backend/tests/test_sitemap.py
@@ -1,0 +1,45 @@
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.services import sitemap  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_image_entries_are_nested_under_their_game_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_list_for_sitemap() -> list[dict[str, str]]:
+        return [
+            {
+                "slug": "catan",
+                "title": "カタン",
+                "updated_at": "2026-08-06T12:34:56Z",
+                "image_url": "/assets/games/catan.webp",
+            }
+        ]
+
+    monkeypatch.setattr(sitemap, "list_for_sitemap", fake_list_for_sitemap)
+    monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
+
+    xml_text = await sitemap.get_sitemap_xml()
+    root = ET.fromstring(xml_text)
+
+    url_tag = f"{{{sitemap.NS_SITEMAP}}}url"
+    image_tag = f"{{{sitemap.NS_IMAGE}}}image"
+    loc_tag = f"{{{sitemap.NS_SITEMAP}}}loc"
+    image_loc_tag = f"{{{sitemap.NS_IMAGE}}}loc"
+    image_title_tag = f"{{{sitemap.NS_IMAGE}}}title"
+
+    assert all(child.tag == url_tag for child in root)
+    game_url = next(
+        child
+        for child in root
+        if child.findtext(loc_tag) == "https://example.test/games/catan"
+    )
+    images = game_url.findall(image_tag)
+    assert len(images) == 1
+    assert images[0].findtext(image_loc_tag) == "https://example.test/assets/games/catan.webp"
+    assert images[0].find(image_title_tag) is None


### PR DESCRIPTION
## Summary
- remove the stray `image:image` element emitted directly under `urlset`
- keep each image entry nested under its owning game URL as required by Google's image sitemap format
- stop emitting deprecated `image:title`; retain only the required `image:loc`
- add an async regression test covering XML structure, relative image URL expansion, and absence of deprecated image-title metadata
- add a dedicated PR/main GitHub Actions regression workflow

## Audit context
Issue #72 records the SEO setup as complete, but the current generator emits an extra root-level image element whenever a game has an image. Google Search Central's current image sitemap documentation shows image entries nested inside their owning `<url>` and lists `<image:image>` plus `<image:loc>` as the required image tags; `image:title` is deprecated.

Primary source:
https://developers.google.com/search/docs/crawling-indexing/sitemaps/image-sitemaps

## Validation
- `backend/tests/test_sitemap.py` deterministically parses the generated XML
- verifies every direct `urlset` child is a sitemap `url`
- verifies exactly one image is nested under the game URL
- verifies relative image URLs are expanded to the configured site origin
- verifies deprecated `image:title` is absent
- `.github/workflows/test-sitemap.yml` runs the regression test on PR and main changes

Closes #72