### PR TITLE
Connect Google login to Supabase session and backend auth

### DIFF
--- a/.github/workflows/frontend-layout.yml
+++ b/.github/workflows/frontend-layout.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Lint changed frontend surface
         working-directory: frontend
-        run: npx eslint src/main.jsx src/auth/AuthContext.jsx src/components/AuthControlPortal.jsx src/components/LoginButton.jsx src/lib/api.js tests/game_layout.spec.js tests/auth.spec.js playwright.config.js
+        run: npx eslint src/main.jsx src/auth/AuthContext.jsx src/auth/authContext.js src/components/AuthControlPortal.jsx src/components/LoginButton.jsx src/lib/api.js tests/game_layout.spec.js tests/auth.spec.js playwright.config.js
 
       - name: Install Chromium
         working-directory: frontend

--- a/.github/workflows/frontend-layout.yml
+++ b/.github/workflows/frontend-layout.yml
@@ -32,14 +32,14 @@ jobs:
         working-directory: frontend
         run: npm run build
 
-      - name: Lint changed layout surface
+      - name: Lint changed frontend surface
         working-directory: frontend
-        run: npx eslint src/main.jsx src/pages/GamePage.jsx tests/game_layout.spec.js playwright.config.js
+        run: npx eslint src/main.jsx src/auth/AuthContext.jsx src/components/AuthControlPortal.jsx src/components/LoginButton.jsx src/lib/api.js tests/game_layout.spec.js tests/auth.spec.js playwright.config.js
 
       - name: Install Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
-      - name: Test game detail layout
+      - name: Test layout and auth mounting
         working-directory: frontend
-        run: npx playwright test tests/game_layout.spec.js --project=chromium
+        run: npx playwright test tests/game_layout.spec.js tests/auth.spec.js --project=chromium

--- a/.github/workflows/test-auth.yml
+++ b/.github/workflows/test-auth.yml
@@ -1,0 +1,38 @@
+name: Test auth
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/routers/auth.py"
+      - "backend/app/main.py"
+      - "backend/tests/test_auth.py"
+      - ".github/workflows/test-auth.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/routers/auth.py"
+      - "backend/app/main.py"
+      - "backend/tests/test_auth.py"
+      - ".github/workflows/test-auth.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv sync --frozen --dev
+      - name: Run auth regression tests
+        run: uv run pytest -q backend/tests/test_auth.py
+        env:
+          PYTHONPATH: backend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import HTMLResponse
 
 from app.core.logger import setup_logging
 from app.middleware.validation import ValidationMiddleware
-from app.routers import games
+from app.routers import auth, games
 from app.services.seo_renderer import generate_seo_html
 from app.services.sitemap import get_sitemap_xml
 
@@ -22,6 +22,7 @@ app.add_middleware(
 )
 
 app.include_router(games.router, prefix="/api", tags=["games"])
