### PR TITLE
Fail closed INST COACH to game-specific summaries

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -64,9 +64,10 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
   const title = game.title_ja || game.title || 'Untitled'
   const rules = game.rules_content || ''
   const sd = game.structured_data || {}
+  const coachSourceUrl = game.official_url || game.source_url || null
 
   const pageTitle = `「${title}」のルール・戦略・インスト要約 | ボドゲのミカタ`
-  const description = game.summary || `「${title}」のルールをAIが瞬時に分析。セットアップから勝利戦略まで。`
+  const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
   const gameUrl = `${BASE_URL}/games/${slug}`
   const imageUrl = game.image_url || `${BASE_URL}/assets/no-image.webp`
 
@@ -185,41 +186,34 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
                   <span className="coach-step-num">STEP 1</span>
                   <div className="coach-step-title">セットアップ (Setup)</div>
                   <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
-                    コンポーネントを準備し、各プレイヤーに初期リソースを配布します。
-                    {sd.key_elements?.length > 0 && (
-                      <div style={{ marginTop: '1rem', color: 'var(--text-secondary)' }}>
-                        💡 注目要素: {sd.key_elements.map(e => e.name).join(', ')}
-                      </div>
-                    )}
+                    {game.setup_summary || 'このゲーム固有のセットアップ要約は未確認です。'}
                   </div>
                 </div>
 
                 <div className="coach-step">
                   <span className="coach-step-num">STEP 2</span>
-                  <div className="coach-step-title">ゲームの目的 (Objective)</div>
+                  <div className="coach-step-title">ゲームの流れ (Gameplay)</div>
                   <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
-                    {game.summary || '勝利条件を確認します。'}
+                    {game.gameplay_summary || 'このゲーム固有のゲーム進行要約は未確認です。'}
                   </div>
                 </div>
 
                 <div className="coach-step">
                   <span className="coach-step-num">STEP 3</span>
-                  <div className="coach-step-title">手番の流れ (Turn Flow)</div>
+                  <div className="coach-step-title">ゲーム終了 (End Game)</div>
                   <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
-                    1. アクションを選択 <br />
-                    2. リソースを支払う <br />
-                    3. 効果を解決 <br />
-                    <br />
-                    {sd.mechanics?.length > 0 && (
-                      <div className="tag-list">
-                        {sd.mechanics.map(m => <span key={m} className="tag-item">{m}</span>)}
-                      </div>
-                    )}
+                    {game.end_game_summary || 'このゲーム固有の終了条件要約は未確認です。'}
                   </div>
                 </div>
 
                 <div style={{ textAlign: 'center', padding: '1rem', color: 'var(--text-muted)', fontSize: '0.8rem' }}>
-                  AIによるインストガイドです。詳細は「ANALYSIS & RULES」タブを確認してください。
+                  登録済みのゲーム固有要約を表示しています。AI生成・要約を含む場合があり、公式裁定ではありません。
+                  {coachSourceUrl && (
+                    <>
+                      {' '}
+                      <a href={coachSourceUrl} target="_blank" rel="noreferrer">出典を確認</a>
+                    </>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -12,6 +12,11 @@ const bigShot = {
   published_year: 2001,
   summary: '土地を競り落とし、資金を管理しながら得点を競うオークションゲーム。',
   description: 'Big Shot description',
+  setup_summary: '各プレイヤーは開始時の資金を受け取ります。',
+  gameplay_summary: '競りで土地を獲得し、資金配分を管理します。',
+  end_game_summary: '全区画の競りが終わったら得点を計算します。',
+  source_url: 'https://example.com/big-shot-source',
+  official_url: 'https://example.com/big-shot-official',
   rules_content: '# Big Shot Rules\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\nゲーム終了時に得点を計算します。',
   structured_data: {
     mechanics: ['Auction / Bidding', 'Area Majority'],
@@ -23,11 +28,11 @@ const bigShot = {
   },
 }
 
-async function mockGameApi(page) {
+async function mockGameApi(page, game = bigShot) {
   await page.route('**/api/games**', async route => {
     const url = new URL(route.request().url())
     if (url.pathname === '/api/games/big-shot') {
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game: bigShot }) })
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
       return
     }
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
@@ -79,4 +84,34 @@ test('game detail keeps a readable desktop main and collapses cleanly at 800px',
   expect(Math.abs(compact.sidebar.x - compact.main.x)).toBeLessThan(2)
   expect(Math.abs(compact.sidebar.width - compact.main.width)).toBeLessThan(2)
   expect(compact.main.y).toBeGreaterThan(compact.sidebar.y + compact.sidebar.height - 2)
+})
+
+test('INST COACH shows only game-specific summaries and fails closed when missing', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+  await page.getByRole('tab', { name: 'INST COACH' }).click()
+
+  await expect(page.getByText(bigShot.setup_summary)).toBeVisible()
+  await expect(page.getByText(bigShot.gameplay_summary)).toBeVisible()
+  await expect(page.getByText(bigShot.end_game_summary)).toBeVisible()
+  await expect(page.getByText('公式裁定ではありません。')).toBeVisible()
+  await expect(page.getByRole('link', { name: '出典を確認' })).toHaveAttribute('href', bigShot.official_url)
+  await expect(page.getByText('初期リソースを配布')).toHaveCount(0)
+  await expect(page.getByText('アクションを選択')).toHaveCount(0)
+  await expect(page.getByText('リソースを支払う')).toHaveCount(0)
+
+  const missing = {
+    ...bigShot,
+    setup_summary: null,
+    gameplay_summary: null,
+    end_game_summary: null,
+  }
+  await page.unrouteAll({ behavior: 'wait' })
+  await mockGameApi(page, missing)
+  await page.reload()
+  await page.getByRole('tab', { name: 'INST COACH' }).click()
+
+  await expect(page.getByText('このゲーム固有のセットアップ要約は未確認です。')).toBeVisible()
+  await expect(page.getByText('このゲーム固有のゲーム進行要約は未確認です。')).toBeVisible()
+  await expect(page.getByText('このゲーム固有の終了条件要約は未確認です。')).toBeVisible()
 })


### PR DESCRIPTION
Closes #87 when all acceptance criteria pass.

## Current implementation
- use only `setup_summary`, `gameplay_summary`, and `end_game_summary` in INST COACH
- show explicit game-specific 未確認 messages instead of invented fallback rules
- remove the generic setup / action / resource-payment rule claims
- identify AI-generated/summarized text as non-official and link back to `official_url || source_url`
- replace the unsupported SEO fallback claim with a registered-information description

## Current evidence / blocker
Implementation commit: `62baed67228a5fb039d39693848b97624f061a24`.

The required Playwright regression update to `frontend/tests/game_layout.spec.js` was attempted twice through the normal connector write path (second attempt after re-reading the exact blob SHA) and both writes were blocked by the host-side safety layer before reaching GitHub. This Draft PR is the single canonical workline; do not create a duplicate branch/PR and do not merge until the regression test is committed and PR CI passes.