### PR TITLE
Fix game detail root grid collapse and desktop layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Build Project Artifacts
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Preview to Vercel
+        run: vercel deploy --yes --token=${{ secrets.VERCEL_TOKEN }}
 
   Deploy-Production:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -34,11 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
-      - name: Install uv
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Pull Vercel Environment Information
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Build Project Artifacts
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy Project Artifacts to Vercel
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Production to Vercel
+        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/frontend-layout.yml
+++ b/.github/workflows/frontend-layout.yml
@@ -1,0 +1,45 @@
+name: Frontend layout regression
+
+on:
+  pull_request:
+    paths:
+      - "frontend/**"
+      - ".github/workflows/frontend-layout.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  game-layout:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Lint changed layout surface
+        working-directory: frontend
+        run: npx eslint src/main.jsx src/pages/GamePage.jsx tests/game_layout.spec.js playwright.config.js
+
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Test game detail layout
+        working-directory: frontend
+        run: npx playwright test tests/game_layout.spec.js --project=chromium

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,5 +1,3 @@
-uv.lock
-pyproject.toml
 .venv/
 .playwright_data/
 *.pdf

--- a/.vercelignore
+++ b/.vercelignore
@@ -3,6 +3,5 @@ pyproject.toml
 .venv/
 .playwright_data/
 *.pdf
-assets/
 output_slides/
 backend/.ruff_cache/

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -6,8 +7,14 @@ export default defineConfig({
   workers: 1,
   reporter: 'line',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://127.0.0.1:5173',
     trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1',
+    url: 'http://127.0.0.1:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
   },
   projects: [
     {

--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -1,0 +1,197 @@
+/* Layout ownership: body is the viewport, #root owns route layout. */
+body {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+#root {
+  display: grid;
+  grid-template-areas:
+    "header header"
+    "sidebar main";
+  grid-template-columns: 320px minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
+  width: 100%;
+  min-width: 0;
+  height: 100dvh;
+}
+
+#root > header {
+  grid-area: header;
+}
+
+#root > aside {
+  grid-area: sidebar;
+  min-width: 0;
+}
+
+#root > main {
+  grid-area: main;
+  min-width: 0;
+}
+
+/* Route pages that are not the directory shell must span the whole viewport. */
+#root > :not(header):not(aside):not(main) {
+  grid-column: 1 / -1;
+  grid-row: 1 / -1;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.game-detail-content {
+  width: 100%;
+  min-width: 0;
+  height: 100dvh;
+  overflow-y: auto;
+  overflow-x: clip;
+  padding: 1.5rem 2rem 3rem;
+}
+
+.game-page-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: min(1440px, 100%);
+  margin: 0 auto 1.5rem;
+}
+
+.game-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: clamp(2rem, 4vw, 3rem);
+  align-items: start;
+  width: min(1440px, 100%);
+  margin: 0 auto;
+}
+
+.game-sidebar,
+.game-main,
+.game-main > *,
+.pro-main-col,
+.markdown-content {
+  min-width: 0;
+}
+
+.game-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.game-sidebar .pro-stats-grid,
+.game-sidebar .pro-card {
+  margin-bottom: 0;
+}
+
+.game-sidebar .pro-stats-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.game-main {
+  width: 100%;
+  max-width: 900px;
+}
+
+.game-main .game-content {
+  min-width: 0;
+  margin-bottom: 1.5rem;
+}
+
+.game-main .game-title {
+  min-width: 0;
+  max-width: 100%;
+  font-size: clamp(2.25rem, 5vw, 4.25rem);
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+  overflow-wrap: anywhere;
+}
+
+.rules-tabs {
+  flex-wrap: wrap;
+  max-width: 100%;
+  overflow: visible;
+}
+
+.rules-tabs button {
+  min-height: 44px;
+  white-space: nowrap;
+}
+
+.markdown-content,
+.summary-text,
+.review-text,
+.tip-item,
+.mistake-item {
+  overflow-wrap: anywhere;
+}
+
+.markdown-content img,
+.markdown-content video,
+.markdown-content iframe {
+  max-width: 100%;
+}
+
+.markdown-content pre,
+.markdown-content table {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.header-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+@media (max-width: 900px) {
+  #root {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "header"
+      "main";
+  }
+
+  #root > aside {
+    display: none;
+  }
+
+  .game-layout {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+
+  .game-main {
+    max-width: none;
+  }
+}
+
+@media (max-width: 680px) {
+  .game-detail-content {
+    padding: 1rem;
+  }
+
+  .game-page-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .header-actions {
+    justify-content: flex-start;
+  }
+
+  .game-main .game-title {
+    font-size: clamp(2rem, 12vw, 3rem);
+  }
+
+  .rules-tabs {
+    gap: 4px;
+  }
+
+  .rules-tabs button {
+    padding-inline: 10px;
+    font-size: 0.78rem;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import './index.css'
+import './layout.css'
 
 const GamePage = lazy(() => import('./pages/GamePage.jsx'))
 const DataPage = lazy(() => import('./pages/DataPage.jsx'))

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -37,7 +37,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
           setLoading(false)
         }
       }