+app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 
 
 @app.get("/health")

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,66 @@
+import os
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+router = APIRouter()
+bearer = HTTPBearer(auto_error=False)
+
+
+def _auth_config() -> tuple[str, str]:
+    url = os.getenv("NEXT_PUBLIC_SUPABASE_URL", "").rstrip("/")
+    key = os.getenv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "")
+    if not url or not key:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Supabase Auth is not configured",
+        )
+    return url, key
+
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer),
+) -> dict:
+    if credentials is None or credentials.scheme.lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    supabase_url, publishable_key = _auth_config()
+    headers = {
+        "apikey": publishable_key,
+        "Authorization": f"Bearer {credentials.credentials}",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{supabase_url}/auth/v1/user", headers=headers)
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from exc
+
+    if response.status_code != status.HTTP_200_OK:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired access token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    payload = response.json()
+    metadata = payload.get("user_metadata") or {}
+    return {
+        "id": payload.get("id"),
+        "email": payload.get("email"),
+        "display_name": metadata.get("full_name") or metadata.get("name"),
+        "avatar_url": metadata.get("avatar_url"),
+    }
+
+
+@router.get("/me")
+async def me(user: dict = Depends(get_current_user)) -> dict:
+    return {"user": user}

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,80 @@
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.routers import auth
+
+
+class FakeResponse:
+    def __init__(self, status_code: int, payload: dict):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeAsyncClient:
+    response = FakeResponse(200, {})
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, headers):
+        self.last_url = url
+        self.last_headers = headers
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_auth_requires_bearer_token():
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(None)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_rejects_invalid_token(monkeypatch):
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'sb_publishable_test')
+    FakeAsyncClient.response = FakeResponse(401, {'message': 'invalid token'})
+    monkeypatch.setattr(auth.httpx, 'AsyncClient', FakeAsyncClient)
+
+    credentials = HTTPAuthorizationCredentials(scheme='Bearer', credentials='bad-token')
+    with pytest.raises(HTTPException) as exc:
+        await auth.get_current_user(credentials)
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_returns_normalized_verified_user(monkeypatch):
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_URL', 'https://example.supabase.co')
+    monkeypatch.setenv('NEXT_PUBLIC_SUPABASE_ANON_KEY', 'sb_publishable_test')
+    FakeAsyncClient.response = FakeResponse(
+        200,
+        {
+            'id': 'user-123',
+            'email': 'user@example.com',
+            'user_metadata': {
+                'full_name': 'Test User',
+                'avatar_url': 'https://example.com/avatar.png',
+            },
+        },
+    )
+    monkeypatch.setattr(auth.httpx, 'AsyncClient', FakeAsyncClient)
+
+    credentials = HTTPAuthorizationCredentials(scheme='Bearer', credentials='valid-token')
+    user = await auth.get_current_user(credentials)
+
+    assert user == {
+        'id': 'user-123',
+        'email': 'user@example.com',
+        'display_name': 'Test User',
+        'avatar_url': 'https://example.com/avatar.png',
+    }

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -1,0 +1,85 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { supabase } from '../lib/supabase'
+
+const AuthContext = createContext(null)
+
+export function AuthProvider({ children }) {
+  const [session, setSession] = useState(null)
+  const [loading, setLoading] = useState(Boolean(supabase))
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false)
+      return undefined
+    }
+
+    let active = true
+
+    supabase.auth.getSession().then(({ data, error: sessionError }) => {
+      if (!active) return
+      if (sessionError) setError(sessionError.message)
+      setSession(data.session ?? null)
+      setLoading(false)
+    })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (!active) return
+      setSession(nextSession)
+      setLoading(false)
+      setError(null)
+    })
+
+    return () => {
+      active = false
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  const signInWithGoogle = async () => {
+    if (!supabase) {
+      setError('Supabase Auth is not configured.')
+      return
+    }
+
+    setError(null)
+    const { error: signInError } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: window.location.origin,
+      },
+    })
+
+    if (signInError) setError(signInError.message)
+  }
+
+  const signOut = async () => {
+    if (!supabase) return
+    setError(null)
+    const { error: signOutError } = await supabase.auth.signOut()
+    if (signOutError) setError(signOutError.message)
+  }
+
+  const value = useMemo(
+    () => ({
+      session,
+      user: session?.user ?? null,
+      loading,
+      error,
+      isConfigured: Boolean(supabase),
+      signInWithGoogle,
+      signOut,
+    }),
+    [session, loading, error],
+  )
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}
+
+export function useAuth() {
+  const value = useContext(AuthContext)
+  if (!value) throw new Error('useAuth must be used inside AuthProvider')
+  return value
+}

