### PR TITLE
feat: add canonical owned-game collection

### DIFF
--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -14,6 +14,7 @@ on:
       - "frontend/src/components/AuthControlPortal.jsx"
       - "frontend/src/components/GameListSavePortal.jsx"
       - "frontend/src/components/game/AddToListButton.jsx"
+      - "frontend/src/components/game/OwnedGameButton.jsx"
       - "frontend/src/pages/ListsPage.jsx"
       - "frontend/tests/lists.spec.js"
       - ".github/workflows/test-lists.yml"
@@ -32,6 +33,7 @@ on:
       - "frontend/src/components/AuthControlPortal.jsx"
       - "frontend/src/components/GameListSavePortal.jsx"
       - "frontend/src/components/game/AddToListButton.jsx"
+      - "frontend/src/components/game/OwnedGameButton.jsx"
       - "frontend/src/pages/ListsPage.jsx"
       - "frontend/tests/lists.spec.js"
       - ".github/workflows/test-lists.yml"
@@ -61,7 +63,7 @@ jobs:
       PYTHONPATH: backend
     steps:
       - uses: actions/checkout@v5
-      - name: Apply list migration and verify RLS/reorder/dedupe/unavailable-game behavior
+      - name: Apply list migration and verify RLS/reorder/dedupe/system-list behavior
         run: psql "$DATABASE_URL" -f backend/app/db/tests/list_integration.sql
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
@@ -90,7 +92,7 @@ jobs:
         run: npm run build
       - name: Lint list surface
         working-directory: frontend
-        run: npx eslint src/main.jsx src/lib/api.js src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js
+        run: npx eslint src/main.jsx src/lib/api.js src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/components/game/OwnedGameButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js
       - name: Install Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium

--- a/backend/app/db/tests/list_integration.sql
+++ b/backend/app/db/tests/list_integration.sql
@@ -35,6 +35,20 @@ SET request.jwt.claim.sub = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 INSERT INTO public.user_lists(id, owner_id, name)
 VALUES ('aaaaaaaa-0000-4000-8000-000000000001','aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','Favorites');
 
+INSERT INTO public.user_lists(id, owner_id, name, visibility, system_key)
+VALUES ('aaaaaaaa-0000-4000-8000-000000000002','aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','所持ゲーム','private','owned');
+
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO public.user_lists(owner_id, name, visibility, system_key)
+    VALUES ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa','duplicate owned','private','owned');
+    RAISE EXCEPTION 'duplicate owned system list unexpectedly accepted';
+  EXCEPTION WHEN unique_violation THEN NULL;
+  END;
+END;
+$$;
+
 INSERT INTO public.user_list_items(id, list_id, game_id, game_title_snapshot, position) VALUES
 ('aaaaaaaa-1000-4000-8000-000000000001','aaaaaaaa-0000-4000-8000-000000000001','11111111-1111-4111-8111-111111111111','ゲーム1',0),
 ('aaaaaaaa-1000-4000-8000-000000000002','aaaaaaaa-0000-4000-8000-000000000001','22222222-2222-4222-8222-222222222222','ゲーム2',1);
@@ -77,6 +91,9 @@ BEGIN
   END IF;
   IF (SELECT count(*) FROM public.user_list_items WHERE list_id='aaaaaaaa-0000-4000-8000-000000000001') <> 2 THEN
     RAISE EXCEPTION 'user B deleted user A item';
+  END IF;
+  IF (SELECT count(*) FROM public.user_lists WHERE owner_id='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' AND system_key='owned') <> 1 THEN
+    RAISE EXCEPTION 'owned system list uniqueness was not preserved';
   END IF;
 END;
 $$;

--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -13,6 +13,7 @@ from app.services.list_service import (
     InvalidReorderError,
     ListNotFoundError,
     ListService,
+    SystemListMutationError,
     list_service,
 )
 