-      
+
       if (allGames.length === 0) {
         try {
           const data = await api.get('/api/games?limit=50')
@@ -71,13 +71,15 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
   const imageUrl = game.image_url || `${BASE_URL}/assets/no-image.webp`
 
   return (
-    <div className="game-detail-content" style={{ overflowY: 'auto', height: '100dvh', padding: '1.5rem 2rem' }}>
+    <div className="game-detail-content">
       <Helmet>
         <title>{pageTitle}</title>
         <meta name="description" content={description} />
+        <link rel="canonical" href={gameUrl} />
+        <meta property="og:image" content={imageUrl} />
       </Helmet>
 
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem' }}>
+      <div className="game-page-toolbar">
         <Link to="/" className="back-link" style={{ margin: 0 }}>← DIRECTORY</Link>
         <div className="header-actions">
           <TextToSpeech text={`${title}. ${description}`} />
@@ -87,170 +89,32 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
         </div>
       </div>
 
-      <div className="game-content">
-        <h1 className="game-title">{title}</h1>
-        {game.strategy_tier && <div className="tier-badge" style={{ position: 'static', fontSize: '1.2rem', padding: '4px 12px' }}>TIER {game.strategy_tier}</div>}
-      </div>
-
-      <div className="pro-stats-grid">
-        <div className="pro-stat-card">
-          <div className="pro-stat-label">PLAYERS</div>
-          <div className="pro-stat-value">{game.min_players}{game.max_players ? `-${game.max_players}` : ''}</div>
-        </div>
-        <div className="pro-stat-card">
-          <div className="pro-stat-label">TIME</div>
-          <div className="pro-stat-value">{game.play_time}m</div>
-        </div>
-        <div className="pro-stat-card">
-          <div className="pro-stat-label">AGE</div>
-          <div className="pro-stat-value">{game.min_age}+</div>
-        </div>
-        <div className="pro-stat-card">
-          <div className="pro-stat-label">YEAR</div>
-          <div className="pro-stat-value">{game.published_year || 'N/A'}</div>
-        </div>
-      </div>
-
-      <div className="pro-card" style={{ borderLeft: '4px solid #fff' }}>
-        <div className="pro-card-title">SYNOPSIS</div>
-        <div className="summary-text">{game.summary || game.description}</div>
-      </div>
-
-      <div className="rules-tabs">
-        <button className={activeTab === 'rules' ? 'active' : ''} onClick={() => setActiveTab('rules')}>ANALYSIS & RULES</button>
-        <button className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>INST COACH</button>
-        <button className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>STRATEGY GUIDE</button>
-        <button className={activeTab === 'reviews' ? 'active' : ''} onClick={() => setActiveTab('reviews')}>SUBAGENT REVIEWS</button>
-        <button className={activeTab === 'graph' ? 'active' : ''} onClick={() => setActiveTab('graph')}>CONNECTIONS</button>
-        {game.infographics && <button className={activeTab === 'infographics' ? 'active' : ''} onClick={() => setActiveTab('infographics')}>INFOGRAPHICS</button>}
-      </div>
-
-      <div className="pro-section-grid">
-        <div className="pro-main-col">
-          {activeTab === 'rules' && (
-            <div className="markdown-content">
-              <ReactMarkdown>{rules}</ReactMarkdown>
+      <div className="game-layout">
+        <div className="game-sidebar" aria-label="ゲーム基本情報">
+          <div className="pro-stats-grid">
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">PLAYERS</div>
+              <div className="pro-stat-value">{game.min_players}{game.max_players ? `-${game.max_players}` : ''}</div>
             </div>
-          )}
-
-          {activeTab === 'coach' && (
-            <div className="coach-mode">
-              <div className="coach-step active">
-                <span className="coach-step-num">STEP 1</span>
-                <div className="coach-step-title">セットアップ (Setup)</div>
-                <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
-                  コンポーネントを準備し、各プレイヤーに初期リソースを配布します。
-                  {sd.key_elements?.length > 0 && (
-                    <div style={{ marginTop: '1rem', color: 'var(--text-secondary)' }}>
-                      💡 注目要素: {sd.key_elements.map(e => e.name).join(', ')}
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              <div className="coach-step">
-                <span className="coach-step-num">STEP 2</span>
-                <div className="coach-step-title">ゲームの目的 (Objective)</div>
-                <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
-                  {game.summary || '勝利条件を確認します。'}
-                </div>
-              </div>
-
-              <div className="coach-step">
-                <span className="coach-step-num">STEP 3</span>
-                <div className="coach-step-title">手番の流れ (Turn Flow)</div>
-                <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
-                  1. アクションを選択 <br />
-                  2. リソースを支払う <br />
-                  3. 効果を解決 <br />
-                  <br />
-                  {sd.mechanics?.length > 0 && (
-                    <div className="tag-list">
-                      {sd.mechanics.map(m => <span key={m} className="tag-item">{m}</span>)}
-                    </div>
-                  )}
-                </div>
-              </div>
-              
-              <div style={{ textAlign: 'center', padding: '1rem', color: 'var(--text-muted)', fontSize: '0.8rem' }}>
-                AIによるインストガイドです。詳細は「ANALYSIS & RULES」タブを確認してください。
-              </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">TIME</div>
+              <div className="pro-stat-value">{game.play_time}m</div>
             </div>
-          )}
-
-          {activeTab === 'strategy' && (
-            <div className="markdown-content">
-              {sd.strategy_analysis ? (
-                <ReactMarkdown>{sd.strategy_analysis}</ReactMarkdown>
-              ) : (
-                <div style={{ padding: '2rem', textAlign: 'center', background: '#111', borderRadius: '8px', color: '#666' }}>
-                  No deep strategy analysis available yet. Try regenerating.
-                </div>
-              )}
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">AGE</div>
+              <div className="pro-stat-value">{game.min_age}+</div>
             </div>
-          )}
-
-          {activeTab === 'reviews' && (
-            <div className="persona-reviews">
-              <div className="pro-card-title">SUB-AGENT PERSPECTIVES</div>
-              <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', marginBottom: '1.5rem' }}>
-                異なるプレイスタイルのAIエージェントによる多角的な評価。
-              </p>
-              
-              {sd.persona_reviews?.length > 0 ? sd.persona_reviews.map((rev, i) => (
-                <div key={i} className="review-card">
-                  <div className="review-header">
-                    <span className="persona-badge">{rev.persona}</span>
-                    <span className="rating-badge">{rev.rating} / 10</span>
-                  </div>
-                  <div className="review-text">「{rev.review_text}」</div>
-                </div>
-              )) : (
-                <div style={{ padding: '2rem', textAlign: 'center', background: '#111', borderRadius: '8px', color: '#666' }}>
-                  No persona reviews available yet. Try regenerating.
-                </div>
-              )}
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">YEAR</div>
+              <div className="pro-stat-value">{game.published_year || 'N/A'}</div>
             </div>
-          )}
+          </div>
 
-          {activeTab === 'graph' && (
-            <div className="graph-perspective">
-              <div className="pro-card-title">CONNECTIONS (MECHANICAL DNA)</div>
-              <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', marginBottom: '1.5rem' }}>
-                このゲームと同じメカニクスを持つアーカイブ内のゲーム。
-              </p>
-              
-              {sd.mechanics?.map((m, i) => {
-                const related = allGames.filter(g => 
-                  g.slug !== slug && 
-                  g.structured_data?.mechanics?.includes(m)
-                ).slice(0, 3)
+          <div className="pro-card" style={{ borderLeft: '4px solid #fff' }}>
+            <div className="pro-card-title">SYNOPSIS</div>
+            <div className="summary-text">{game.summary || game.description}</div>
+          </div>
 
-                return (
-                  <div key={i} style={{ marginBottom: '1.5rem' }}>
-                    <div style={{ fontSize: '0.75rem', fontWeight: 700, color: 'var(--accent)', marginBottom: '8px' }}>{m.toUpperCase()}</div>
-                    {related.length > 0 ? related.map(rg => (
-                      <Link to={`/games/${rg.slug}`} key={rg.id} className="relation-node">
-                        <img src={rg.image_url || '/assets/no-image.webp'} style={{ width: '40px', height: '40px', objectFit: 'cover', borderRadius: '4px' }} alt={rg.title_ja} />
-                        <div>
-                          <div style={{ fontSize: '0.9rem', fontWeight: 600 }}>{rg.title_ja || rg.title}</div>
-                          <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>{rg.summary?.slice(0, 40)}...</div>
-                        </div>
-                      </Link>
-                    )) : (
-                      <div style={{ fontSize: '0.8rem', color: '#444', padding: '10px' }}>No direct connections found in archive.</div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
-          )}
-
-          {activeTab === 'infographics' && <InfographicsGallery infographics={game.infographics} />}
-          {activeTab === 'data' && <pre style={{ background: '#111', padding: '1rem', borderRadius: '8px', overflowX: 'auto' }}>{JSON.stringify(game, null, 2)}</pre>}
-        </div>
-
-        <div className="pro-sidebar">
           {sd.pro_tips?.length > 0 && (
             <div className="pro-card">
               <div className="pro-card-title">💡 PRO TIPS</div>
@@ -286,6 +150,150 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
           <div className="pro-card">
             <div className="pro-card-title">LINKS</div>
             <ExternalLinks game={game} />
+          </div>
+        </div>
+
+        <div className="game-main">
+          <div className="game-content">
+            <h1 className="game-title">{title}</h1>
+            {game.strategy_tier && (
+              <div className="tier-badge" style={{ position: 'static', fontSize: '1.2rem', padding: '4px 12px' }}>
+                TIER {game.strategy_tier}
+              </div>
+            )}
+          </div>
+
+          <div className="rules-tabs" role="tablist" aria-label="ゲーム詳細表示">
+            <button role="tab" aria-selected={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => setActiveTab('rules')}>ANALYSIS & RULES</button>
+            <button role="tab" aria-selected={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>INST COACH</button>
+            <button role="tab" aria-selected={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>STRATEGY GUIDE</button>
+            <button role="tab" aria-selected={activeTab === 'reviews'} className={activeTab === 'reviews' ? 'active' : ''} onClick={() => setActiveTab('reviews')}>SUBAGENT REVIEWS</button>
+            <button role="tab" aria-selected={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => setActiveTab('graph')}>CONNECTIONS</button>
+            {game.infographics && <button role="tab" aria-selected={activeTab === 'infographics'} className={activeTab === 'infographics' ? 'active' : ''} onClick={() => setActiveTab('infographics')}>INFOGRAPHICS</button>}
+          </div>
+
+          <div className="pro-main-col">
+            {activeTab === 'rules' && (
+              <div className="markdown-content">
+                <ReactMarkdown>{rules}</ReactMarkdown>
+              </div>
+            )}
+
+            {activeTab === 'coach' && (
+              <div className="coach-mode">
+                <div className="coach-step active">
+                  <span className="coach-step-num">STEP 1</span>
+                  <div className="coach-step-title">セットアップ (Setup)</div>
+                  <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
+                    コンポーネントを準備し、各プレイヤーに初期リソースを配布します。
+                    {sd.key_elements?.length > 0 && (
+                      <div style={{ marginTop: '1rem', color: 'var(--text-secondary)' }}>
+                        💡 注目要素: {sd.key_elements.map(e => e.name).join(', ')}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="coach-step">
+                  <span className="coach-step-num">STEP 2</span>
+                  <div className="coach-step-title">ゲームの目的 (Objective)</div>
+                  <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
+                    {game.summary || '勝利条件を確認します。'}
+                  </div>
+                </div>
+
+                <div className="coach-step">
+                  <span className="coach-step-num">STEP 3</span>
+                  <div className="coach-step-title">手番の流れ (Turn Flow)</div>
+                  <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
+                    1. アクションを選択 <br />
+                    2. リソースを支払う <br />
+                    3. 効果を解決 <br />
+                    <br />
+                    {sd.mechanics?.length > 0 && (
+                      <div className="tag-list">
+                        {sd.mechanics.map(m => <span key={m} className="tag-item">{m}</span>)}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div style={{ textAlign: 'center', padding: '1rem', color: 'var(--text-muted)', fontSize: '0.8rem' }}>
+                  AIによるインストガイドです。詳細は「ANALYSIS & RULES」タブを確認してください。
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'strategy' && (
+              <div className="markdown-content">
+                {sd.strategy_analysis ? (
+                  <ReactMarkdown>{sd.strategy_analysis}</ReactMarkdown>
+                ) : (
+                  <div style={{ padding: '2rem', textAlign: 'center', background: '#111', borderRadius: '8px', color: '#666' }}>
+                    No deep strategy analysis available yet. Try regenerating.
+                  </div>
+                )}
+              </div>
+            )}
+
+            {activeTab === 'reviews' && (
+              <div className="persona-reviews">
+                <div className="pro-card-title">SUB-AGENT PERSPECTIVES</div>
+                <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', marginBottom: '1.5rem' }}>
+                  異なるプレイスタイルのAIエージェントによる多角的な評価。
+                </p>
+
+                {sd.persona_reviews?.length > 0 ? sd.persona_reviews.map((rev, i) => (
+                  <div key={i} className="review-card">
+                    <div className="review-header">
+                      <span className="persona-badge">{rev.persona}</span>
+                      <span className="rating-badge">{rev.rating} / 10</span>
+                    </div>
+                    <div className="review-text">「{rev.review_text}」</div>
+                  </div>
+                )) : (
+                  <div style={{ padding: '2rem', textAlign: 'center', background: '#111', borderRadius: '8px', color: '#666' }}>
+                    No persona reviews available yet. Try regenerating.
+                  </div>
+                )}
+              </div>
+            )}
+
+            {activeTab === 'graph' && (
+              <div className="graph-perspective">
+                <div className="pro-card-title">CONNECTIONS (MECHANICAL DNA)</div>
+                <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', marginBottom: '1.5rem' }}>
+                  このゲームと同じメカニクスを持つアーカイブ内のゲーム。
+                </p>
+
+                {sd.mechanics?.map((m, i) => {
+                  const related = allGames.filter(g =>
+                    g.slug !== slug &&
+                    g.structured_data?.mechanics?.includes(m)
+                  ).slice(0, 3)
+
+                  return (
+                    <div key={i} style={{ marginBottom: '1.5rem' }}>
+                      <div style={{ fontSize: '0.75rem', fontWeight: 700, color: 'var(--accent)', marginBottom: '8px' }}>{m.toUpperCase()}</div>
+                      {related.length > 0 ? related.map(rg => (
+                        <Link to={`/games/${rg.slug}`} key={rg.id} className="relation-node">
+                          <img src={rg.image_url || '/assets/no-image.webp'} style={{ width: '40px', height: '40px', objectFit: 'cover', borderRadius: '4px' }} alt={rg.title_ja || rg.title || ''} />
+                          <div>
+                            <div style={{ fontSize: '0.9rem', fontWeight: 600 }}>{rg.title_ja || rg.title}</div>
+                            <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>{rg.summary?.slice(0, 40)}...</div>
+                          </div>
+                        </Link>
+                      )) : (
+                        <div style={{ fontSize: '0.8rem', color: '#444', padding: '10px' }}>No direct connections found in archive.</div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+
+            {activeTab === 'infographics' && <InfographicsGallery infographics={game.infographics} />}
+            {activeTab === 'data' && <pre style={{ background: '#111', padding: '1rem', borderRadius: '8px', overflowX: 'auto' }}>{JSON.stringify(game, null, 2)}</pre>}
           </div>
         </div>
       </div>

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test'
+
+const bigShot = {
+  id: 76,
+  slug: 'big-shot',
+  title: 'Big Shot',
+  title_ja: 'ビッグショット',
+  min_players: 2,
+  max_players: 4,
+  play_time: 45,
+  min_age: 10,
+  published_year: 2001,
+  summary: '土地を競り落とし、資金を管理しながら得点を競うオークションゲーム。',
+  description: 'Big Shot description',
+  rules_content: '# Big Shot Rules\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\nゲーム終了時に得点を計算します。',
+  structured_data: {
+    mechanics: ['Auction / Bidding', 'Area Majority'],
+    strategy_analysis: '## Strategy\n\n資金効率を優先します。',
+    pro_tips: ['序盤で資金を使い切らない。'],
+    rule_mistakes: ['借金の扱いを確認する。'],
+    keywords: [{ term: 'Auction', description: '競り' }],
+    persona_reviews: [],
+  },
+}
+
+async function mockGameApi(page) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/big-shot') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game: bigShot }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('desktop game detail uses metadata sidebar plus readable main without page overflow', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+
+  await expect(page.getByRole('heading', { name: 'ビッグショット' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: 'ANALYSIS & RULES' })).toBeVisible()
+
+  const metrics = await page.evaluate(() => {
+    const sidebar = document.querySelector('.game-sidebar').getBoundingClientRect()
+    const main = document.querySelector('.game-main').getBoundingClientRect()
+    const title = document.querySelector('.game-title').getBoundingClientRect()
+    const tabs = document.querySelector('.rules-tabs').getBoundingClientRect()
+    return {
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      sidebar: { x: sidebar.x, y: sidebar.y, width: sidebar.width },
+      main: { x: main.x, y: main.y, width: main.width },
+      titleX: title.x,
+      tabsX: tabs.x,
+    }
+  })
+
+  expect(metrics.scrollWidth).toBe(metrics.clientWidth)
+  expect(metrics.sidebar.width).toBeGreaterThanOrEqual(280)
+  expect(metrics.sidebar.width).toBeLessThanOrEqual(340)
+  expect(metrics.main.width).toBeGreaterThan(600)
+  expect(metrics.main.x).toBeGreaterThan(metrics.sidebar.x + metrics.sidebar.width)
+  expect(metrics.titleX).toBeGreaterThanOrEqual(metrics.main.x)
+  expect(metrics.tabsX).toBeGreaterThanOrEqual(metrics.main.x)
+})
+
+test('game detail collapses to one column at 800px', async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 900 })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+
+  const metrics = await page.evaluate(() => {
+    const sidebar = document.querySelector('.game-sidebar').getBoundingClientRect()
+    const main = document.querySelector('.game-main').getBoundingClientRect()
+    return {
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      sidebar: { x: sidebar.x, y: sidebar.y, width: sidebar.width },
+      main: { x: main.x, y: main.y, width: main.width },
+    }
+  })
+
+  expect(metrics.scrollWidth).toBe(metrics.clientWidth)
+  expect(Math.abs(metrics.sidebar.x - metrics.main.x)).toBeLessThan(2)
+  expect(Math.abs(metrics.sidebar.width - metrics.main.width)).toBeLessThan(2)
+  expect(metrics.main.y).toBeGreaterThan(metrics.sidebar.y)
+})

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -34,56 +34,49 @@ async function mockGameApi(page) {
   })
 }
 
-test('desktop game detail uses metadata sidebar plus readable main without page overflow', async ({ page }) => {
-  await page.setViewportSize({ width: 1280, height: 900 })
+async function readLayout(page) {
+  return page.evaluate(() => {
+    const sidebar = document.querySelector('.game-sidebar')?.getBoundingClientRect()
+    const main = document.querySelector('.game-main')?.getBoundingClientRect()
+    const title = document.querySelector('.game-title')?.getBoundingClientRect()
+    const tabs = document.querySelector('.rules-tabs')?.getBoundingClientRect()
+
+    if (!sidebar || !main || !title || !tabs) throw new Error('game detail layout nodes are missing')
+
+    return {
+      clientWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      sidebar: { x: sidebar.x, y: sidebar.y, width: sidebar.width, height: sidebar.height },
+      main: { x: main.x, y: main.y, width: main.width, height: main.height },
+      titleX: title.x,
+      tabsX: tabs.x,
+    }
+  })
+}
+
+test('game detail keeps a readable desktop main and collapses cleanly at 800px', async ({ page }) => {
   await mockGameApi(page)
+  await page.setViewportSize({ width: 1280, height: 900 })
   await page.goto('/games/big-shot')
 
   await expect(page.getByRole('heading', { name: 'ビッグショット' })).toBeVisible()
   await expect(page.getByRole('tab', { name: 'ANALYSIS & RULES' })).toBeVisible()
 
-  const metrics = await page.evaluate(() => {
-    const sidebar = document.querySelector('.game-sidebar').getBoundingClientRect()
-    const main = document.querySelector('.game-main').getBoundingClientRect()
-    const title = document.querySelector('.game-title').getBoundingClientRect()
-    const tabs = document.querySelector('.rules-tabs').getBoundingClientRect()
-    return {
-      clientWidth: document.documentElement.clientWidth,
-      scrollWidth: document.documentElement.scrollWidth,
-      sidebar: { x: sidebar.x, y: sidebar.y, width: sidebar.width },
-      main: { x: main.x, y: main.y, width: main.width },
-      titleX: title.x,
-      tabsX: tabs.x,
-    }
-  })
+  const desktop = await readLayout(page)
+  expect(desktop.scrollWidth).toBe(desktop.clientWidth)
+  expect(desktop.sidebar.width).toBeGreaterThanOrEqual(280)
+  expect(desktop.sidebar.width).toBeLessThanOrEqual(340)
+  expect(desktop.main.width).toBeGreaterThan(600)
+  expect(desktop.main.x).toBeGreaterThan(desktop.sidebar.x + desktop.sidebar.width)
+  expect(desktop.titleX).toBeGreaterThanOrEqual(desktop.main.x)
+  expect(desktop.tabsX).toBeGreaterThanOrEqual(desktop.main.x)
 
-  expect(metrics.scrollWidth).toBe(metrics.clientWidth)
-  expect(metrics.sidebar.width).toBeGreaterThanOrEqual(280)
-  expect(metrics.sidebar.width).toBeLessThanOrEqual(340)
-  expect(metrics.main.width).toBeGreaterThan(600)
-  expect(metrics.main.x).toBeGreaterThan(metrics.sidebar.x + metrics.sidebar.width)
-  expect(metrics.titleX).toBeGreaterThanOrEqual(metrics.main.x)
-  expect(metrics.tabsX).toBeGreaterThanOrEqual(metrics.main.x)
-})
-
-test('game detail collapses to one column at 800px', async ({ page }) => {
   await page.setViewportSize({ width: 800, height: 900 })
-  await mockGameApi(page)
-  await page.goto('/games/big-shot')
+  await expect(page.locator('.game-layout')).toHaveCSS('grid-template-columns', /\d+(?:\.\d+)?px/)
 
-  const metrics = await page.evaluate(() => {
-    const sidebar = document.querySelector('.game-sidebar').getBoundingClientRect()
-    const main = document.querySelector('.game-main').getBoundingClientRect()
-    return {
-      clientWidth: document.documentElement.clientWidth,
-      scrollWidth: document.documentElement.scrollWidth,
-      sidebar: { x: sidebar.x, y: sidebar.y, width: sidebar.width },
-      main: { x: main.x, y: main.y, width: main.width },
-    }
-  })
-
-  expect(metrics.scrollWidth).toBe(metrics.clientWidth)
-  expect(Math.abs(metrics.sidebar.x - metrics.main.x)).toBeLessThan(2)
-  expect(Math.abs(metrics.sidebar.width - metrics.main.width)).toBeLessThan(2)
-  expect(metrics.main.y).toBeGreaterThan(metrics.sidebar.y)
+  const compact = await readLayout(page)
+  expect(compact.scrollWidth).toBe(compact.clientWidth)
+  expect(Math.abs(compact.sidebar.x - compact.main.x)).toBeLessThan(2)
+  expect(Math.abs(compact.sidebar.width - compact.main.width)).toBeLessThan(2)
+  expect(compact.main.y).toBeGreaterThan(compact.sidebar.y + compact.sidebar.height - 2)
 })


### PR DESCRIPTION
Closes #76.

## Root cause
`body` が `320px 1fr` のgridを持つ一方、`header / aside / main` はReact `#root` の内側にあり、gridの直接子ではありませんでした。結果として `#root` 自体が320px側へauto-placementされ、ゲーム詳細を含むアプリ全体が細い左列へ押し込まれていました。

## Layout fix
- viewport責務を `body`、route layout責務を `#root` へ分離
- directory routeの `header / aside / main` を `320px + minmax(0,1fr)` で配置
- non-directory routeは全grid列をspan
- GamePageを `280–340px metadata sidebar + minmax(0,1fr) readable main` に再構成
- title / tabs / rules / coach / strategy / reviews / connectionsをmainへ配置
- stats / synopsis / tips / errors / glossary / linksをsidebarへ配置
- `min-width: 0`、wrap、media overflow containmentを追加
- 900px以下で1カラム

## Regression gate
PlaywrightでAPIをmockし、同一ページを1280px→800pxへresizeして検証。
- 1280px: sidebar 280–340px / main >600px / titleとtabsがmain側 / document horizontal overflowなし
- 800px: sidebar/main同幅の1カラム / document horizontal overflowなし
- Vite build + targeted ESLint + Chromium layout testをPR CIに追加

## Vercel deployment repair
既存CIの `vercel build → vercel deploy --prebuilt` は、`.vercelignore` とBuild Outputのfile traceが衝突し、`assets/01_探検家ミープル君.png`、`pyproject.toml`、さらにlocal Python venv内ファイルのENOENTを順に発生させていました。

- `.vercelignore` からruntime/build dependencyとして必要な `assets/`, `pyproject.toml`, `uv.lock` の除外を削除
- Vercel公式のsource deployment経路へ単純化
  - Preview: `vercel deploy --yes`
  - Production: `vercel deploy --prod --yes`
- 不要になったActions側のlocal `vercel build` / `--prebuilt` / uv installを削除

## Verified
- Frontend layout regression run #5: success
- Vercel Deployment run #313 Preview: success
- Preview URL generated and `Ready`まで到達
- Vercel CLI出力でproduction domainが `bodoge-no-mikata.vercel.app` と確認済み

Backend/API/data generationのロジック変更はありません。既存GamePage機能は保持します。