### PR TITLE
Add private user list foundation (#59)

### DIFF
--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -1,0 +1,99 @@
+name: Test user lists
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/db/migrations/005_user_lists.sql"
+      - "backend/app/db/tests/list_integration.sql"
+      - "backend/app/routers/lists.py"
+      - "backend/app/services/list_service.py"
+      - "backend/app/main.py"
+      - "backend/tests/test_lists.py"
+      - "frontend/src/lib/api.js"
+      - "frontend/src/main.jsx"
+      - "frontend/src/components/AuthControlPortal.jsx"
+      - "frontend/src/components/GameListSavePortal.jsx"
+      - "frontend/src/components/game/AddToListButton.jsx"
+      - "frontend/src/pages/ListsPage.jsx"
+      - "frontend/tests/lists.spec.js"
+      - ".github/workflows/test-lists.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/db/migrations/005_user_lists.sql"
+      - "backend/app/db/tests/list_integration.sql"
+      - "backend/app/routers/lists.py"
+      - "backend/app/services/list_service.py"
+      - "backend/app/main.py"
+      - "backend/tests/test_lists.py"
+      - "frontend/src/lib/api.js"
+      - "frontend/src/main.jsx"
+      - "frontend/src/components/AuthControlPortal.jsx"
+      - "frontend/src/components/GameListSavePortal.jsx"
+      - "frontend/src/components/game/AddToListButton.jsx"
+      - "frontend/src/pages/ListsPage.jsx"
+      - "frontend/tests/lists.spec.js"
+      - ".github/workflows/test-lists.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  database-backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      PGPASSWORD: postgres
+      PYTHONPATH: backend
+    steps:
+      - uses: actions/checkout@v5
+      - name: Apply list migration and verify RLS/reorder/dedupe/unavailable-game behavior
+        run: psql "$DATABASE_URL" -f backend/app/db/tests/list_integration.sql
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv sync --frozen --dev
+      - name: Run backend list authorization tests
+        run: uv run pytest -q backend/tests/test_lists.py backend/tests/test_auth.py
+
+  frontend-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      VITE_SUPABASE_URL: https://example.supabase.co
+      VITE_SUPABASE_ANON_KEY: sb_publishable_test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+      - name: Lint list surface
+        working-directory: frontend
+        run: npx eslint src/main.jsx src/lib/api.js src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+      - name: Run list E2E
+        working-directory: frontend
+        run: npx playwright test tests/lists.spec.js --project=chromium

--- a/backend/app/db/migrations/005_user_lists.sql
+++ b/backend/app/db/migrations/005_user_lists.sql
@@ -1,0 +1,153 @@
+BEGIN;
+
+CREATE TABLE public.user_lists (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+  name text NOT NULL CHECK (length(trim(name)) BETWEEN 1 AND 80),
+  visibility text NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public')),
+  system_key text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX user_lists_owner_system_key_unique
+  ON public.user_lists(owner_id, system_key)
+  WHERE system_key IS NOT NULL;
+CREATE INDEX user_lists_owner_created_idx
+  ON public.user_lists(owner_id, created_at DESC);
+
+CREATE TABLE public.user_list_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  list_id uuid NOT NULL REFERENCES public.user_lists(id) ON DELETE CASCADE,
+  game_id uuid REFERENCES public.games(id) ON DELETE SET NULL,
+  game_title_snapshot text NOT NULL CHECK (length(trim(game_title_snapshot)) > 0),
+  position integer NOT NULL DEFAULT 0 CHECK (position >= 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX user_list_items_list_game_unique
+  ON public.user_list_items(list_id, game_id)
+  WHERE game_id IS NOT NULL;
+CREATE INDEX user_list_items_list_position_idx
+  ON public.user_list_items(list_id, position, created_at);
+
+ALTER TABLE public.user_lists ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_list_items ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY user_lists_select_own ON public.user_lists
+  FOR SELECT TO authenticated
+  USING ((SELECT auth.uid()) = owner_id);
+CREATE POLICY user_lists_insert_own ON public.user_lists
+  FOR INSERT TO authenticated
+  WITH CHECK ((SELECT auth.uid()) = owner_id);
+CREATE POLICY user_lists_update_own ON public.user_lists
+  FOR UPDATE TO authenticated
+  USING ((SELECT auth.uid()) = owner_id)
+  WITH CHECK ((SELECT auth.uid()) = owner_id);
+CREATE POLICY user_lists_delete_own ON public.user_lists
+  FOR DELETE TO authenticated
+  USING ((SELECT auth.uid()) = owner_id);
+
+CREATE POLICY user_list_items_select_own ON public.user_list_items
+  FOR SELECT TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.user_lists l
+    WHERE l.id = user_list_items.list_id
+      AND l.owner_id = (SELECT auth.uid())
+  ));
+CREATE POLICY user_list_items_insert_own ON public.user_list_items
+  FOR INSERT TO authenticated
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.user_lists l
+    WHERE l.id = user_list_items.list_id
+      AND l.owner_id = (SELECT auth.uid())
+  ));
+CREATE POLICY user_list_items_update_own ON public.user_list_items
+  FOR UPDATE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.user_lists l
+    WHERE l.id = user_list_items.list_id
+      AND l.owner_id = (SELECT auth.uid())
+  ))
+  WITH CHECK (EXISTS (
+    SELECT 1 FROM public.user_lists l
+    WHERE l.id = user_list_items.list_id
+      AND l.owner_id = (SELECT auth.uid())
+  ));
+CREATE POLICY user_list_items_delete_own ON public.user_list_items
+  FOR DELETE TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM public.user_lists l
+    WHERE l.id = user_list_items.list_id
+      AND l.owner_id = (SELECT auth.uid())
+  ));
+
+REVOKE ALL PRIVILEGES ON TABLE public.user_lists FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON TABLE public.user_list_items FROM anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_lists TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.user_list_items TO authenticated;
+GRANT ALL PRIVILEGES ON TABLE public.user_lists TO service_role;
+GRANT ALL PRIVILEGES ON TABLE public.user_list_items TO service_role;
+
+CREATE OR REPLACE FUNCTION public.reorder_owned_list_items(
+  p_owner_id uuid,
+  p_list_id uuid,
+  p_item_ids uuid[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  expected_count integer;
+  supplied_count integer;
+  supplied_distinct integer;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_lists
+    WHERE id = p_list_id AND owner_id = p_owner_id
+  ) THEN
+    RAISE EXCEPTION 'list_not_found' USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT count(*) INTO expected_count
+  FROM public.user_list_items
+  WHERE list_id = p_list_id;
+
+  supplied_count := COALESCE(cardinality(p_item_ids), 0);
+  SELECT count(DISTINCT item_id) INTO supplied_distinct
+  FROM unnest(COALESCE(p_item_ids, ARRAY[]::uuid[])) AS item_id;
+
+  IF supplied_count <> expected_count OR supplied_distinct <> expected_count THEN
+    RAISE EXCEPTION 'invalid_item_order' USING ERRCODE = '22023';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM unnest(COALESCE(p_item_ids, ARRAY[]::uuid[])) AS supplied(item_id)
+    LEFT JOIN public.user_list_items li
+      ON li.id = supplied.item_id AND li.list_id = p_list_id
+    WHERE li.id IS NULL
+  ) THEN
+    RAISE EXCEPTION 'invalid_item_order' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.user_list_items li
+  SET position = ordered.ordinality - 1,
+      updated_at = now()
+  FROM unnest(COALESCE(p_item_ids, ARRAY[]::uuid[])) WITH ORDINALITY AS ordered(item_id, ordinality)
+  WHERE li.id = ordered.item_id AND li.list_id = p_list_id;
+
+  UPDATE public.user_lists
+  SET updated_at = now()
+  WHERE id = p_list_id AND owner_id = p_owner_id;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.reorder_owned_list_items(uuid, uuid, uuid[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.reorder_owned_list_items(uuid, uuid, uuid[]) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.reorder_owned_list_items(uuid, uuid, uuid[]) TO service_role;
+
+COMMIT;

--- a/backend/app/db/tests/list_integration.sql
+++ b/backend/app/db/tests/list_integration.sql
@@ -1,0 +1,136 @@
+\set ON_ERROR_STOP on
+
+CREATE ROLE anon NOLOGIN;
+CREATE ROLE authenticated NOLOGIN;
+CREATE ROLE service_role NOLOGIN BYPASSRLS;
+
+CREATE SCHEMA auth;
+CREATE FUNCTION auth.uid()
+RETURNS uuid LANGUAGE sql STABLE
+AS $$ SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid; $$;
+
+CREATE TABLE public.profiles (
+  id uuid PRIMARY KEY,
+  username text
+);
+CREATE TABLE public.games (
+  id uuid PRIMARY KEY,
+  title text NOT NULL,
+  title_ja text,
+  slug text
+);
+
+INSERT INTO public.profiles(id, username) VALUES
+  ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','user-a'),
+  ('bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb','user-b');
+INSERT INTO public.games(id, title, title_ja, slug) VALUES
+  ('11111111-1111-4111-8111-111111111111','Game One','ゲーム1','game-one'),
+  ('22222222-2222-4222-8222-222222222222','Game Two','ゲーム2','game-two');
+
+\ir ../migrations/005_user_lists.sql
+
+SET ROLE authenticated;
+SET request.jwt.claim.sub = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+INSERT INTO public.user_lists(id, owner_id, name)
+VALUES ('aaaaaaaa-0000-4000-8000-000000000001','aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','Favorites');
+
+INSERT INTO public.user_list_items(id, list_id, game_id, game_title_snapshot, position) VALUES
+('aaaaaaaa-1000-4000-8000-000000000001','aaaaaaaa-0000-4000-8000-000000000001','11111111-1111-4111-8111-111111111111','ゲーム1',0),
+('aaaaaaaa-1000-4000-8000-000000000002','aaaaaaaa-0000-4000-8000-000000000001','22222222-2222-4222-8222-222222222222','ゲーム2',1);
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.user_list_items(list_id, game_id, game_title_snapshot, position)
+    VALUES ('aaaaaaaa-0000-4000-8000-000000000001','11111111-1111-4111-8111-111111111111','duplicate',2);
+    RAISE EXCEPTION 'duplicate membership unexpectedly accepted';
+  EXCEPTION WHEN unique_violation THEN NULL;
+  END;
+END;
+$$;
+
+RESET ROLE;
+RESET request.jwt.claim.sub;
+
+SET ROLE authenticated;
+SET request.jwt.claim.sub = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.user_lists) THEN
+    RAISE EXCEPTION 'user B can read user A private list';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.user_list_items) THEN
+    RAISE EXCEPTION 'user B can read user A private list items';
+  END IF;
+END;
+$$;
+UPDATE public.user_lists SET name='tampered' WHERE id='aaaaaaaa-0000-4000-8000-000000000001';
+DELETE FROM public.user_list_items WHERE id='aaaaaaaa-1000-4000-8000-000000000001';
+RESET ROLE;
+RESET request.jwt.claim.sub;
+
+DO $$
+BEGIN
+  IF (SELECT name FROM public.user_lists WHERE id='aaaaaaaa-0000-4000-8000-000000000001') <> 'Favorites' THEN
+    RAISE EXCEPTION 'user B modified user A list';
+  END IF;
+  IF (SELECT count(*) FROM public.user_list_items WHERE list_id='aaaaaaaa-0000-4000-8000-000000000001') <> 2 THEN
+    RAISE EXCEPTION 'user B deleted user A item';
+  END IF;
+END;
+$$;
+
+SET ROLE service_role;
+SELECT public.reorder_owned_list_items(
+  'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  'aaaaaaaa-0000-4000-8000-000000000001',
+  ARRAY['aaaaaaaa-1000-4000-8000-000000000002','aaaaaaaa-1000-4000-8000-000000000001']::uuid[]
+);
+RESET ROLE;
+
+DO $$
+BEGIN
+  IF (SELECT position FROM public.user_list_items WHERE id='aaaaaaaa-1000-4000-8000-000000000002') <> 0 THEN
+    RAISE EXCEPTION 'reorder did not persist';
+  END IF;
+  IF (SELECT position FROM public.user_list_items WHERE id='aaaaaaaa-1000-4000-8000-000000000001') <> 1 THEN
+    RAISE EXCEPTION 'reorder did not persist';
+  END IF;
+END;
+$$;
+
+DELETE FROM public.games WHERE id='11111111-1111-4111-8111-111111111111';
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.user_list_items
+    WHERE id='aaaaaaaa-1000-4000-8000-000000000001'
+      AND game_id IS NULL
+      AND game_title_snapshot='ゲーム1'
+  ) THEN
+    RAISE EXCEPTION 'deleted game did not preserve unavailable item snapshot';
+  END IF;
+END;
+$$;
+
+SET ROLE anon;
+DO $$
+BEGIN
+  BEGIN
+    PERFORM * FROM public.user_lists;
+    RAISE EXCEPTION 'anon unexpectedly read private lists';
+  EXCEPTION WHEN insufficient_privilege THEN NULL;
+  END;
+  BEGIN
+    PERFORM public.reorder_owned_list_items(
+      'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      'aaaaaaaa-0000-4000-8000-000000000001',
+      ARRAY[]::uuid[]
+    );
+    RAISE EXCEPTION 'anon unexpectedly executed reorder RPC';
+  EXCEPTION WHEN insufficient_privilege THEN NULL;
+  END;
+END;
+$$;
+RESET ROLE;

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import HTMLResponse
 
 from app.core.logger import setup_logging
 from app.middleware.validation import ValidationMiddleware
