### PR TITLE
Establish canonical game identity contract (#90)

### DIFF
--- a/.github/workflows/test-game-identity.yml
+++ b/.github/workflows/test-game-identity.yml
@@ -42,12 +42,16 @@ jobs:
       PGPASSWORD: postgres
     steps:
       - uses: actions/checkout@v4
-      - name: Apply identity migrations to same-title fixtures
+      - name: Apply identity migrations to identity fixtures
         run: psql "$DATABASE_URL" -f backend/app/db/tests/identity_integration.sql
-      - name: Verify title alone did not merge records
+      - name: Verify migration did not infer legacy merges
         run: |
-          test "$(psql "$DATABASE_URL" -Atc 'select count(*) from public.games;')" = "3"
-          test "$(psql "$DATABASE_URL" -Atc 'select count(*) from public.game_works;')" = "3"
+          test "$(psql "$DATABASE_URL" -Atc 'select count(*) from public.games;')" = "4"
+          test "$(psql "$DATABASE_URL" -Atc 'select count(*) from public.game_works;')" = "4"
+      - name: Verify verified EN/JA editions stay separate under one work
+        run: |
+          test "$(psql "$DATABASE_URL" -Atc "select count(distinct work_id) from public.games where id in ('cccccccc-cccc-4ccc-8ccc-cccccccccccc','dddddddd-dddd-4ddd-8ddd-dddddddddddd');")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(distinct bgg_version_id) from public.games where id in ('cccccccc-cccc-4ccc-8ccc-cccccccccccc','dddddddd-dddd-4ddd-8ddd-dddddddddddd');")" = "2"
       - name: Verify old slug resolves to the same game ID
         run: |
           test "$(psql "$DATABASE_URL" -Atc "select game_id from public.game_slug_aliases where alias_slug='twin-a';")" = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"