@@ -71,6 +72,10 @@ def _not_found() -> HTTPException:
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="List or item not found")
 
 
+def _system_list_conflict() -> HTTPException:
+    return HTTPException(status_code=status.HTTP_409_CONFLICT, detail="System lists cannot be renamed or deleted")
+
+
 @router.get("/lists")
 async def list_user_lists(
     user: dict = Depends(get_current_user),
@@ -86,6 +91,44 @@ async def create_user_list(
     service: ListService = Depends(get_list_service),
 ):
     return await service.create_list(_owner_id(user), payload.name, payload.visibility)
+
+
+@router.get("/owned-games")
+async def get_owned_games(
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    return await service.get_owned_collection(_owner_id(user))
+
+
+@router.get("/owned-games/{game_id}")
+async def get_owned_game_status(
+    game_id: UUID,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    return await service.owned_status(_owner_id(user), str(game_id))
+
+
+@router.put("/owned-games/{game_id}")
+async def set_owned_game(
+    game_id: UUID,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    try:
+        return await service.set_owned(_owner_id(user), str(game_id))
+    except GameNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Canonical game not found") from exc
+
+
+@router.delete("/owned-games/{game_id}")
+async def remove_owned_game(
+    game_id: UUID,
+    user: dict = Depends(get_current_user),
+    service: ListService = Depends(get_list_service),
+):
+    return await service.remove_owned(_owner_id(user), str(game_id))
 
 
 @router.get("/lists/{list_id}")
@@ -111,6 +154,8 @@ async def rename_user_list(
         return await service.rename_list(_owner_id(user), str(list_id), payload.name)
     except ListNotFoundError as exc:
         raise _not_found() from exc
+    except SystemListMutationError as exc:
+        raise _system_list_conflict() from exc
 
 
 @router.delete("/lists/{list_id}")
@@ -124,6 +169,8 @@ async def delete_user_list(
         return {"status": "deleted"}
     except ListNotFoundError as exc:
         raise _not_found() from exc
+    except SystemListMutationError as exc:
+        raise _system_list_conflict() from exc
 
 
 @router.post("/lists/{list_id}/items", status_code=status.HTTP_201_CREATED)

--- a/backend/app/services/list_service.py
+++ b/backend/app/services/list_service.py
@@ -8,6 +8,10 @@ import anyio
 from app.core.supabase import _get_client
 
 
+OWNED_SYSTEM_KEY = "owned"
+OWNED_LIST_NAME = "所持ゲーム"
+
+
 class ListNotFoundError(RuntimeError):
     pass
 
@@ -21,6 +25,10 @@ class DuplicateMembershipError(RuntimeError):
 
 
 class InvalidReorderError(RuntimeError):
+    pass
+
+
+class SystemListMutationError(RuntimeError):
     pass
 
 
@@ -44,9 +52,103 @@ class ListService:
             raise ListNotFoundError(list_id)
         return rows[0]
 
+    @staticmethod
+    def _system_list(client, owner_id: str, system_key: str) -> dict[str, Any] | None:
+        rows = (
+            client.table("user_lists")
+            .select("*")
+            .eq("owner_id", owner_id)
+            .eq("system_key", system_key)
+            .limit(1)
+            .execute()
+            .data
+        )
+        return rows[0] if rows else None
+
+    @staticmethod
+    def _canonical_game(client, game_id: str) -> dict[str, Any]:
+        rows = (
+            client.table("games")
+            .select("id,slug,title,title_ja,image_url")
+            .eq("id", game_id)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rows:
+            raise GameNotFoundError(game_id)
+        return rows[0]
+
+    @staticmethod
+    def _next_position(client, list_id: str) -> int:
+        rows = (
+            client.table("user_list_items")
+            .select("position")
+            .eq("list_id", list_id)
+            .order("position", desc=True)
+            .limit(1)
+            .execute()
+            .data
+        )
+        return int(rows[0]["position"]) + 1 if rows else 0
+
+    @staticmethod
+    def _detail(client, user_list: dict[str, Any]) -> dict[str, Any]:
+        list_id = str(user_list["id"])
+        items = (
+            client.table("user_list_items")
+            .select("id,list_id,game_id,game_title_snapshot,position,created_at,updated_at")
+            .eq("list_id", list_id)
+            .order("position")
+            .order("created_at")
+            .execute()
+            .data
+        )
+        game_ids = [item["game_id"] for item in items if item.get("game_id")]
+        games: list[dict[str, Any]] = []
+        if game_ids:
+            games = (
+                client.table("games")
+                .select("id,slug,title,title_ja,image_url")
+                .in_("id", game_ids)
+                .execute()
+                .data
+            )
+        games_by_id = {game["id"]: game for game in games}
+        normalized_items = []
+        for item in items:
+            game = games_by_id.get(item.get("game_id"))
+            normalized_items.append({**item, "game": game, "unavailable": game is None})
+        return {**user_list, "items": normalized_items}
+
+    @classmethod
+    def _ensure_owned_system_list(cls, client, owner_id: str) -> dict[str, Any]:
+        existing = cls._system_list(client, owner_id, OWNED_SYSTEM_KEY)
+        if existing:
+            return existing
+        try:
+            return (
+                client.table("user_lists")
+                .insert({
+                    "owner_id": owner_id,
+                    "name": OWNED_LIST_NAME,
+                    "visibility": "private",
+                    "system_key": OWNED_SYSTEM_KEY,
+                })
+                .execute()
+                .data[0]
+            )
+        except Exception as exc:
+            if "23505" not in str(exc) and "duplicate" not in str(exc).lower():
+                raise
+            existing = cls._system_list(client, owner_id, OWNED_SYSTEM_KEY)
+            if existing:
+                return existing
+            raise
+
     async def list_lists(self, owner_id: str) -> list[dict[str, Any]]:
         def _q():
-            return (
+            rows = (
                 _get_client()
                 .table("user_lists")
                 .select("id,name,visibility,system_key,created_at,updated_at")
@@ -55,6 +157,7 @@ class ListService:
                 .execute()
                 .data
             )
+            return [row for row in rows if row.get("system_key") is None]
         return await anyio.to_thread.run_sync(_q)
 
     async def create_list(self, owner_id: str, name: str, visibility: str) -> dict[str, Any]:
@@ -71,38 +174,15 @@ class ListService:
     async def get_list(self, owner_id: str, list_id: str) -> dict[str, Any]:
         def _q():
             client = _get_client()
-            user_list = self._owned_list(client, owner_id, list_id)
-            items = (
-                client.table("user_list_items")
-                .select("id,list_id,game_id,game_title_snapshot,position,created_at,updated_at")
-                .eq("list_id", list_id)
-                .order("position")
-                .order("created_at")
-                .execute()
-                .data
-            )
-            game_ids = [item["game_id"] for item in items if item.get("game_id")]
-            games: list[dict[str, Any]] = []
-            if game_ids:
-                games = (
-                    client.table("games")
-                    .select("id,slug,title,title_ja,image_url")
-                    .in_("id", game_ids)
-                    .execute()
-                    .data
-                )
-            games_by_id = {game["id"]: game for game in games}
-            normalized_items = []
-            for item in items:
-                game = games_by_id.get(item.get("game_id"))
-                normalized_items.append({**item, "game": game, "unavailable": game is None})
-            return {**user_list, "items": normalized_items}
+            return self._detail(client, self._owned_list(client, owner_id, list_id))
         return await anyio.to_thread.run_sync(_q)
 
     async def rename_list(self, owner_id: str, list_id: str, name: str) -> dict[str, Any]:
         def _q():
             client = _get_client()
-            self._owned_list(client, owner_id, list_id)
+            user_list = self._owned_list(client, owner_id, list_id)
+            if user_list.get("system_key") is not None:
+                raise SystemListMutationError(list_id)
             rows = (
                 client.table("user_lists")
                 .update({"name": name, "updated_at": _now()})
@@ -119,7 +199,9 @@ class ListService:
     async def delete_list(self, owner_id: str, list_id: str) -> None:
         def _q():
             client = _get_client()
-            self._owned_list(client, owner_id, list_id)
+            user_list = self._owned_list(client, owner_id, list_id)
+            if user_list.get("system_key") is not None:
+                raise SystemListMutationError(list_id)
             client.table("user_lists").delete().eq("id", list_id).eq("owner_id", owner_id).execute()
         await anyio.to_thread.run_sync(_q)
 
@@ -127,17 +209,7 @@ class ListService:
         def _q():
             client = _get_client()
             self._owned_list(client, owner_id, list_id)
-            game_rows = (
-                client.table("games")
-                .select("id,slug,title,title_ja,image_url")
-                .eq("id", game_id)
-                .limit(1)
-                .execute()
-                .data
-            )
-            if not game_rows:
-                raise GameNotFoundError(game_id)
-            game = game_rows[0]
+            game = self._canonical_game(client, game_id)
             existing = (
                 client.table("user_list_items")
                 .select("id")
@@ -149,16 +221,6 @@ class ListService:
             )
             if existing:
                 raise DuplicateMembershipError(game_id)
-            last = (
-                client.table("user_list_items")
-                .select("position")
-                .eq("list_id", list_id)
-                .order("position", desc=True)
-                .limit(1)
-                .execute()
-                .data
-            )
-            position = int(last[0]["position"]) + 1 if last else 0
             title_snapshot = str(game.get("title_ja") or game.get("title") or game_id)
             try:
                 item = (
@@ -167,7 +229,7 @@ class ListService:
                         "list_id": list_id,
                         "game_id": game_id,
                         "game_title_snapshot": title_snapshot,
-                        "position": position,
+                        "position": self._next_position(client, list_id),
                     })
                     .execute()
                     .data[0]
@@ -213,6 +275,119 @@ class ListService:
                     raise InvalidReorderError(list_id) from exc
                 raise
         await anyio.to_thread.run_sync(_q)
+
+    async def get_owned_collection(self, owner_id: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            owned_list = self._system_list(client, owner_id, OWNED_SYSTEM_KEY)
+            if not owned_list:
+                return {
+                    "id": None,
+                    "owner_id": owner_id,
+                    "name": OWNED_LIST_NAME,
+                    "visibility": "private",
+                    "system_key": OWNED_SYSTEM_KEY,
+                    "created_at": None,
+                    "updated_at": None,
+                    "items": [],
+                }
+            return self._detail(client, owned_list)
+        return await anyio.to_thread.run_sync(_q)
+
+    async def owned_status(self, owner_id: str, game_id: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            owned_list = self._system_list(client, owner_id, OWNED_SYSTEM_KEY)
+            if not owned_list:
+                return {"owned": False, "item_id": None, "created_at": None}
+            rows = (
+                client.table("user_list_items")
+                .select("id,created_at")
+                .eq("list_id", str(owned_list["id"]))
+                .eq("game_id", game_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+            if not rows:
+                return {"owned": False, "item_id": None, "created_at": None}
+            return {"owned": True, "item_id": rows[0]["id"], "created_at": rows[0].get("created_at")}
+        return await anyio.to_thread.run_sync(_q)
+
+    async def set_owned(self, owner_id: str, game_id: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            game = self._canonical_game(client, game_id)
+            owned_list = self._ensure_owned_system_list(client, owner_id)
+            list_id = str(owned_list["id"])
+            existing = (
+                client.table("user_list_items")
+                .select("id,list_id,game_id,game_title_snapshot,position,created_at,updated_at")
+                .eq("list_id", list_id)
+                .eq("game_id", game_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+            if existing:
+                return {"owned": True, "created": False, "item": {**existing[0], "game": game, "unavailable": False}}
+
+            title_snapshot = str(game.get("title_ja") or game.get("title") or game_id)
+            try:
+                item = (
+                    client.table("user_list_items")
+                    .insert({
+                        "list_id": list_id,
+                        "game_id": game_id,
+                        "game_title_snapshot": title_snapshot,
+                        "position": self._next_position(client, list_id),
+                    })
+                    .execute()
+                    .data[0]
+                )
+                created = True
+            except Exception as exc:
+                if "23505" not in str(exc) and "duplicate" not in str(exc).lower():
+                    raise
+                rows = (
+                    client.table("user_list_items")
+                    .select("id,list_id,game_id,game_title_snapshot,position,created_at,updated_at")
+                    .eq("list_id", list_id)
+                    .eq("game_id", game_id)
+                    .limit(1)
+                    .execute()
+                    .data
+                )
+                if not rows:
+                    raise
+                item = rows[0]
+                created = False
+            client.table("user_lists").update({"updated_at": _now()}).eq("id", list_id).eq("owner_id", owner_id).execute()
+            return {"owned": True, "created": created, "item": {**item, "game": game, "unavailable": False}}
+        return await anyio.to_thread.run_sync(_q)
+
+    async def remove_owned(self, owner_id: str, game_id: str) -> dict[str, Any]:
+        def _q():
+            client = _get_client()
+            owned_list = self._system_list(client, owner_id, OWNED_SYSTEM_KEY)
+            if not owned_list:
+                return {"owned": False, "removed": False}
+            list_id = str(owned_list["id"])
+            rows = (
+                client.table("user_list_items")
+                .select("id")
+                .eq("list_id", list_id)
+                .eq("game_id", game_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+            if not rows:
+                return {"owned": False, "removed": False}
+            client.table("user_list_items").delete().eq("id", rows[0]["id"]).eq("list_id", list_id).execute()
+            client.table("user_lists").update({"updated_at": _now()}).eq("id", list_id).eq("owner_id", owner_id).execute()
+            return {"owned": False, "removed": True}
+        return await anyio.to_thread.run_sync(_q)
 
 
 list_service = ListService()

--- a/backend/tests/test_lists.py
+++ b/backend/tests/test_lists.py
@@ -2,7 +2,7 @@ import pytest
 from pydantic import ValidationError
 
 from app.routers import lists
-from app.services.list_service import DuplicateMembershipError
+from app.services.list_service import DuplicateMembershipError, SystemListMutationError
 
 
 USER_A = {"id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}
@@ -15,6 +15,7 @@ class FakeListService:
     def __init__(self):
         self.calls = []
         self.duplicate = False
+        self.system_mutation = False
 
     async def list_lists(self, owner_id):
         self.calls.append(("list", owner_id))
@@ -30,10 +31,14 @@ class FakeListService:
 
     async def rename_list(self, owner_id, list_id, name):
         self.calls.append(("rename", owner_id, list_id, name))
+        if self.system_mutation:
+            raise SystemListMutationError(list_id)
         return {"id": list_id, "name": name}
 
     async def delete_list(self, owner_id, list_id):
         self.calls.append(("delete", owner_id, list_id))
+        if self.system_mutation:
+            raise SystemListMutationError(list_id)
 
     async def add_item(self, owner_id, list_id, game_id):
         self.calls.append(("add", owner_id, list_id, game_id))
@@ -46,6 +51,22 @@ class FakeListService:
 
     async def reorder(self, owner_id, list_id, item_ids):
         self.calls.append(("reorder", owner_id, list_id, item_ids))
+
+    async def get_owned_collection(self, owner_id):
+        self.calls.append(("owned-list", owner_id))
+        return {"id": None, "owner_id": owner_id, "name": "所持ゲーム", "system_key": "owned", "items": []}
+
+    async def owned_status(self, owner_id, game_id):
+        self.calls.append(("owned-status", owner_id, game_id))
+        return {"owned": False, "item_id": None, "created_at": None}
+
+    async def set_owned(self, owner_id, game_id):
+        self.calls.append(("set-owned", owner_id, game_id))
+        return {"owned": True, "created": len([c for c in self.calls if c[0] == "set-owned"]) == 1}
+
+    async def remove_owned(self, owner_id, game_id):
+        self.calls.append(("remove-owned", owner_id, game_id))
+        return {"owned": False, "removed": True}
 
 
 def test_list_payloads_forbid_user_supplied_owner_id():
@@ -91,6 +112,52 @@ async def test_reorder_uses_verified_owner_and_full_item_order():
     payload = lists.UserListReorder(item_ids=[ITEM_ID])
     await lists.reorder_user_list(LIST_ID, payload, user=USER_A, service=service)
     assert service.calls == [("reorder", USER_A["id"], LIST_ID, [ITEM_ID])]
+
+
+@pytest.mark.asyncio
+async def test_owned_collection_and_status_use_verified_owner():
+    service = FakeListService()
+    collection = await lists.get_owned_games(user=USER_A, service=service)
+    status_result = await lists.get_owned_game_status(GAME_ID, user=USER_A, service=service)
+    assert collection["system_key"] == "owned"
+    assert status_result["owned"] is False
+    assert service.calls == [
+        ("owned-list", USER_A["id"]),
+        ("owned-status", USER_A["id"], GAME_ID),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_owned_game_put_is_idempotent_contract_with_canonical_game_id():
+    service = FakeListService()
+    first = await lists.set_owned_game(GAME_ID, user=USER_A, service=service)
+    second = await lists.set_owned_game(GAME_ID, user=USER_A, service=service)
+    assert first == {"owned": True, "created": True}
+    assert second == {"owned": True, "created": False}
+    assert service.calls == [
+        ("set-owned", USER_A["id"], GAME_ID),
+        ("set-owned", USER_A["id"], GAME_ID),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_remove_owned_game_is_scoped_to_verified_owner():
+    service = FakeListService()
+    result = await lists.remove_owned_game(GAME_ID, user=USER_A, service=service)
+    assert result == {"owned": False, "removed": True}
+    assert service.calls == [("remove-owned", USER_A["id"], GAME_ID)]
+
+
+@pytest.mark.asyncio
+async def test_system_list_cannot_be_renamed_or_deleted_via_custom_list_api():
+    service = FakeListService()
+    service.system_mutation = True
+    with pytest.raises(lists.HTTPException) as rename_exc:
+        await lists.rename_user_list(LIST_ID, lists.UserListRename(name="renamed"), user=USER_A, service=service)
+    with pytest.raises(lists.HTTPException) as delete_exc:
+        await lists.delete_user_list(LIST_ID, user=USER_A, service=service)
+    assert rename_exc.value.status_code == 409
+    assert delete_exc.value.status_code == 409
 
 
 def test_missing_verified_user_id_fails_closed():

--- a/frontend/src/components/GameListSavePortal.jsx
+++ b/frontend/src/components/GameListSavePortal.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 
 import { api } from '../lib/api'
 import AddToListButton from './game/AddToListButton'
+import OwnedGameButton from './game/OwnedGameButton'
 
 function currentGameSlug() {
   const match = window.location.pathname.match(/^\/games\/([^/]+)\/?$/)
@@ -44,5 +45,11 @@ export default function GameListSavePortal() {
   }, [])
 
   if (!target || !game) return null
-  return createPortal(<AddToListButton game={game} />, target)
+  return createPortal(
+    <>
+      <OwnedGameButton game={game} />
+      <AddToListButton game={game} />
+    </>,
+    target,
+  )
 }

--- a/frontend/src/components/game/OwnedGameButton.jsx
+++ b/frontend/src/components/game/OwnedGameButton.jsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+
+import { useAuth } from '../../auth/authContext'
+import { api } from '../../lib/api'
+
+export default function OwnedGameButton({ game }) {
+  const { user, loading: authLoading, signInWithGoogle } = useAuth()
+  const [owned, setOwned] = useState(false)
+  const [checking, setChecking] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [status, setStatus] = useState('')
+
+  useEffect(() => {
+    if (!user || !game?.id) {
+      setOwned(false)
+      setChecking(false)
+      setStatus('')
+      return
+    }
+
+    let active = true
+    setChecking(true)
+    setStatus('')
+    api.get(`/api/owned-games/${game.id}`)
+      .then((data) => {
+        if (active) setOwned(Boolean(data.owned))
+      })
+      .catch((err) => {
+        if (active) setStatus(err.message)
+      })
+      .finally(() => {
+        if (active) setChecking(false)
+      })
+
+    return () => { active = false }
+  }, [user, game?.id])
+
+  if (authLoading) return null
+
+  if (!user) {
+    return (
+      <button className="filter-btn" onClick={signInWithGoogle} type="button">
+        ログインして所持登録
+      </button>
+    )
+  }
+
+  const toggleOwned = async () => {
+    if (!game?.id || checking || busy) return
+    setBusy(true)
+    setStatus('')
+    try {
+      if (owned) {
+        const data = await api.delete(`/api/owned-games/${game.id}`)
+        setOwned(Boolean(data.owned))
+        setStatus('所持ゲームから解除しました')
+      } else {
+        const data = await api.put(`/api/owned-games/${game.id}`, {})
+        setOwned(Boolean(data.owned))
+        setStatus(data.created ? '所持ゲームに登録しました' : '所持登録済みです')
+      }
+    } catch (err) {
+      setStatus(err.message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const label = checking
+    ? '所持状態を確認中…'
+    : busy
+      ? '更新中…'
+      : owned
+        ? '✓ 所持しています'
+        : '所持している'
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap' }}>
+      <button
+        className={`filter-btn ${owned ? 'active' : ''}`}
+        type="button"
+        aria-pressed={owned}
+        disabled={checking || busy}
+        onClick={toggleOwned}
+      >
+        {label}
+      </button>
+      {status && <span role="status" style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>{status}</span>}
+    </div>
+  )
+}

--- a/frontend/src/pages/ListsPage.jsx
+++ b/frontend/src/pages/ListsPage.jsx
@@ -4,14 +4,22 @@ import { Link } from 'react-router-dom'
 import { useAuth } from '../auth/authContext'
 import { api } from '../lib/api'
 
+const OWNED_SELECTION = '__owned__'
+
 export default function ListsPage() {
   const { user, loading: authLoading, signInWithGoogle } = useAuth()
   const [lists, setLists] = useState([])
-  const [selectedId, setSelectedId] = useState('')
+  const [selectedId, setSelectedId] = useState(OWNED_SELECTION)
   const [detail, setDetail] = useState(null)
   const [newName, setNewName] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+
+  const loadDetail = async (id) => (
+    id === OWNED_SELECTION
+      ? api.get('/api/owned-games')
+      : api.get(`/api/lists/${id}`)
+  )
 
   const loadLists = async (preferredId = '') => {
     setLoading(true)
@@ -20,13 +28,9 @@ export default function ListsPage() {
       const data = await api.get('/api/lists')
       const next = data.lists || []
       setLists(next)
-      const nextId = preferredId || selectedId || next[0]?.id || ''
+      const nextId = preferredId || selectedId || OWNED_SELECTION
       setSelectedId(nextId)
-      if (nextId) {
-        setDetail(await api.get(`/api/lists/${nextId}`))
-      } else {
-        setDetail(null)
-      }
+      setDetail(await loadDetail(nextId))
     } catch (err) {
       setError(err.message)
     } finally {
@@ -35,10 +39,10 @@ export default function ListsPage() {
   }
 
   useEffect(() => {
-    if (user) loadLists()
+    if (user) loadLists(OWNED_SELECTION)
     else {
       setLists([])
-      setSelectedId('')
+      setSelectedId(OWNED_SELECTION)
       setDetail(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -49,7 +53,7 @@ export default function ListsPage() {
     setLoading(true)
     setError('')
     try {
-      setDetail(await api.get(`/api/lists/${id}`))
+      setDetail(await loadDetail(id))
     } catch (err) {
       setError(err.message)
     } finally {
@@ -72,7 +76,7 @@ export default function ListsPage() {
   }
 
   const renameList = async () => {
-    if (!detail) return
+    if (!detail || detail.system_key) return
     const name = window.prompt('新しいリスト名', detail.name)?.trim()
     if (!name || name === detail.name) return
     try {
@@ -84,29 +88,34 @@ export default function ListsPage() {
   }
 
   const deleteList = async () => {
-    if (!detail || !window.confirm(`「${detail.name}」を削除しますか？`)) return
+    if (!detail || detail.system_key || !window.confirm(`「${detail.name}」を削除しますか？`)) return
     try {
       await api.delete(`/api/lists/${detail.id}`)
-      setSelectedId('')
+      setSelectedId(OWNED_SELECTION)
       setDetail(null)
-      await loadLists()
+      await loadLists(OWNED_SELECTION)
     } catch (err) {
       setError(err.message)
     }
   }
 
-  const removeItem = async (itemId) => {
+  const removeItem = async (item) => {
     if (!detail) return
     try {
-      await api.delete(`/api/lists/${detail.id}/items/${itemId}`)
-      await selectList(detail.id)
+      if (detail.system_key === 'owned' && item.game_id) {
+        await api.delete(`/api/owned-games/${item.game_id}`)
+        await selectList(OWNED_SELECTION)
+      } else if (detail.id) {
+        await api.delete(`/api/lists/${detail.id}/items/${item.id}`)
+        await selectList(selectedId)
+      }
     } catch (err) {
       setError(err.message)
     }
   }
 
   const moveItem = async (index, delta) => {
-    if (!detail) return
+    if (!detail?.id) return
     const nextIndex = index + delta
     if (nextIndex < 0 || nextIndex >= detail.items.length) return
     const items = [...detail.items]
@@ -116,7 +125,7 @@ export default function ListsPage() {
       await api.put(`/api/lists/${detail.id}/order`, { item_ids: items.map((item) => item.id) })
     } catch (err) {
       setError(err.message)
-      await selectList(detail.id)
+      await selectList(selectedId)
     }
   }
 
@@ -127,7 +136,7 @@ export default function ListsPage() {
       <main style={{ maxWidth: '720px', margin: '0 auto', padding: '3rem 1rem' }}>
         <Link to="/" className="back-link">← DIRECTORY</Link>
         <h1>マイリスト</h1>
-        <p>リストの作成・保存にはログインが必要です。</p>
+        <p>所持ゲームやリストの保存にはログインが必要です。</p>
         <button type="button" className="filter-btn active" onClick={signInWithGoogle}>Googleでログイン</button>
       </main>
     )
@@ -156,56 +165,80 @@ export default function ListsPage() {
       {error && <div role="alert" style={{ marginBottom: '1rem', color: '#ff7777' }}>{error}</div>}
       {loading && <div style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>読み込み中…</div>}
 
-      {lists.length === 0 && !loading ? (
-        <div className="pro-card">まだリストがありません。最初のリストを作成してください。</div>
-      ) : (
-        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 260px) minmax(0, 1fr)', gap: '16px' }}>
-          <aside style={{ position: 'static', width: 'auto', height: 'auto' }}>
-            {lists.map((list) => (
-              <button
-                type="button"
-                key={list.id}
-                className={`filter-btn ${selectedId === list.id ? 'active' : ''}`}
-                style={{ width: '100%', marginBottom: '8px', textAlign: 'left' }}
-                onClick={() => selectList(list.id)}
-              >
-                {list.name}
-              </button>
-            ))}
-          </aside>
+      <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 260px) minmax(0, 1fr)', gap: '16px' }}>
+        <aside style={{ position: 'static', width: 'auto', height: 'auto' }}>
+          <button
+            type="button"
+            className={`filter-btn ${selectedId === OWNED_SELECTION ? 'active' : ''}`}
+            style={{ width: '100%', marginBottom: '8px', textAlign: 'left' }}
+            onClick={() => selectList(OWNED_SELECTION)}
+          >
+            所持ゲーム
+          </button>
+          {lists.map((list) => (
+            <button
+              type="button"
+              key={list.id}
+              className={`filter-btn ${selectedId === list.id ? 'active' : ''}`}
+              style={{ width: '100%', marginBottom: '8px', textAlign: 'left' }}
+              onClick={() => selectList(list.id)}
+            >
+              {list.name}
+            </button>
+          ))}
+          {lists.length === 0 && !loading && (
+            <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', padding: '4px 2px' }}>
+              custom listはまだありません。
+            </div>
+          )}
+        </aside>
 
-          <section>
-            {detail && (
-              <>
-                <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
-                  <h2 style={{ margin: 0 }}>{detail.name}</h2>
-                  <button type="button" className="filter-btn" onClick={renameList}>名前変更</button>
-                  <button type="button" className="filter-btn" onClick={deleteList}>削除</button>
+        <section>
+          {detail && (
+            <>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
+                <h2 style={{ margin: 0 }}>{detail.name}</h2>
+                {!detail.system_key && (
+                  <>
+                    <button type="button" className="filter-btn" onClick={renameList}>名前変更</button>
+                    <button type="button" className="filter-btn" onClick={deleteList}>削除</button>
+                  </>
+                )}
+              </div>
+
+              {detail.items.length === 0 ? (
+                <div className="pro-card">
+                  {detail.system_key === 'owned'
+                    ? '所持ゲームはまだありません。ゲーム詳細から「所持している」を選択してください。'
+                    : 'このリストは空です。ゲーム詳細から追加できます。'}
                 </div>
-
-                {detail.items.length === 0 ? (
-                  <div className="pro-card">このリストは空です。ゲーム詳細から追加できます。</div>
-                ) : detail.items.map((item, index) => {
-                  const title = item.game?.title_ja || item.game?.title || item.game_title_snapshot
-                  return (
-                    <div key={item.id} className="pro-card" style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '10px', flexWrap: 'wrap' }}>
-                      <div style={{ flex: '1 1 220px' }}>
-                        {item.game ? <Link to={`/games/${item.game.slug}`}>{title}</Link> : <strong>{title}</strong>}
-                        {item.unavailable && <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>現在利用できないゲーム</div>}
-                      </div>
-                      <div style={{ display: 'flex', gap: '6px' }}>
-                        <button type="button" className="filter-btn" aria-label={`${title}を上へ`} disabled={index === 0} onClick={() => moveItem(index, -1)}>↑</button>
-                        <button type="button" className="filter-btn" aria-label={`${title}を下へ`} disabled={index === detail.items.length - 1} onClick={() => moveItem(index, 1)}>↓</button>
-                        <button type="button" className="filter-btn" onClick={() => removeItem(item.id)}>削除</button>
-                      </div>
+              ) : detail.items.map((item, index) => {
+                const title = item.game?.title_ja || item.game?.title || item.game_title_snapshot
+                return (
+                  <div key={item.id} className="pro-card" style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '10px', flexWrap: 'wrap' }}>
+                    <div style={{ flex: '1 1 220px' }}>
+                      {item.game ? <Link to={`/games/${item.game.slug}`}>{title}</Link> : <strong>{title}</strong>}
+                      {item.unavailable && <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>現在利用できないゲーム</div>}
+                      {detail.system_key === 'owned' && item.created_at && (
+                        <div style={{ fontSize: '0.7rem', color: 'var(--text-muted)' }}>
+                          登録: {new Date(item.created_at).toLocaleDateString('ja-JP')}
+                        </div>
+                      )}
                     </div>
-                  )
-                })}
-              </>
-            )}
-          </section>
-        </div>
-      )}
+                    <div style={{ display: 'flex', gap: '6px' }}>
+                      <button type="button" className="filter-btn" aria-label={`${title}を上へ`} disabled={!detail.id || index === 0} onClick={() => moveItem(index, -1)}>↑</button>
+                      <button type="button" className="filter-btn" aria-label={`${title}を下へ`} disabled={!detail.id || index === detail.items.length - 1} onClick={() => moveItem(index, 1)}>↓</button>
+                      <button type="button" className="filter-btn" onClick={() => removeItem(item)}>
+                        {detail.system_key === 'owned' ? '所持解除' : '削除'}
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </>
+          )}
+        </section>
+      </div>
 
       <style>{`@media (max-width: 720px) { main > div[style*="grid-template-columns"] { grid-template-columns: 1fr !important; } }`}</style>
     </main>

--- a/frontend/tests/lists.spec.js
+++ b/frontend/tests/lists.spec.js
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test'
 
 const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const LIST_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+const OWNED_LIST_ID = 'aaaaaaaa-0000-4000-8000-000000000002'
 const GAME_ID = '11111111-1111-4111-8111-111111111111'
 const TOKEN = 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJhYWFhYWFhYS1hYWFhLTRhYWEtOGFhYS1hYWFhYWFhYWFhYWFhYSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjo0MTAyNDQ0ODAwfQ.'
 
@@ -24,50 +25,7 @@ async function installSession(page) {
   }, { token: TOKEN, userId: USER_ID })
 }
 
-test('anonymous list route is mobile-usable and offers Google login instead of private mutations', async ({ page }) => {
-  await page.setViewportSize({ width: 390, height: 844 })
-  await page.goto('/lists')
-  await expect(page.getByRole('heading', { name: 'マイリスト' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Googleでログイン' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'リストを作成' })).toHaveCount(0)
-})
-
-test('authenticated list page renders private list and reorder/remove controls', async ({ page }) => {
-  await installSession(page)
-  await page.route('**/api/lists', async (route) => {
-    await expect(route.request().headers()['authorization']).toBe(`Bearer ${TOKEN}`)
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private' }] }),
-    })
-  })
-  await page.route(`**/api/lists/${LIST_ID}`, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        id: LIST_ID,
-        name: 'Favorites',
-        visibility: 'private',
-        items: [
-          { id: 'aaaaaaaa-1000-4000-8000-000000000001', game_id: GAME_ID, game_title_snapshot: 'ゲーム1', position: 0, unavailable: false, game: { id: GAME_ID, slug: 'game-one', title_ja: 'ゲーム1', title: 'Game One' } },
-          { id: 'aaaaaaaa-1000-4000-8000-000000000002', game_id: null, game_title_snapshot: 'Unavailable Game', position: 1, unavailable: true, game: null },
-        ],
-      }),
-    })
-  })
-
-  await page.goto('/lists')
-  await expect(page.getByText('Favorites', { exact: true }).first()).toBeVisible()
-  await expect(page.getByText('ゲーム1', { exact: true })).toBeVisible()
-  await expect(page.getByText('Unavailable Game', { exact: true })).toBeVisible()
-  await expect(page.getByText('現在利用できないゲーム')).toBeVisible()
-  await expect(page.getByRole('button', { name: 'ゲーム1を下へ' })).toBeVisible()
-})
-
-test('game detail saves canonical game id to selected user list with bearer token', async ({ page }) => {
-  await installSession(page)
+async function mockGame(page) {
   await page.route('**/api/games/game-one', async (route) => {
     await route.fulfill({
       status: 200,
@@ -78,12 +36,114 @@ test('game detail saves canonical game id to selected user list with bearer toke
   await page.route('**/api/games?limit=50', async (route) => {
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
   })
+}
+
+test('anonymous list route is mobile-usable and offers Google login instead of private mutations', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.goto('/lists')
+  await expect(page.getByRole('heading', { name: 'マイリスト' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Googleでログイン' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'リストを作成' })).toHaveCount(0)
+})
+
+test('authenticated list page keeps custom lists separate from the owned system collection', async ({ page }) => {
+  await installSession(page)
+  await page.route('**/api/lists', async (route) => {
+    await expect(route.request().headers()['authorization']).toBe(`Bearer ${TOKEN}`)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private', system_key: null }] }),
+    })
+  })
+  await page.route('**/api/owned-games', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: null, name: '所持ゲーム', visibility: 'private', system_key: 'owned', items: [] }),
+    })
+  })
+  await page.route(`**/api/lists/${LIST_ID}`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: LIST_ID,
+        name: 'Favorites',
+        visibility: 'private',
+        system_key: null,
+        items: [
+          { id: 'aaaaaaaa-1000-4000-8000-000000000001', game_id: GAME_ID, game_title_snapshot: 'ゲーム1', position: 0, unavailable: false, game: { id: GAME_ID, slug: 'game-one', title_ja: 'ゲーム1', title: 'Game One' } },
+          { id: 'aaaaaaaa-1000-4000-8000-000000000002', game_id: null, game_title_snapshot: 'Unavailable Game', position: 1, unavailable: true, game: null },
+        ],
+      }),
+    })
+  })
+
+  await page.goto('/lists')
+  await expect(page.getByRole('button', { name: '所持ゲーム' })).toBeVisible()
+  await expect(page.getByText('所持ゲームはまだありません。')).toBeVisible()
+  await page.getByRole('button', { name: 'Favorites' }).click()
+  await expect(page.getByText('ゲーム1', { exact: true })).toBeVisible()
+  await expect(page.getByText('Unavailable Game', { exact: true })).toBeVisible()
+  await expect(page.getByText('現在利用できないゲーム')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'ゲーム1を下へ' })).toBeVisible()
+})
+
+test('owned collection is mobile-usable and can remove an owned canonical game', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await installSession(page)
+  await page.route('**/api/lists', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ lists: [] }) })
+  })
+  let removed = false
+  await page.route('**/api/owned-games', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: OWNED_LIST_ID,
+        name: '所持ゲーム',
+        visibility: 'private',
+        system_key: 'owned',
+        items: removed ? [] : [{
+          id: 'aaaaaaaa-1000-4000-8000-000000000003',
+          game_id: GAME_ID,
+          game_title_snapshot: 'ゲーム1',
+          position: 0,
+          created_at: '2026-08-14T01:34:48Z',
+          unavailable: false,
+          game: { id: GAME_ID, slug: 'game-one', title_ja: 'ゲーム1', title: 'Game One' },
+        }],
+      }),
+    })
+  })
+  await page.route(`**/api/owned-games/${GAME_ID}`, async (route) => {
+    expect(route.request().method()).toBe('DELETE')
+    expect(route.request().headers()['authorization']).toBe(`Bearer ${TOKEN}`)
+    removed = true
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ owned: false, removed: true }) })
+  })
+
+  await page.goto('/lists')
+  await expect(page.getByText('ゲーム1', { exact: true })).toBeVisible()
+  await page.getByRole('button', { name: '所持解除' }).click()
+  await expect(page.getByText('所持ゲームはまだありません。')).toBeVisible()
+  expect(removed).toBe(true)
+})
+
+test('game detail saves canonical game id to selected custom list with bearer token', async ({ page }) => {
+  await installSession(page)
+  await mockGame(page)
   await page.route('**/api/lists', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private' }] }),
+      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private', system_key: null }] }),
     })
+  })
+  await page.route(`**/api/owned-games/${GAME_ID}`, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ owned: false, item_id: null }) })
   })
 
   let saved = false