--- a/frontend/src/auth/AuthContext.jsx
+++ b/frontend/src/auth/AuthContext.jsx
@@ -1,7 +1,6 @@
-import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { supabase } from '../lib/supabase'
-
-const AuthContext = createContext(null)
+import { AuthContext } from './authContext'
 
 export function AuthProvider({ children }) {
   const [session, setSession] = useState(null)
@@ -9,10 +8,7 @@ export function AuthProvider({ children }) {
   const [error, setError] = useState(null)
 
   useEffect(() => {
-    if (!supabase) {
-      setLoading(false)
-      return undefined
-    }
+    if (!supabase) return undefined
 
     let active = true
 
@@ -76,10 +72,4 @@ export function AuthProvider({ children }) {
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
-}
-
-export function useAuth() {
-  const value = useContext(AuthContext)
-  if (!value) throw new Error('useAuth must be used inside AuthProvider')
-  return value
 }

--- a/frontend/src/auth/authContext.js
+++ b/frontend/src/auth/authContext.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react'
+
+export const AuthContext = createContext(null)
+
+export function useAuth() {
+  const value = useContext(AuthContext)
+  if (!value) throw new Error('useAuth must be used inside AuthProvider')
+  return value
+}

--- a/frontend/src/components/AuthControlPortal.jsx
+++ b/frontend/src/components/AuthControlPortal.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import LoginButton from './LoginButton'
+
+function findTarget() {
+  return document.querySelector('header') || document.querySelector('.game-page-toolbar')
+}
+
+export default function AuthControlPortal() {
+  const [target, setTarget] = useState(null)
+
+  useEffect(() => {
+    const resolveTarget = () => setTarget(findTarget())
+    resolveTarget()
+
+    const root = document.getElementById('root')
+    if (!root) return undefined
+
+    const observer = new MutationObserver(resolveTarget)
+    observer.observe(root, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  }, [])
+
+  if (!target) return null
+
+  return createPortal(
+    <div data-auth-control style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
+      <LoginButton />
+    </div>,
+    target,
+  )
+}

--- a/frontend/src/components/LoginButton.jsx
+++ b/frontend/src/components/LoginButton.jsx
@@ -1,35 +1,53 @@
-import { supabase } from '../lib/supabase'
+import { useAuth } from '../auth/AuthContext'
 
-export default function LoginButton({ session }) {
-  const handleLogout = async () => {
-    await supabase.auth.signOut()
+export default function LoginButton() {
+  const { user, loading, isConfigured, signInWithGoogle, signOut, error } = useAuth()
+
+  if (loading) {
+    return (
+      <button className="button-secondary" type="button" disabled aria-label="認証状態を確認中">
+        AUTH...
+      </button>
+    )
   }
 
-  if (session) {
+  if (user) {
+    const avatarUrl = user.user_metadata?.avatar_url
+    const displayName = user.user_metadata?.full_name || user.email || 'USER'
+
     return (
-      <div className="user-menu">
-        <img
-          src={session.user.user_metadata.avatar_url}
-          alt="Avatar"
-          className="user-avatar"
-          style={{
-            width: '32px',
-            height: '32px',
-            borderRadius: '50%',
-            marginRight: '8px',
-            verticalAlign: 'middle',
-          }}
-        />
-        <button
-          onClick={handleLogout}
-          className="button-secondary"
-          style={{ fontSize: '0.8rem', padding: '4px 8px' }}
-        >
+      <div className="user-menu" data-auth-state="signed-in" style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt=""
+            className="user-avatar"
+            width="32"
+            height="32"
+            style={{ borderRadius: '50%' }}
+          />
+        ) : null}
+        <span style={{ fontSize: '0.75rem', maxWidth: '160px', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          {displayName}
+        </span>
+        <button type="button" onClick={signOut} className="button-secondary" style={{ fontSize: '0.8rem', padding: '4px 8px' }}>
           ログアウト
         </button>
       </div>
     )
   }
 
-  return null
+  return (
+    <div data-auth-state="signed-out" title={error || undefined}>
+      <button
+        type="button"
+        onClick={signInWithGoogle}
+        className="button-secondary"
+        disabled={!isConfigured}
+        aria-label="Googleでログイン"
+      >
+        Googleでログイン
+      </button>
+    </div>
+  )
 }

--- a/frontend/src/components/LoginButton.jsx
+++ b/frontend/src/components/LoginButton.jsx
@@ -1,4 +1,4 @@
-import { useAuth } from '../auth/AuthContext'
+import { useAuth } from '../auth/authContext'
 
 export default function LoginButton() {
   const { user, loading, isConfigured, signInWithGoogle, signOut, error } = useAuth()

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,30 +1,44 @@
+import { supabase } from './supabase'
+
 const handleResponse = async (res) => {
   if (!res.ok) {
     const errorBody = await res.json().catch(() => ({}))
-    throw new Error(errorBody.message || `API Error: ${res.status} ${res.statusText}`)
+    throw new Error(errorBody.message || errorBody.detail || `API Error: ${res.status} ${res.statusText}`)
   }
   return res.json()
 }
 
+const getAuthHeaders = async () => {
+  if (!supabase) return {}
+  const { data } = await supabase.auth.getSession()
+  const accessToken = data.session?.access_token
+  return accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
+}
+
+const request = async (path, options = {}) => {
+  const authHeaders = await getAuthHeaders()
+  const res = await fetch(path, {
+    ...options,
+    headers: {
+      ...authHeaders,
+      ...(options.headers || {}),
+    },
+  })
+  return handleResponse(res)
+}
+
 export const api = {
-  get: async (path) => {
-    const res = await fetch(path)
-    return handleResponse(res)
-  },
-  post: async (path, body) => {
-    const res = await fetch(path, {
+  get: async (path) => request(path),
+  post: async (path, body) =>
+    request(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-    })
-    return handleResponse(res)
-  },
-  patch: async (path, body) => {
-    const res = await fetch(path, {
+    }),
+  patch: async (path, body) =>
+    request(path, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-    })
-    return handleResponse(res)
-  },
+    }),
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -9,7 +9,10 @@ import './layout.css'
 const GamePage = lazy(() => import('./pages/GamePage.jsx'))
 const DataPage = lazy(() => import('./pages/DataPage.jsx'))
 
+import { AuthProvider } from './auth/AuthContext.jsx'
+import AuthControlPortal from './components/AuthControlPortal.jsx'
 import LoadingFallback from './components/LoadingFallback.jsx'
+
 const router = createBrowserRouter([
   {
     path: '/',
@@ -40,7 +43,10 @@ const router = createBrowserRouter([
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <HelmetProvider>
-      <RouterProvider router={router} />
+      <AuthProvider>
+        <RouterProvider router={router} />
+        <AuthControlPortal />
+      </AuthProvider>
     </HelmetProvider>
   </StrictMode>
 )

--- a/frontend/tests/auth.spec.js
+++ b/frontend/tests/auth.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test'
+
+test('auth control mounts inside existing layout without becoming a root grid item', async ({ page }) => {
+  await page.route('**/api/games?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games: [], total: 0 }),
+    })
+  })
+
+  await page.goto('/')
+
+  const authControl = page.locator('header [data-auth-control]')
+  await expect(authControl).toBeVisible()
+  await expect(authControl.getByRole('button', { name: 'Googleでログイン' })).toBeVisible()
+
+  const directChildren = await page.locator('#root > *').evaluateAll((nodes) => nodes.map((node) => node.tagName))
+  expect(directChildren).toEqual(['HEADER', 'ASIDE', 'MAIN'])
+})


### PR DESCRIPTION
Closes #61
Closes #78

## What changed
- Google OAuth is the single supported provider.
- Added React-wide Supabase session state with restore/sign-out handling.
- Added a login control mounted into the existing header/toolbar via React portal, so `#root` keeps the direct `header / aside / main` layout fixed by #76.
- All frontend API calls now forward the current Supabase access token as `Authorization: Bearer ...` when signed in.
- Added `/api/auth/me`; the backend validates the bearer token against Supabase Auth `/auth/v1/user` using the publishable key and returns a minimal normalized user object.
- Added backend auth tests and frontend Playwright coverage.
- Extended CI so auth integration is build/lint/test gated.

## Security boundary
Frontend session data is only used to forward the access token. The backend does not trust browser session metadata; it revalidates the token with Supabase Auth before treating the user as authenticated.

## External configuration required
Supabase Google provider must be enabled with the production origin/redirect allow-list configured. No Google client secret is added to the repository.