-from app.routers import auth, games
+from app.routers import auth, games, lists
 from app.services.seo_renderer import generate_seo_html
 from app.services.sitemap import get_sitemap_xml
 
@@ -23,6 +23,7 @@ app.add_middleware(
 
 app.include_router(games.router, prefix="/api", tags=["games"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
+app.include_router(lists.router, prefix="/api", tags=["lists"])
 
 
 @app.get("/health")
@@ -39,8 +40,6 @@ async def sitemap_xml():
 
 @app.get("/games/{slug}")
 async def game_seo_page(slug: str):
-    """
-    Serve the game page with server-side injected SEO tags.
-    """
+    """Serve the game page with server-side injected SEO tags."""
     content = await generate_seo_html(slug)
     return HTMLResponse(content=content)

--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.routers.auth import get_current_user
+from app.services.list_service import (
+    DuplicateMembershipError,
+    GameNotFoundError,
+    InvalidReorderError,
+    ListNotFoundError,
+    ListService,
+    list_service,
+)
+
+router = APIRouter()
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class UserListCreate(StrictModel):
+    name: str = Field(min_length=1, max_length=80)
+    visibility: Literal["private", "public"] = "private"
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("name must not be blank")
+        return value
+
+
+class UserListRename(StrictModel):
+    name: str = Field(min_length=1, max_length=80)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("name must not be blank")
+        return value
+
+
+class UserListItemAdd(StrictModel):
+    game_id: UUID
+
+
+class UserListReorder(StrictModel):
+    item_ids: list[UUID]
+
+
+def get_list_service() -> ListService:
+    return list_service
+
+
+def _owner_id(user: dict) -> str:
+    owner_id = user.get("id")
+    if not owner_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Verified user id required")
+    return str(owner_id)
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="List or item not found")
+
+
+@router.get("/lists")
+async def list_user_lists(
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    return {"lists": await service.list_lists(_owner_id(user))}
+
+
+@router.post("/lists", status_code=status.HTTP_201_CREATED)
+async def create_user_list(
+    payload: UserListCreate,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    return await service.create_list(_owner_id(user), payload.name, payload.visibility)
+
+
+@router.get("/lists/{list_id}")
+async def get_user_list(
+    list_id: UUID,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        return await service.get_list(_owner_id(user), str(list_id))
+    except ListNotFoundError as exc:
+        raise _not_found() from exc
+
+
+@router.patch("/lists/{list_id}")
+async def rename_user_list(
+    list_id: UUID,
+    payload: UserListRename,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        return await service.rename_list(_owner_id(user), str(list_id), payload.name)
+    except ListNotFoundError as exc:
+        raise _not_found() from exc
+
+
+@router.delete("/lists/{list_id}")
+async def delete_user_list(
+    list_id: UUID,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        await service.delete_list(_owner_id(user), str(list_id))
+        return {"status": "deleted"}
+    except ListNotFoundError as exc:
+        raise _not_found() from exc
+
+
+@router.post("/lists/{list_id}/items", status_code=status.HTTP_201_CREATED)
+async def add_user_list_item(
+    list_id: UUID,
+    payload: UserListItemAdd,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        return await service.add_item(_owner_id(user), str(list_id), str(payload.game_id))
+    except ListNotFoundError as exc:
+        raise _not_found() from exc
+    except GameNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Canonical game not found") from exc
+    except DuplicateMembershipError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Game is already in this list") from exc
+
+
+@router.delete("/lists/{list_id}/items/{item_id}")
+async def remove_user_list_item(
+    list_id: UUID,
+    item_id: UUID,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        await service.remove_item(_owner_id(user), str(list_id), str(item_id))
+        return {"status": "deleted"}
+    except ListNotFoundError as exc:
+        raise _not_found() from exc
+
+
+@router.put("/lists/{list_id}/order")
+async def reorder_user_list(
+    list_id: UUID,
+    payload: UserListReorder,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        await service.reorder(_owner_id(user), str(list_id), [str(item_id) for item_id in payload.item_ids])
+        return {"status": "reordered"}
+    except ListNotFoundError as exc:
+        raise _not_found() from exc
+    except InvalidReorderError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Order must contain every list item exactly once") from exc

--- a/backend/app/services/list_service.py
+++ b/backend/app/services/list_service.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import anyio
+
+from app.core.supabase import _get_client
+
+
+class ListNotFoundError(RuntimeError):
+    pass
+
+
+class GameNotFoundError(RuntimeError):
+    pass
+
+
+class DuplicateMembershipError(RuntimeError):
+    pass
+
+
+class InvalidReorderError(RuntimeError):
+    pass
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class ListService:
+    @staticmethod
+    def _owned_list(client, owner_id: str, list_id: str) -> dict[str, Any]:
+        rows = (
+            client.table("user_lists")
+            .select("*")
+            .eq("id", list_id)
+            .eq("owner_id", owner_id)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rows:
+            raise ListNotFoundError(list_id)
+        return rows[0]
+
+    async def list_lists(self, owner_id: str) -> list[dict[str, Any]]:
+        def _q():
+            return (
+                _get_client()
+                .table("user_lists")
+                .select("id,name,visibility,system_key,created_at,updated_at")
+                .eq("owner_id", owner_id)
+                .order("created_at")
+                .execute()
+                .data
+            )
+        return await anyio.to_thread.run_sync(_q)
+
+    async def create_list(self, owner_id: str, name: str, visibility: str) -> dict[str, Any]:
+        def _q():
+            return (
+                _get_client()
+                .table("user_lists")
+                .insert({"owner_id": owner_id, "name": name, "visibility": visibility})
+                .execute()
+                .data[0]
+            )
+        return await anyio.to_thread.run_sync(_q)
+
+    async def get_list(self, owner_id: str, list_id: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            user_list = self._owned_list(client, owner_id, list_id)
+            items = (
+                client.table("user_list_items")
+                .select("id,list_id,game_id,game_title_snapshot,position,created_at,updated_at")
+                .eq("list_id", list_id)
+                .order("position")
+                .order("created_at")
+                .execute()
+                .data
+            )
+            game_ids = [item["game_id"] for item in items if item.get("game_id")]
+            games: list[dict[str, Any]] = []
+            if game_ids:
+                games = (
+                    client.table("games")
+                    .select("id,slug,title,title_ja,image_url")
+                    .in_("id", game_ids)
+                    .execute()
+                    .data
+                )
+            games_by_id = {game["id"]: game for game in games}
+            normalized_items = []
+            for item in items:
+                game = games_by_id.get(item.get("game_id"))
+                normalized_items.append({**item, "game": game, "unavailable": game is None})
+            return {**user_list, "items": normalized_items}
+        return await anyio.to_thread.run_sync(_q)
+
+    async def rename_list(self, owner_id: str, list_id: str, name: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            self._owned_list(client, owner_id, list_id)
+            rows = (
+                client.table("user_lists")
+                .update({"name": name, "updated_at": _now()})
+                .eq("id", list_id)
+                .eq("owner_id", owner_id)
+                .execute()
+                .data
+            )
+            if not rows:
+                raise ListNotFoundError(list_id)
+            return rows[0]
+        return await anyio.to_thread.run_sync(_q)
+
+    async def delete_list(self, owner_id: str, list_id: str) -> None:
+        def _q():
+            client = _get_client()
+            self._owned_list(client, owner_id, list_id)
+            client.table("user_lists").delete().eq("id", list_id).eq("owner_id", owner_id).execute()
+        await anyio.to_thread.run_sync(_q)
+
+    async def add_item(self, owner_id: str, list_id: str, game_id: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            self._owned_list(client, owner_id, list_id)
+            game_rows = (
+                client.table("games")
+                .select("id,slug,title,title_ja,image_url")
+                .eq("id", game_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+            if not game_rows:
+                raise GameNotFoundError(game_id)
+            game = game_rows[0]
+            existing = (
+                client.table("user_list_items")
+                .select("id")
+                .eq("list_id", list_id)
+                .eq("game_id", game_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+            if existing:
+                raise DuplicateMembershipError(game_id)
+            last = (
+                client.table("user_list_items")
+                .select("position")
+                .eq("list_id", list_id)
+                .order("position", desc=True)
+                .limit(1)
+                .execute()
+                .data
+            )
+            position = int(last[0]["position"]) + 1 if last else 0
+            title_snapshot = str(game.get("title_ja") or game.get("title") or game_id)
+            try:
+                item = (
+                    client.table("user_list_items")
+                    .insert({
+                        "list_id": list_id,
+                        "game_id": game_id,
+                        "game_title_snapshot": title_snapshot,
+                        "position": position,
+                    })
+                    .execute()
+                    .data[0]
+                )
+            except Exception as exc:
+                if "23505" in str(exc) or "duplicate" in str(exc).lower():
+                    raise DuplicateMembershipError(game_id) from exc
+                raise
+            client.table("user_lists").update({"updated_at": _now()}).eq("id", list_id).eq("owner_id", owner_id).execute()
+            return {**item, "game": game, "unavailable": False}
+        return await anyio.to_thread.run_sync(_q)
+
+    async def remove_item(self, owner_id: str, list_id: str, item_id: str) -> None:
+        def _q():
+            client = _get_client()
+            self._owned_list(client, owner_id, list_id)
+            rows = (
+                client.table("user_list_items")
+                .select("id")
+                .eq("id", item_id)
+                .eq("list_id", list_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+            if not rows:
+                raise ListNotFoundError(item_id)
+            client.table("user_list_items").delete().eq("id", item_id).eq("list_id", list_id).execute()
+            client.table("user_lists").update({"updated_at": _now()}).eq("id", list_id).eq("owner_id", owner_id).execute()
+        await anyio.to_thread.run_sync(_q)
+
+    async def reorder(self, owner_id: str, list_id: str, item_ids: list[str]) -> None:
+        def _q():
+            client = _get_client()
+            self._owned_list(client, owner_id, list_id)
+            try:
+                client.rpc(
+                    "reorder_owned_list_items",
+                    {"p_owner_id": owner_id, "p_list_id": list_id, "p_item_ids": item_ids},
+                ).execute()
+            except Exception as exc:
+                if "invalid_item_order" in str(exc) or "22023" in str(exc):
+                    raise InvalidReorderError(list_id) from exc
+                raise
+        await anyio.to_thread.run_sync(_q)
+
+
+list_service = ListService()

--- a/backend/tests/test_lists.py
+++ b/backend/tests/test_lists.py
@@ -1,0 +1,99 @@
+import pytest
+from pydantic import ValidationError
+
+from app.routers import lists
+from app.services.list_service import DuplicateMembershipError
+
+
+USER_A = {"id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}
+LIST_ID = "aaaaaaaa-0000-4000-8000-000000000001"
+GAME_ID = "11111111-1111-4111-8111-111111111111"
+ITEM_ID = "aaaaaaaa-1000-4000-8000-000000000001"
+
+
+class FakeListService:
+    def __init__(self):
+        self.calls = []
+        self.duplicate = False
+
+    async def list_lists(self, owner_id):
+        self.calls.append(("list", owner_id))
+        return []
+
+    async def create_list(self, owner_id, name, visibility):
+        self.calls.append(("create", owner_id, name, visibility))
+        return {"id": LIST_ID, "owner_id": owner_id, "name": name, "visibility": visibility}
+
+    async def get_list(self, owner_id, list_id):
+        self.calls.append(("get", owner_id, list_id))
+        return {"id": list_id, "name": "Favorites", "items": []}
+
+    async def rename_list(self, owner_id, list_id, name):
+        self.calls.append(("rename", owner_id, list_id, name))
+        return {"id": list_id, "name": name}
+
+    async def delete_list(self, owner_id, list_id):
+        self.calls.append(("delete", owner_id, list_id))
+
+    async def add_item(self, owner_id, list_id, game_id):
+        self.calls.append(("add", owner_id, list_id, game_id))
+        if self.duplicate:
+            raise DuplicateMembershipError(game_id)
+        return {"id": ITEM_ID, "list_id": list_id, "game_id": game_id}
+
+    async def remove_item(self, owner_id, list_id, item_id):
+        self.calls.append(("remove", owner_id, list_id, item_id))
+
+    async def reorder(self, owner_id, list_id, item_ids):
+        self.calls.append(("reorder", owner_id, list_id, item_ids))
+
+
+def test_list_payloads_forbid_user_supplied_owner_id():
+    with pytest.raises(ValidationError):
+        lists.UserListCreate(name="Favorites", owner_id=USER_A["id"])
+
+
+def test_item_payloads_forbid_user_supplied_owner_id():
+    with pytest.raises(ValidationError):
+        lists.UserListItemAdd(game_id=GAME_ID, owner_id=USER_A["id"])
+
+
+@pytest.mark.asyncio
+async def test_create_list_uses_only_verified_request_user():
+    service = FakeListService()
+    payload = lists.UserListCreate(name="  Favorites  ")
+    result = await lists.create_user_list(payload, user=USER_A, service=service)
+    assert result["owner_id"] == USER_A["id"]
+    assert service.calls == [("create", USER_A["id"], "Favorites", "private")]
+
+
+@pytest.mark.asyncio
+async def test_add_item_uses_verified_owner_and_canonical_game_id():
+    service = FakeListService()
+    payload = lists.UserListItemAdd(game_id=GAME_ID)
+    await lists.add_user_list_item(LIST_ID, payload, user=USER_A, service=service)
+    assert service.calls == [("add", USER_A["id"], LIST_ID, GAME_ID)]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_membership_returns_conflict():
+    service = FakeListService()
+    service.duplicate = True
+    payload = lists.UserListItemAdd(game_id=GAME_ID)
+    with pytest.raises(lists.HTTPException) as exc:
+        await lists.add_user_list_item(LIST_ID, payload, user=USER_A, service=service)
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_reorder_uses_verified_owner_and_full_item_order():
+    service = FakeListService()
+    payload = lists.UserListReorder(item_ids=[ITEM_ID])
+    await lists.reorder_user_list(LIST_ID, payload, user=USER_A, service=service)
+    assert service.calls == [("reorder", USER_A["id"], LIST_ID, [ITEM_ID])]
+
+
+def test_missing_verified_user_id_fails_closed():
+    with pytest.raises(lists.HTTPException) as exc:
+        lists._owner_id({})
+    assert exc.value.status_code == 401

--- a/frontend/src/components/AuthControlPortal.jsx
+++ b/frontend/src/components/AuthControlPortal.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
+
+import { useAuth } from '../auth/authContext'
 import LoginButton from './LoginButton'
 
 function findTarget() {
@@ -8,6 +10,7 @@ function findTarget() {
 
 export default function AuthControlPortal() {
   const [target, setTarget] = useState(null)
+  const { user } = useAuth()
 
   useEffect(() => {
     const resolveTarget = () => setTarget(findTarget())
@@ -24,7 +27,8 @@ export default function AuthControlPortal() {
   if (!target) return null
 
   return createPortal(
-    <div data-auth-control style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center' }}>
+    <div data-auth-control style={{ marginLeft: 'auto', display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap' }}>
+      {user && <a href="/lists" className="filter-btn" style={{ textDecoration: 'none' }}>マイリスト</a>}
       <LoginButton />
     </div>,
     target,

--- a/frontend/src/components/GameListSavePortal.jsx
+++ b/frontend/src/components/GameListSavePortal.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import { api } from '../lib/api'
+import AddToListButton from './game/AddToListButton'
+
+function currentGameSlug() {
+  const match = window.location.pathname.match(/^\/games\/([^/]+)\/?$/)
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+export default function GameListSavePortal() {
+  const [target, setTarget] = useState(null)
+  const [game, setGame] = useState(null)
+
+  useEffect(() => {
+    let active = true
+    const resolve = async () => {
+      const slug = currentGameSlug()
+      const nextTarget = document.querySelector('.game-page-toolbar .header-actions')
+      setTarget(nextTarget)
+      if (!slug || !nextTarget) {
+        setGame(null)
+        return
+      }
+      try {
+        const data = await api.get(`/api/games/${slug}`)
+        if (!active) return
+        setGame(Array.isArray(data) ? data[0] : data.game || data)
+      } catch {
+        if (active) setGame(null)
+      }
+    }
+
+    resolve()
+    const root = document.getElementById('root')
+    if (!root) return () => { active = false }
+    const observer = new MutationObserver(resolve)
+    observer.observe(root, { childList: true, subtree: true })
+    return () => {
+      active = false
+      observer.disconnect()
+    }
+  }, [])
+
+  if (!target || !game) return null
+  return createPortal(<AddToListButton game={game} />, target)
+}

--- a/frontend/src/components/game/AddToListButton.jsx
+++ b/frontend/src/components/game/AddToListButton.jsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+
+import { useAuth } from '../../auth/authContext'
+import { api } from '../../lib/api'
+
+export default function AddToListButton({ game }) {
+  const { user, loading: authLoading, signInWithGoogle } = useAuth()
+  const [lists, setLists] = useState([])
+  const [listId, setListId] = useState('')
+  const [status, setStatus] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    if (!user) {
+      setLists([])
+      setListId('')
+      return
+    }
+    let active = true
+    api.get('/api/lists')
+      .then((data) => {
+        if (!active) return
+        const next = data.lists || []
+        setLists(next)
+        setListId((current) => current || next[0]?.id || '')
+      })
+      .catch((err) => {
+        if (active) setStatus(err.message)
+      })
+    return () => { active = false }
+  }, [user])
+
+  if (authLoading) return null
+
+  if (!user) {
+    return (
+      <button className="filter-btn" onClick={signInWithGoogle} type="button">
+        ログインしてリスト保存
+      </button>
+    )
+  }
+
+  if (lists.length === 0) {
+    return <a className="filter-btn" href="/lists">リストを作成</a>
+  }
+
+  const add = async () => {
+    if (!listId || !game?.id) return
+    setBusy(true)
+    setStatus('')
+    try {
+      await api.post(`/api/lists/${listId}/items`, { game_id: game.id })
+      setStatus('保存しました')
+    } catch (err) {
+      setStatus(err.message.includes('already') ? 'すでに追加済みです' : err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+      <select
+        aria-label="保存先リスト"
+        className="sort-select"
+        value={listId}
+        onChange={(event) => setListId(event.target.value)}
+      >
+        {lists.map((list) => <option key={list.id} value={list.id}>{list.name}</option>)}
+      </select>
+      <button className="filter-btn" type="button" disabled={busy} onClick={add}>
+        {busy ? '保存中…' : 'リストに保存'}
+      </button>
+      {status && <span role="status" style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>{status}</span>}
+    </div>
+  )
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -5,6 +5,7 @@ const handleResponse = async (res) => {
     const errorBody = await res.json().catch(() => ({}))
     throw new Error(errorBody.message || errorBody.detail || `API Error: ${res.status} ${res.statusText}`)
   }
+  if (res.status === 204) return null
   return res.json()
 }
 
@@ -35,10 +36,17 @@ export const api = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
+  put: async (path, body) =>
+    request(path, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
   patch: async (path, body) =>
     request(path, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
+  delete: async (path) => request(path, { method: 'DELETE' }),
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -8,9 +8,11 @@ import './layout.css'
 
 const GamePage = lazy(() => import('./pages/GamePage.jsx'))
 const DataPage = lazy(() => import('./pages/DataPage.jsx'))
+const ListsPage = lazy(() => import('./pages/ListsPage.jsx'))
 
 import { AuthProvider } from './auth/AuthContext.jsx'
 import AuthControlPortal from './components/AuthControlPortal.jsx'
+import GameListSavePortal from './components/GameListSavePortal.jsx'
 import LoadingFallback from './components/LoadingFallback.jsx'
 
 const router = createBrowserRouter([
@@ -31,6 +33,14 @@ const router = createBrowserRouter([
     ),
   },
   {
+    path: '/lists',
+    element: (
+      <Suspense fallback={<LoadingFallback />}>
+        <ListsPage />
+      </Suspense>
+    ),
+  },
+  {
     path: '/data',
     element: (
       <Suspense fallback={<LoadingFallback />}>
@@ -46,6 +56,7 @@ createRoot(document.getElementById('root')).render(
       <AuthProvider>
         <RouterProvider router={router} />
         <AuthControlPortal />
+        <GameListSavePortal />
       </AuthProvider>
     </HelmetProvider>
   </StrictMode>

--- a/frontend/src/pages/ListsPage.jsx
+++ b/frontend/src/pages/ListsPage.jsx
@@ -1,0 +1,213 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+import { useAuth } from '../auth/authContext'
+import { api } from '../lib/api'
+
+export default function ListsPage() {
+  const { user, loading: authLoading, signInWithGoogle } = useAuth()
+  const [lists, setLists] = useState([])
+  const [selectedId, setSelectedId] = useState('')
+  const [detail, setDetail] = useState(null)
+  const [newName, setNewName] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const loadLists = async (preferredId = '') => {
+    setLoading(true)
+    setError('')
+    try {
+      const data = await api.get('/api/lists')
+      const next = data.lists || []
+      setLists(next)
+      const nextId = preferredId || selectedId || next[0]?.id || ''
+      setSelectedId(nextId)
+      if (nextId) {
+        setDetail(await api.get(`/api/lists/${nextId}`))
+      } else {
+        setDetail(null)
+      }
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (user) loadLists()
+    else {
+      setLists([])
+      setSelectedId('')
+      setDetail(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user])
+
+  const selectList = async (id) => {
+    setSelectedId(id)
+    setLoading(true)
+    setError('')
+    try {
+      setDetail(await api.get(`/api/lists/${id}`))
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const createList = async (event) => {
+    event.preventDefault()
+    const name = newName.trim()
+    if (!name) return
+    setError('')
+    try {
+      const created = await api.post('/api/lists', { name, visibility: 'private' })
+      setNewName('')
+      await loadLists(created.id)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const renameList = async () => {
+    if (!detail) return
+    const name = window.prompt('新しいリスト名', detail.name)?.trim()
+    if (!name || name === detail.name) return
+    try {
+      await api.patch(`/api/lists/${detail.id}`, { name })
+      await loadLists(detail.id)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const deleteList = async () => {
+    if (!detail || !window.confirm(`「${detail.name}」を削除しますか？`)) return
+    try {
+      await api.delete(`/api/lists/${detail.id}`)
+      setSelectedId('')
+      setDetail(null)
+      await loadLists()
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const removeItem = async (itemId) => {
+    if (!detail) return
+    try {
+      await api.delete(`/api/lists/${detail.id}/items/${itemId}`)
+      await selectList(detail.id)
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  const moveItem = async (index, delta) => {
+    if (!detail) return
+    const nextIndex = index + delta
+    if (nextIndex < 0 || nextIndex >= detail.items.length) return
+    const items = [...detail.items]
+    ;[items[index], items[nextIndex]] = [items[nextIndex], items[index]]
+    setDetail({ ...detail, items })
+    try {
+      await api.put(`/api/lists/${detail.id}/order`, { item_ids: items.map((item) => item.id) })
+    } catch (err) {
+      setError(err.message)
+      await selectList(detail.id)
+    }
+  }
+
+  if (authLoading) return <main style={{ padding: '3rem' }}>認証状態を確認しています…</main>
+
+  if (!user) {
+    return (
+      <main style={{ maxWidth: '720px', margin: '0 auto', padding: '3rem 1rem' }}>
+        <Link to="/" className="back-link">← DIRECTORY</Link>
+        <h1>マイリスト</h1>
+        <p>リストの作成・保存にはログインが必要です。</p>
+        <button type="button" className="filter-btn active" onClick={signInWithGoogle}>Googleでログイン</button>
+      </main>
+    )
+  }
+
+  return (
+    <main style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1rem' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
+        <Link to="/" className="back-link">← DIRECTORY</Link>
+        <h1 style={{ margin: 0 }}>マイリスト</h1>
+      </div>
+
+      <form onSubmit={createList} style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
+        <input
+          className="search-input"
+          style={{ maxWidth: '360px' }}
+          value={newName}
+          maxLength={80}
+          onChange={(event) => setNewName(event.target.value)}
+          placeholder="新しいリスト名"
+          aria-label="新しいリスト名"
+        />
+        <button className="filter-btn" type="submit">リストを作成</button>
+      </form>
+
+      {error && <div role="alert" style={{ marginBottom: '1rem', color: '#ff7777' }}>{error}</div>}
+      {loading && <div style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>読み込み中…</div>}
+
+      {lists.length === 0 && !loading ? (
+        <div className="pro-card">まだリストがありません。最初のリストを作成してください。</div>
+      ) : (
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 260px) minmax(0, 1fr)', gap: '16px' }}>
+          <aside style={{ position: 'static', width: 'auto', height: 'auto' }}>
+            {lists.map((list) => (
+              <button
+                type="button"
+                key={list.id}
+                className={`filter-btn ${selectedId === list.id ? 'active' : ''}`}
+                style={{ width: '100%', marginBottom: '8px', textAlign: 'left' }}
+                onClick={() => selectList(list.id)}
+              >
+                {list.name}
+              </button>
+            ))}
+          </aside>
+
+          <section>
+            {detail && (
+              <>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
+                  <h2 style={{ margin: 0 }}>{detail.name}</h2>
+                  <button type="button" className="filter-btn" onClick={renameList}>名前変更</button>
+                  <button type="button" className="filter-btn" onClick={deleteList}>削除</button>
+                </div>
+
+                {detail.items.length === 0 ? (
+                  <div className="pro-card">このリストは空です。ゲーム詳細から追加できます。</div>
+                ) : detail.items.map((item, index) => {
+                  const title = item.game?.title_ja || item.game?.title || item.game_title_snapshot
+                  return (
+                    <div key={item.id} className="pro-card" style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '10px', flexWrap: 'wrap' }}>
+                      <div style={{ flex: '1 1 220px' }}>
+                        {item.game ? <Link to={`/games/${item.game.slug}`}>{title}</Link> : <strong>{title}</strong>}
+                        {item.unavailable && <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>現在利用できないゲーム</div>}
+                      </div>
+                      <div style={{ display: 'flex', gap: '6px' }}>
+                        <button type="button" className="filter-btn" aria-label={`${title}を上へ`} disabled={index === 0} onClick={() => moveItem(index, -1)}>↑</button>
+                        <button type="button" className="filter-btn" aria-label={`${title}を下へ`} disabled={index === detail.items.length - 1} onClick={() => moveItem(index, 1)}>↓</button>
+                        <button type="button" className="filter-btn" onClick={() => removeItem(item.id)}>削除</button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </>
+            )}
+          </section>
+        </div>
+      )}
+
+      <style>{`@media (max-width: 720px) { main > div[style*="grid-template-columns"] { grid-template-columns: 1fr !important; } }`}</style>
+    </main>
+  )
+}

--- a/frontend/tests/lists.spec.js
+++ b/frontend/tests/lists.spec.js
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test'
+
+const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const LIST_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+const GAME_ID = '11111111-1111-4111-8111-111111111111'
+const TOKEN = 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJhYWFhYWFhYS1hYWFhLTRhYWEtOGFhYS1hYWFhYWFhYWFhYWFhYSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjo0MTAyNDQ0ODAwfQ.'
+
+async function installSession(page) {
+  await page.addInitScript(({ token, userId }) => {
+    localStorage.setItem('sb-example-auth-token', JSON.stringify({
+      access_token: token,
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: 4102444800,
+      refresh_token: 'test-refresh',
+      user: {
+        id: userId,
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'user@example.com',
+        user_metadata: { full_name: 'Test User' },
+      },
+    }))
+  }, { token: TOKEN, userId: USER_ID })
+}
+
+test('anonymous list route is mobile-usable and offers Google login instead of private mutations', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/lists')
+  await expect(page.getByRole('heading', { name: 'マイリスト' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Googleでログイン' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'リストを作成' })).toHaveCount(0)
+})
+
+test('authenticated list page renders private list and reorder/remove controls', async ({ page }) => {
+  await installSession(page)
+  await page.route('**/api/lists', async (route) => {
+    await expect(route.request().headers()['authorization']).toBe(`Bearer ${TOKEN}`)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private' }] }),
+    })
+  })
+  await page.route(`**/api/lists/${LIST_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: LIST_ID,
+        name: 'Favorites',
+        visibility: 'private',
+        items: [
+          { id: 'aaaaaaaa-1000-4000-8000-000000000001', game_id: GAME_ID, game_title_snapshot: 'ゲーム1', position: 0, unavailable: false, game: { id: GAME_ID, slug: 'game-one', title_ja: 'ゲーム1', title: 'Game One' } },
+          { id: 'aaaaaaaa-1000-4000-8000-000000000002', game_id: null, game_title_snapshot: 'Unavailable Game', position: 1, unavailable: true, game: null },
+        ],
+      }),
+    })
+  })
+
+  await page.goto('/lists')
+  await expect(page.getByText('Favorites', { exact: true }).first()).toBeVisible()
+  await expect(page.getByText('ゲーム1', { exact: true })).toBeVisible()
+  await expect(page.getByText('Unavailable Game', { exact: true })).toBeVisible()
+  await expect(page.getByText('現在利用できないゲーム')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'ゲーム1を下へ' })).toBeVisible()
+})
+
+test('game detail saves canonical game id to selected user list with bearer token', async ({ page }) => {
+  await installSession(page)
+  await page.route('**/api/games/game-one', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: GAME_ID, slug: 'game-one', title: 'Game One', title_ja: 'ゲーム1', structured_data: {} }),
+    })
+  })
+  await page.route('**/api/games?limit=50', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+  await page.route('**/api/lists', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private' }] }),
+    })
+  })
+
+  let saved = false
+  await page.route(`**/api/lists/${LIST_ID}/items`, async (route) => {
+    expect(route.request().method()).toBe('POST')
+    expect(route.request().headers()['authorization']).toBe(`Bearer ${TOKEN}`)
+    expect(route.request().postDataJSON()).toEqual({ game_id: GAME_ID })
+    saved = true
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'item-1', game_id: GAME_ID }),
+    })
+  })
+
+  await page.goto('/games/game-one')
+  await expect(page.getByRole('button', { name: 'リストに保存' })).toBeVisible()
+  await page.getByRole('button', { name: 'リストに保存' }).click()
+  await expect(page.getByRole('status')).toContainText('保存しました')
+  expect(saved).toBe(true)
+})


### PR DESCRIPTION
Refs #59.

## Implemented
- canonical `user_lists` / `user_list_items` schema; private by default
- owner-only RLS; anon has no list grants
- duplicate `(list_id, game_id)` constraint
- deleted canonical game preserves list item via `game_id ON DELETE SET NULL` + title snapshot
- atomic reorder RPC validates the complete item set and is executable only by `service_role`
- backend CRUD/add/remove/reorder derives owner only from verified Bearer user; request schemas forbid user-supplied `owner_id` / `user_id`
- service-role backend filters every list operation by verified owner
- `/lists` UI with create/rename/delete/remove/reorder, unavailable-game rendering and mobile layout
- authenticated `マイリスト` entry and GamePage save portal

## CI on `2cec827f65f8a398ba62a7c83fdeba7cdf0d7dfd`
- Test user lists: success (database/backend + frontend E2E)
- Frontend layout regression: success
- Test auth: success
- Test Supabase RLS: success
- Test Canonical Game Identity: success
- Vercel Preview: env contract success, Google OAuth preflight success, deploy success

## Production Supabase verification
Migration applied only after all PR gates were green.
- actual Google user used as user A in a rollback-only audit transaction
- own create/read + duplicate rejection + service-role reorder: PASS
- simulated user B private list/item reads = 0; update/delete had no effect
- rollback residue: 0 lists / 0 items
- `user_lists` and `user_list_items`: RLS enabled
- anon table grants: none
- authenticated grants: SELECT/INSERT/UPDATE/DELETE only
- `reorder_owned_list_items`: EXECUTE granted only to service_role

Post-merge production OAuth-session create→add→reload persistence remains the final live UI check before closing #59.