@@ -104,4 +164,46 @@ test('game detail saves canonical game id to selected user list with bearer toke
   await page.getByRole('button', { name: 'リストに保存' }).click()
   await expect(page.getByRole('status')).toContainText('保存しました')
   expect(saved).toBe(true)
+})
+
+test('game detail toggles owned state with idempotent canonical-game endpoints', async ({ page }) => {
+  await installSession(page)
+  await mockGame(page)
+  await page.route('**/api/lists', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ lists: [] }) })
+  })
+
+  let owned = false
+  let putCount = 0
+  let deleteCount = 0
+  await page.route(`**/api/owned-games/${GAME_ID}`, async (route) => {
+    expect(route.request().headers()['authorization']).toBe(`Bearer ${TOKEN}`)
+    if (route.request().method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ owned, item_id: null }) })
+      return
+    }
+    if (route.request().method() === 'PUT') {
+      putCount += 1
+      owned = true
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ owned: true, created: true }) })
+      return
+    }
+    if (route.request().method() === 'DELETE') {
+      deleteCount += 1
+      owned = false
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ owned: false, removed: true }) })
+      return
+    }
+    await route.abort()
+  })
+
+  await page.goto('/games/game-one')
+  const toggle = page.getByRole('button', { name: '所持している' })
+  await expect(toggle).toBeVisible()
+  await toggle.click()
+  await expect(page.getByRole('button', { name: '✓ 所持しています' })).toBeVisible()
+  await page.getByRole('button', { name: '✓ 所持しています' }).click()
+  await expect(page.getByRole('button', { name: '所持している' })).toBeVisible()
+  expect(putCount).toBe(1)
+  expect(deleteCount).toBe(1)
 })


### PR DESCRIPTION
## Summary
- reuse `user_lists.system_key='owned'` as the single canonical owned-game collection per user
- add authenticated idempotent `GET/PUT/DELETE /api/owned-games` endpoints backed by canonical game UUIDs
- keep system collections out of custom-list selection and block rename/delete through the custom-list API
- add a game-detail owned toggle and an owned collection view under `/lists`
- preserve registration timestamps and current canonical title/slug joins
- extend PostgreSQL, backend, frontend, mobile, and CI coverage

## Data contract
No new table or migration is introduced. The existing partial unique index on `(owner_id, system_key)` enforces at most one `owned` collection per user, and existing `(list_id, game_id)` uniqueness prevents duplicate ownership rows.

## Tests
- PostgreSQL integration: system-list uniqueness + existing RLS/dedupe/reorder/unavailable-game checks
- backend pytest: verified owner scoping, idempotent owned PUT contract, remove, system-list protection
- Playwright: authenticated custom/system separation, mobile owned collection/remove, canonical game owned toggle, existing custom list save
- frontend build + eslint through `Test user lists`

Refs #60