--- a/.github/workflows/test-game-identity.yml
+++ b/.github/workflows/test-game-identity.yml
@@ -1,0 +1,55 @@
+name: Test Canonical Game Identity
+
+on:
+  pull_request:
+    paths:
+      - 'backend/app/db/migrations/**'
+      - 'backend/app/db/tests/identity_integration.sql'
+      - 'backend/app/core/supabase.py'
+      - 'backend/app/core/local_db.py'
+      - 'backend/app/models/__init__.py'
+      - 'docs/CANONICAL_GAME_IDENTITY.md'
+      - '.github/workflows/test-game-identity.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'backend/app/db/migrations/**'
+      - 'backend/app/db/tests/identity_integration.sql'
+      - 'backend/app/core/supabase.py'
+      - 'backend/app/core/local_db.py'
+      - 'backend/app/models/__init__.py'
+      - 'docs/CANONICAL_GAME_IDENTITY.md'
+      - '.github/workflows/test-game-identity.yml'
+
+jobs:
+  identity-contract:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      PGPASSWORD: postgres
+    steps:
+      - uses: actions/checkout@v4
+      - name: Apply identity migrations to same-title fixtures
+        run: psql "$DATABASE_URL" -f backend/app/db/tests/identity_integration.sql
+      - name: Verify title alone did not merge records
+        run: |
+          test "$(psql "$DATABASE_URL" -Atc 'select count(*) from public.games;')" = "3"
+          test "$(psql "$DATABASE_URL" -Atc 'select count(*) from public.game_works;')" = "3"
+      - name: Verify old slug resolves to the same game ID
+        run: |
+          test "$(psql "$DATABASE_URL" -Atc "select game_id from public.game_slug_aliases where alias_slug='twin-a';")" = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+      - name: Verify audit surface exists
+        run: psql "$DATABASE_URL" -c 'select * from public.game_identity_audit_summary;'

--- a/backend/app/core/supabase.py
+++ b/backend/app/core/supabase.py
@@ -60,7 +60,6 @@ def _with_canonical_storage_image(game: Dict[str, Any]) -> Dict[str, Any]:
 
 async def search(query: str) -> List[Dict[str, Any]]:
     if is_local():
-        # Search the entire local DB
         res = local_db.list_recent(limit=10000)
         q = query.lower()
         return [
@@ -112,6 +111,22 @@ async def get_by_slug(slug: str) -> Optional[Dict[str, Any]]:
 
     def _q():
         rows = _get_client().table(_TABLE).select("*").eq("slug", slug).execute().data
+        if rows:
+            return _with_canonical_storage_image(rows[0])
+
+        aliases = (
+            _get_client()
+            .table("game_slug_aliases")
+            .select("game_id")
+            .eq("alias_slug", slug)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not aliases:
+            return None
+
+        rows = _get_client().table(_TABLE).select("*").eq("id", aliases[0]["game_id"]).execute().data
         return _with_canonical_storage_image(rows[0]) if rows else None
 
     return await anyio.to_thread.run_sync(_q)

--- a/backend/app/db/migrations/003_canonical_game_identity.sql
+++ b/backend/app/db/migrations/003_canonical_game_identity.sql
@@ -1,0 +1,196 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.normalize_game_title(value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+RETURNS NULL ON NULL INPUT
+AS $$
+  SELECT lower(regexp_replace(trim(value), '[[:space:][:punct:]！!？?・：:]+', '', 'g'));
+$$;
+
+CREATE TABLE IF NOT EXISTS public.game_works (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  canonical_title text NOT NULL,
+  bgg_id bigint,
+  identity_status text NOT NULL DEFAULT 'unverified'
+    CHECK (identity_status IN ('unverified', 'verified', 'needs_review')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS game_works_bgg_id_unique
+  ON public.game_works (bgg_id)
+  WHERE bgg_id IS NOT NULL;
+
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS work_id uuid,
+  ADD COLUMN IF NOT EXISTS edition_label text,
+  ADD COLUMN IF NOT EXISTS language_code text,
+  ADD COLUMN IF NOT EXISTS publisher text,
+  ADD COLUMN IF NOT EXISTS bgg_version_id bigint,
+  ADD COLUMN IF NOT EXISTS source_revision text,
+  ADD COLUMN IF NOT EXISTS generated_from_source_revision text,
+  ADD COLUMN IF NOT EXISTS identity_status text NOT NULL DEFAULT 'unverified';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'games_identity_status_check'
+      AND conrelid = 'public.games'::regclass
+  ) THEN
+    ALTER TABLE public.games
+      ADD CONSTRAINT games_identity_status_check
+      CHECK (identity_status IN ('unverified', 'verified', 'needs_review'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'games_work_id_fkey'
+      AND conrelid = 'public.games'::regclass
+  ) THEN
+    ALTER TABLE public.games
+      ADD CONSTRAINT games_work_id_fkey
+      FOREIGN KEY (work_id) REFERENCES public.game_works(id) ON DELETE RESTRICT;
+  END IF;
+END;
+$$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS games_bgg_version_id_unique
+  ON public.games (bgg_version_id)
+  WHERE bgg_version_id IS NOT NULL;
+
+-- Safe bootstrap: every legacy row starts as a distinct work. We never infer a
+-- merge from title/slug similarity. A BGG boardgame ID is backfilled only when
+-- it is explicitly present in an existing canonical BGG URL.
+INSERT INTO public.game_works (id, canonical_title, bgg_id, identity_status, created_at, updated_at)
+SELECT
+  g.id,
+  g.title,
+  CASE
+    WHEN g.bgg_url ~* 'boardgame/[0-9]+'
+      THEN substring(g.bgg_url from 'boardgame/([0-9]+)')::bigint
+    ELSE NULL
+  END,
+  'unverified',
+  COALESCE(g.created_at, now()),
+  COALESCE(g.updated_at, now())
+FROM public.games g
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE public.games
+SET work_id = id
+WHERE work_id IS NULL;
+
+ALTER TABLE public.games ALTER COLUMN work_id SET NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.game_title_aliases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  game_id uuid NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  language_code text,
+  normalized_title text NOT NULL,
+  source text NOT NULL DEFAULT 'legacy',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS game_title_aliases_unique
+  ON public.game_title_aliases (game_id, title, COALESCE(language_code, ''));
+CREATE INDEX IF NOT EXISTS game_title_aliases_normalized_idx
+  ON public.game_title_aliases (normalized_title);
+
+INSERT INTO public.game_title_aliases (game_id, title, language_code, normalized_title, source)
+SELECT id, title, NULL, public.normalize_game_title(title), 'games.title'
+FROM public.games
+WHERE title IS NOT NULL AND trim(title) <> ''
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.game_title_aliases (game_id, title, language_code, normalized_title, source)
+SELECT id, title_ja, 'ja', public.normalize_game_title(title_ja), 'games.title_ja'
+FROM public.games
+WHERE title_ja IS NOT NULL AND trim(title_ja) <> ''
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.game_title_aliases (game_id, title, language_code, normalized_title, source)
+SELECT id, title_en, 'en', public.normalize_game_title(title_en), 'games.title_en'
+FROM public.games
+WHERE title_en IS NOT NULL AND trim(title_en) <> ''
+ON CONFLICT DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS public.game_slug_aliases (
+  alias_slug text PRIMARY KEY,
+  game_id uuid NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  reason text NOT NULL DEFAULT 'slug_changed',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION public.protect_and_capture_game_slug()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.slug IS NOT NULL AND EXISTS (
+    SELECT 1
+    FROM public.game_slug_aliases a
+    WHERE a.alias_slug = NEW.slug
+      AND a.game_id <> NEW.id
+  ) THEN
+    RAISE EXCEPTION 'slug % is reserved by an existing alias', NEW.slug
+      USING ERRCODE = 'unique_violation';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND OLD.slug IS DISTINCT FROM NEW.slug
+     AND OLD.slug IS NOT NULL
+     AND trim(OLD.slug) <> '' THEN
+    INSERT INTO public.game_slug_aliases (alias_slug, game_id, reason)
+    VALUES (OLD.slug, OLD.id, 'slug_changed')
+    ON CONFLICT (alias_slug) DO NOTHING;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS capture_game_slug_alias ON public.games;
+CREATE TRIGGER capture_game_slug_alias
+BEFORE INSERT OR UPDATE OF slug ON public.games
+FOR EACH ROW
+EXECUTE FUNCTION public.protect_and_capture_game_slug();
+
+CREATE OR REPLACE VIEW public.game_identity_duplicate_candidates AS
+SELECT
+  a.normalized_title,
+  count(DISTINCT a.game_id) AS game_count,
+  array_agg(DISTINCT a.game_id ORDER BY a.game_id) AS game_ids
+FROM public.game_title_aliases a
+WHERE a.normalized_title <> ''
+GROUP BY a.normalized_title
+HAVING count(DISTINCT a.game_id) > 1;
+
+CREATE OR REPLACE VIEW public.game_generation_freshness AS
+SELECT
+  id AS game_id,
+  source_url,
+  source_revision,
+  generated_from_source_revision,
+  CASE
+    WHEN source_revision IS NULL THEN 'source_revision_unknown'
+    WHEN generated_from_source_revision IS NULL THEN 'generation_revision_unknown'
+    WHEN source_revision = generated_from_source_revision THEN 'current'
+    ELSE 'stale'
+  END AS generation_status
+FROM public.games;
+
+CREATE OR REPLACE VIEW public.game_identity_audit_summary AS
+SELECT
+  (SELECT count(*) FROM public.games) AS total_games,
+  (SELECT count(*) FROM public.game_works) AS total_works,
+  (SELECT count(*) FROM public.game_works WHERE bgg_id IS NOT NULL) AS works_with_bgg_id,
+  (SELECT count(*) FROM public.games WHERE bgg_version_id IS NOT NULL) AS editions_with_bgg_version_id,
+  (SELECT count(*) FROM public.games WHERE language_code IS NULL) AS missing_language_code,
+  (SELECT count(*) FROM public.games WHERE source_revision IS NULL) AS missing_source_revision,
+  (SELECT count(*) FROM public.game_identity_duplicate_candidates) AS duplicate_title_groups;
+
+COMMIT;

--- a/backend/app/db/migrations/004_lock_identity_metadata.sql
+++ b/backend/app/db/migrations/004_lock_identity_metadata.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE public.game_works ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.game_title_aliases ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.game_slug_aliases ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL PRIVILEGES ON TABLE public.game_works FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.game_title_aliases FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.game_slug_aliases FROM anon, authenticated;
+
+REVOKE ALL PRIVILEGES ON TABLE public.game_identity_duplicate_candidates FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.game_generation_freshness FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.game_identity_audit_summary FROM anon, authenticated;
+
+COMMIT;

--- a/backend/app/db/tests/identity_integration.sql
+++ b/backend/app/db/tests/identity_integration.sql
@@ -1,0 +1,97 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='anon') THEN CREATE ROLE anon NOLOGIN; END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname='authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF;
+END;
+$$;
+
+CREATE TABLE public.games (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  title_ja text,
+  title_en text,
+  slug text UNIQUE,
+  bgg_url text,
+  source_url text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+INSERT INTO public.games (id,title,title_ja,title_en,slug,bgg_url) VALUES
+('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','Twin Game','ツインゲーム','Twin Game','twin-a','https://boardgamegeek.com/boardgame/100/twin-game-a'),
+('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb','Twin Game','ツインゲーム別版','Twin Game','twin-b','https://boardgamegeek.com/boardgame/200/twin-game-b'),
+('cccccccc-cccc-4ccc-8ccc-cccccccccccc','Other Game','別ゲーム','Other Game','other',NULL);
+
+\ir ../migrations/003_canonical_game_identity.sql
+\ir ../migrations/004_lock_identity_metadata.sql
+
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM public.games) <> 3 THEN
+    RAISE EXCEPTION 'migration changed game row count';
+  END IF;
+  IF (SELECT count(*) FROM public.game_works) <> 3 THEN
+    RAISE EXCEPTION 'title similarity caused an inferred work merge';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.games WHERE work_id <> id) THEN
+    RAISE EXCEPTION 'legacy bootstrap must preserve one distinct work per game';
+  END IF;
+  IF (SELECT bgg_id FROM public.game_works WHERE id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') <> 100 THEN
+    RAISE EXCEPTION 'explicit BGG ID was not extracted';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.game_identity_duplicate_candidates
+    WHERE normalized_title = public.normalize_game_title('Twin Game')
+  ) THEN
+    RAISE EXCEPTION 'same-title duplicate candidate was not surfaced';
+  END IF;
+END;
+$$;
+
+UPDATE public.games
+SET language_code='en', edition_label='First edition', bgg_version_id=1001,
+    source_revision='rev-2', generated_from_source_revision='rev-1'
+WHERE id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+DO $$
+BEGIN
+  IF (SELECT generation_status FROM public.game_generation_freshness WHERE game_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') <> 'stale' THEN
+    RAISE EXCEPTION 'source revision mismatch was not marked stale';
+  END IF;
+END;
+$$;
+
+UPDATE public.games SET slug='twin-a-v2'
+WHERE id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.game_slug_aliases
+    WHERE alias_slug='twin-a' AND game_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+  ) THEN
+    RAISE EXCEPTION 'old slug was not preserved as an alias';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.game_title_aliases
+    WHERE game_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' AND language_code='ja'
+  ) THEN
+    RAISE EXCEPTION 'localized title alias missing';
+  END IF;
+END;
+$$;
+
+SET ROLE anon;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.game_works LIMIT 1;
+    RAISE EXCEPTION 'anon unexpectedly read identity metadata';
+  EXCEPTION WHEN insufficient_privilege THEN
+    NULL;
+  END;
+END;
+$$;
+RESET ROLE;

--- a/backend/app/db/tests/identity_integration.sql
+++ b/backend/app/db/tests/identity_integration.sql
@@ -19,21 +19,25 @@ CREATE TABLE public.games (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- A/B: same title but verified distinct BGG work IDs.
+-- C/D: same work represented by separate English/Japanese editions; D starts
+-- unlinked and is linked only after explicit verification in the fixture.
 INSERT INTO public.games (id,title,title_ja,title_en,slug,bgg_url) VALUES
 ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','Twin Game','ツインゲーム','Twin Game','twin-a','https://boardgamegeek.com/boardgame/100/twin-game-a'),
-('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb','Twin Game','ツインゲーム別版','Twin Game','twin-b','https://boardgamegeek.com/boardgame/200/twin-game-b'),
-('cccccccc-cccc-4ccc-8ccc-cccccccccccc','Other Game','別ゲーム','Other Game','other',NULL);
+('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb','Twin Game','ツインゲーム別作品','Twin Game','twin-b','https://boardgamegeek.com/boardgame/200/twin-game-b'),
+('cccccccc-cccc-4ccc-8ccc-cccccccccccc','Shared Work','共有ゲーム','Shared Work','shared-en','https://boardgamegeek.com/boardgame/300/shared-work'),
+('dddddddd-dddd-4ddd-8ddd-dddddddddddd','共有ゲーム 日本語版','共有ゲーム 日本語版','Shared Work Japanese Edition','shared-ja',NULL);
 
 \ir ../migrations/003_canonical_game_identity.sql
 \ir ../migrations/004_lock_identity_metadata.sql
 
 DO $$
 BEGIN
-  IF (SELECT count(*) FROM public.games) <> 3 THEN
+  IF (SELECT count(*) FROM public.games) <> 4 THEN
     RAISE EXCEPTION 'migration changed game row count';
   END IF;
-  IF (SELECT count(*) FROM public.game_works) <> 3 THEN
-    RAISE EXCEPTION 'title similarity caused an inferred work merge';
+  IF (SELECT count(*) FROM public.game_works) <> 4 THEN
+    RAISE EXCEPTION 'migration inferred a work merge';
   END IF;
   IF EXISTS (SELECT 1 FROM public.games WHERE work_id <> id) THEN
     RAISE EXCEPTION 'legacy bootstrap must preserve one distinct work per game';
@@ -45,14 +49,38 @@ BEGIN
     SELECT 1 FROM public.game_identity_duplicate_candidates
     WHERE normalized_title = public.normalize_game_title('Twin Game')
   ) THEN
-    RAISE EXCEPTION 'same-title duplicate candidate was not surfaced';
+    RAISE EXCEPTION 'same-title distinct-work candidate was not surfaced';
+  END IF;
+END;
+$$;
+
+-- Simulate verified same-work evidence. The two editions remain distinct rows and
+-- receive distinct BGG version IDs and language codes.
+UPDATE public.games
+SET language_code='en', edition_label='English edition', bgg_version_id=3001
+WHERE id='cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+UPDATE public.games
+SET work_id='cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+    language_code='ja', edition_label='Japanese edition', bgg_version_id=3002
+WHERE id='dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+
+DO $$
+BEGIN
+  IF (SELECT work_id FROM public.games WHERE id='cccccccc-cccc-4ccc-8ccc-cccccccccccc')
+     IS DISTINCT FROM
+     (SELECT work_id FROM public.games WHERE id='dddddddd-dddd-4ddd-8ddd-dddddddddddd') THEN
+    RAISE EXCEPTION 'verified EN/JA editions do not share work identity';
+  END IF;
+  IF (SELECT bgg_version_id FROM public.games WHERE id='cccccccc-cccc-4ccc-8ccc-cccccccccccc') =
+     (SELECT bgg_version_id FROM public.games WHERE id='dddddddd-dddd-4ddd-8ddd-dddddddddddd') THEN
+    RAISE EXCEPTION 'separate editions collapsed to one edition identity';
   END IF;
 END;
 $$;
 
 UPDATE public.games
-SET language_code='en', edition_label='First edition', bgg_version_id=1001,
-    source_revision='rev-2', generated_from_source_revision='rev-1'
+SET source_revision='rev-2', generated_from_source_revision='rev-1'
 WHERE id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 
 DO $$
@@ -76,7 +104,7 @@ BEGIN
   END IF;
   IF NOT EXISTS (
     SELECT 1 FROM public.game_title_aliases
-    WHERE game_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' AND language_code='ja'
+    WHERE game_id='cccccccc-cccc-4ccc-8ccc-cccccccccccc' AND language_code='ja'
   ) THEN
     RAISE EXCEPTION 'localized title alias missing';
   END IF;

--- a/docs/CANONICAL_GAME_IDENTITY.md
+++ b/docs/CANONICAL_GAME_IDENTITY.md
@@ -1,0 +1,60 @@
+# Canonical Game Identity Contract
+
+Issue: #90
+
+## Identity levels
+
+`game_works` represents the abstract game/work. `games` remains the concrete edition record used by existing URLs and foreign keys. A work can therefore have multiple editions without mixing their rule content.
+
+Stable external identity is explicit:
+
+- `game_works.bgg_id`: BoardGameGeek boardgame/thing ID (work-level evidence).
+- `games.bgg_version_id`: BoardGameGeek version ID (edition-level evidence).
+- `games.work_id`: explicit work membership.
+
+A title, localized title, slug, publisher, year, or language is never sufficient by itself to merge records.
+
+## Legacy migration rule
+
+Every existing `games` row becomes its own distinct `game_works` row using the same UUID. This deliberately produces false-positive duplicate candidates instead of destructive false merges. Existing BGG work IDs are backfilled only when a numeric ID is already present in the stored `bgg_url`; missing IDs remain missing.
+
+No legacy row is deleted or merged by the migration.
+
+## Edition metadata
+
+The edition record can carry:
+
+- `edition_label`
+- `language_code`
+- `publisher`
+- `bgg_version_id`
+- `source_revision`
+- `generated_from_source_revision`
+- `identity_status`: `unverified`, `verified`, or `needs_review`
+
+`game_generation_freshness` reports whether generated content is current, stale, or lacks revision evidence.
+
+## Names and URLs
+
+`game_title_aliases` stores display/search names separately from identity. Existing `title`, `title_ja`, and `title_en` are backfilled as aliases.
+
+`game_slug_aliases` is URL history. Changing `games.slug` automatically reserves the old slug for the same game, so an old public URL can still resolve to the canonical edition. A slug already reserved by another game's alias cannot be reused.
+
+## Duplicate handling
+
+`game_identity_duplicate_candidates` surfaces normalized-title collisions for review. It is an audit queue, not an automatic merge list.
+
+Resolution order:
+
+1. Exact verified edition external ID -> same edition.
+2. Exact verified work external ID -> same work, but editions remain separate unless edition identity is also proven.
+3. Conflicting verified work IDs -> distinct works.
+4. Title/alias similarity without stable external evidence -> `needs_review`; never merge automatically.
+
+## Source provenance
+
+`source_revision` identifies the currently observed upstream revision. `generated_from_source_revision` records which revision produced the current generated rules. A mismatch is `stale`; missing evidence remains explicitly unknown.
+
+## Audit
+
+`game_identity_audit_summary` reports total games, total works, BGG coverage, missing language/source revision, and duplicate-title groups. Production migration acceptance requires row-count preservation and review of this summary plus duplicate candidates.


### PR DESCRIPTION
Refs #90.

## Canonical identity contract
- existing `games.id` remains the edition identity used by existing FKs/URLs
- new `game_works` separates abstract work identity from edition identity
- legacy bootstrap is fail-closed: 182 existing games become 182 distinct works; no title/slug-based merge
- BGG work ID is backfilled only from an explicit stored BGG URL; BGG version ID is a separate edition-level field
- edition/language/publisher/source revision fields are explicit; unknown values remain NULL
- title/title_ja/title_en are backfilled into `game_title_aliases`, not used as identity keys
- slug changes are captured in `game_slug_aliases`; backend resolves an old slug to the canonical game
- source revision vs generated-from revision is exposed through freshness audit
- duplicate-title collisions are exposed as review candidates, never auto-merged
- identity metadata tables/views are locked from anon/authenticated direct access so #89 is preserved

## CI
Current head `5e2b337ebb7fd7f183843fd4b1805560a9c63a21`:
- Test Canonical Game Identity: success
- Test Supabase RLS: success
- Vercel Preview + auth/server env + Google OAuth preflight: success
- fixtures cover same-title distinct works, same-work distinct editions, EN/JA editions, old slug alias, BGG IDs, and source-revision staleness

## Production audit
Migration already applied after green CI:
- games: 182 -> 182
- game_works: 182
- bootstrap `work_id != id`: 0
- explicit BGG work IDs recovered: 103
- inferred BGG version IDs: 0
- missing language_code: 182 (left unknown, not guessed)
- missing source_revision: 182 (left unknown, not guessed)
- duplicate normalized-title groups surfaced: 10
- identity tables: RLS enabled; anon/authenticated grants: 0

BGG API contract checked against BoardGameGeek's current XML API documentation: boardgame/thing ID and version information are distinct evidence levels; this implementation stores them separately.