### PR TITLE
Complete Board Game Arena link support

### DIFF
--- a/.github/workflows/test-bga-links.yml
+++ b/.github/workflows/test-bga-links.yml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: backend
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6

--- a/.github/workflows/test-bga-links.yml
+++ b/.github/workflows/test-bga-links.yml
@@ -1,0 +1,33 @@
+name: Test Board Game Arena links
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/**"
+      - "backend/app/prompts/**"
+      - "backend/app/core/local_db.py"
+      - "backend/tests/test_bga_links.py"
+      - ".github/workflows/test-bga-links.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/app/models/**"
+      - "backend/app/prompts/**"
+      - "backend/app/core/local_db.py"
+      - "backend/tests/test_bga_links.py"
+      - ".github/workflows/test-bga-links.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync --dev
+      - run: uv run pytest -q backend/tests/test_bga_links.py

--- a/backend/app/core/local_db.py
+++ b/backend/app/core/local_db.py
@@ -1,10 +1,11 @@
-import sqlite3
 import json
 import os
+import sqlite3
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 DB_PATH = Path("/home/kafka/projects/rule-scribe-games/data/games.db")
+
 
 def get_db():
     os.makedirs(DB_PATH.parent, exist_ok=True)
@@ -12,10 +13,11 @@ def get_db():
     conn.row_factory = sqlite3.Row
     return conn
 
+
 def init_db():
     conn = get_db()
     cursor = conn.cursor()
-    
+
     # Mirroring Supabase games schema
     cursor.execute("""
     CREATE TABLE IF NOT EXISTS games (
@@ -35,43 +37,49 @@ def init_db():
         strategy_tier TEXT,
         structured_data TEXT, -- JSON string
         infographics TEXT,    -- JSON string
+        bga_url TEXT,
         view_count INTEGER DEFAULT 0,
         created_at TEXT,
         updated_at TEXT
     )
     """)
-    
+
+    columns = {row[1] for row in cursor.execute("PRAGMA table_info(games)")}
+    if "bga_url" not in columns:
+        cursor.execute("ALTER TABLE games ADD COLUMN bga_url TEXT")
+
     conn.commit()
     conn.close()
+
 
 def upsert_game(game_data: Dict[str, Any]):
     conn = get_db()
     cursor = conn.cursor()
-    
+
     # Extract structured_data and infographics as JSON strings
     sd = game_data.get("structured_data", {})
     if isinstance(sd, dict):
         sd = json.dumps(sd, ensure_ascii=False)
-        
+
     info = game_data.get("infographics")
     if isinstance(info, dict):
         info = json.dumps(info, ensure_ascii=False)
-    
+
     fields = [
         game_data.get("id"), game_data.get("slug"), game_data.get("title"),
         game_data.get("title_ja"), game_data.get("summary"), game_data.get("description"),
         game_data.get("rules_content"), game_data.get("min_players"), game_data.get("max_players"),
         game_data.get("play_time"), game_data.get("min_age"), game_data.get("published_year"),
         game_data.get("image_url"), game_data.get("strategy_tier"), sd, info,
-        game_data.get("created_at"), game_data.get("updated_at")
+        game_data.get("bga_url"), game_data.get("created_at"), game_data.get("updated_at")
     ]
-    
+
     cursor.execute("""
     INSERT INTO games (
         id, slug, title, title_ja, summary, description, rules_content,
         min_players, max_players, play_time, min_age, published_year,
-        image_url, strategy_tier, structured_data, infographics, created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        image_url, strategy_tier, structured_data, infographics, bga_url, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(slug) DO UPDATE SET
         title=excluded.title,
         title_ja=excluded.title_ja,
@@ -87,24 +95,24 @@ def upsert_game(game_data: Dict[str, Any]):
         strategy_tier=excluded.strategy_tier,
         structured_data=excluded.structured_data,
         infographics=excluded.infographics,
+        bga_url=excluded.bga_url,
         updated_at=excluded.updated_at
     """, fields)
-    
+
     conn.commit()
     conn.close()
+
 
 def list_recent(limit: int = 100, offset: int = 0) -> Dict[str, Any]:
     conn = get_db()
     cursor = conn.cursor()
-    
-    # Get data
+
     cursor.execute(f"SELECT * FROM games ORDER BY updated_at DESC LIMIT {limit} OFFSET {offset}")
     rows = cursor.fetchall()
-    
-    # Get total count
+
     cursor.execute("SELECT COUNT(*) FROM games")
     total = cursor.fetchone()[0]
-    
+
     games = []
     for row in rows:
         g = dict(row)
@@ -113,9 +121,10 @@ def list_recent(limit: int = 100, offset: int = 0) -> Dict[str, Any]:
         if g.get("infographics"):
             g["infographics"] = json.loads(g["infographics"])
         games.append(g)
-        
+
     conn.close()
     return {"data": games, "total": total}
+
 
 def get_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     conn = get_db()
@@ -123,7 +132,7 @@ def get_by_slug(slug: str) -> Optional[Dict[str, Any]]:
     cursor.execute("SELECT * FROM games WHERE slug = ?", (slug,))
     row = cursor.fetchone()
     conn.close()
-    
+
     if row:
         g = dict(row)
         if g.get("structured_data"):
@@ -132,6 +141,7 @@ def get_by_slug(slug: str) -> Optional[Dict[str, Any]]:
             g["infographics"] = json.loads(g["infographics"])
         return g
     return None
+
 
 if __name__ == "__main__":
     init_db()

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,22 @@
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+def validate_bga_url(value: str | None) -> str | None:
+    """Accept only canonical HTTPS Board Game Arena links."""
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    parsed = urlparse(value)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not (host == "boardgamearena.com" or host.endswith(".boardgamearena.com")):
+        raise ValueError("bga_url must be an HTTPS URL on boardgamearena.com")
+    return value
 
 
 class BaseSchema(BaseModel):
@@ -28,6 +43,7 @@ class PersonaReview(BaseSchema):
     persona: str
     review_text: str
     rating: float
+
 
 class StructuredData(BaseSchema):
     keywords: list[Keyword] = []
@@ -81,6 +97,8 @@ class GameDetail(BaseSchema):
     created_at: str | None = None
     updated_at: str | None = None
 
+    _validate_bga_url = field_validator("bga_url")(validate_bga_url)
+
 
 class GameUpdate(BaseSchema):
     title: str | None = None
@@ -103,11 +121,14 @@ class GameUpdate(BaseSchema):
     image_url: str | None = None
     official_url: str | None = None
     bgg_url: str | None = None
+    bga_url: str | None = None
     structured_data: StructuredData | None = None
     rules_content: str | None = None
     infographics: dict[str, str] | None = None
     data_version: int | None = None
     last_regenerated_at: datetime | None = None
+
+    _validate_bga_url = field_validator("bga_url")(validate_bga_url)
 
 
 SEARCH_RESULT = GameDetail
@@ -124,7 +145,10 @@ class GeneratedGameMetadata(BaseSchema):
     min_age: int
     rules_content: str
     structured_data: StructuredData
+    bga_url: str | None = None
     infographics: dict[str, str] | None = None
+
+    _validate_bga_url = field_validator("bga_url")(validate_bga_url)
 
 
 class StrategyTier(BaseSchema):

--- a/backend/app/prompts/prompts.py
+++ b/backend/app/prompts/prompts.py
@@ -15,6 +15,7 @@ Return ONLY valid JSON matching this schema:
     "max_players": int,
     "play_time": int (minutes),
     "min_age": int (recommended age),
+    "bga_url": "Verified HTTPS Board Game Arena game URL, or null",
     "rules_content": "See format below",
     "structured_data": {{
         "keywords": [
@@ -39,7 +40,8 @@ IMPORTANT GUIDELINES:
 3. key_elements: Include 4-6 fun elements.
 4. **STYLE: Explain Like I'm 5.** Use polite Japanese (Desu/Masu). Avoid Katakana jargon where possible.
 5. Focus on "How to start" and "What do I do on my turn?".
-If the game is not found, do your best to infer from similar games.
+6. bga_url MUST be null unless the exact game is confirmed on Board Game Arena. Never infer a slug or fabricate a URL. When present, it MUST use HTTPS and a boardgamearena.com host.
+If the game is not found, do your best to infer from similar games, but keep bga_url null.
 """
     },
     "metadata_critic": {
@@ -52,6 +54,7 @@ Check:
 3. Are there 5-8 keywords explaining game terms simply?
 4. Are there 4-6 key_elements describing fun components?
 5. Is the flow of play clear step-by-step?
+6. Preserve bga_url only when it is a verified HTTPS URL on boardgamearena.com; otherwise set it to null.
 Return the improved JSON with richer, simpler content.
 """
     },

--- a/backend/tests/test_bga_links.py
+++ b/backend/tests/test_bga_links.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import GameDetail, GameUpdate, GeneratedGameMetadata, StructuredData
+from app.prompts.prompts import PROMPTS
+
+
+VALID_BGA_URL = "https://en.boardgamearena.com/gamepanel?game=azul"
+
+
+def test_bga_url_is_supported_across_read_update_and_generated_models():
+    detail = GameDetail(id="game-1", title="Azul", bga_url=VALID_BGA_URL)
+    update = GameUpdate(bga_url=VALID_BGA_URL)
+    generated = GeneratedGameMetadata(
+        title="Azul",
+        summary="summary",
+        description="description",
+        min_players=2,
+        max_players=4,
+        play_time=45,
+        min_age=8,
+        rules_content="rules",
+        structured_data=StructuredData(),
+        bga_url=VALID_BGA_URL,
+    )
+
+    assert detail.bga_url == VALID_BGA_URL
+    assert update.bga_url == VALID_BGA_URL
+    assert generated.bga_url == VALID_BGA_URL
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://en.boardgamearena.com/gamepanel?game=azul",
+        "https://boardgamearena.example/gamepanel?game=azul",
+        "https://evil.example/?next=https://boardgamearena.com",
+    ],
+)
+def test_bga_url_rejects_non_https_or_non_bga_hosts(url):
+    with pytest.raises(ValidationError):
+        GameUpdate(bga_url=url)
+
+
+def test_blank_bga_url_normalizes_to_none():
+    assert GameUpdate(bga_url="  ").bga_url is None
+
+
+def test_prompt_requires_verified_bga_url_and_forbids_fabricated_slugs():
+    prompt = PROMPTS["metadata_generator"]["generate"]
+
+    assert '"bga_url"' in prompt
+    assert "MUST be null unless" in prompt
+    assert "Never infer a slug or fabricate a URL" in prompt
+    assert "boardgamearena.com" in prompt
+
+
+def test_local_database_schema_and_upsert_include_bga_url():
+    source = Path("backend/app/core/local_db.py").read_text(encoding="utf-8")
+
+    assert "bga_url TEXT" in source
+    assert "ALTER TABLE games ADD COLUMN bga_url TEXT" in source
+    assert "bga_url=excluded.bga_url" in source


### PR DESCRIPTION
## Summary
- add validated `bga_url` support to read, manual update, and generated metadata schemas
- require verified HTTPS `boardgamearena.com` URLs in the generation and critic prompts; unknown links remain `null`
- persist `bga_url` in the local SQLite schema, including an idempotent migration for existing databases
- add regression tests and a focused GitHub Actions workflow

The existing UI already renders Board Game Arena as the last item in the Links section. This PR completes the backend schema, persistence, prompt, validation, and audit path.

## Validation
- accepted: `https://en.boardgamearena.com/gamepanel?game=azul`
- rejected: HTTP, lookalike domains, and redirect-style non-BGA URLs
- blank values normalize to `null`
- prompt is audited for anti-fabrication requirements
- local schema and upsert path are audited for `bga_url`

Official service/domain reference: https://en.boardgamearena.com/gamelist

Closes #70