### PR TITLE
perf: bound waits and remove list request waterfalls

### DIFF
--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -111,17 +111,22 @@ jobs:
         working-directory: frontend
         run: npx playwright test tests/lists.spec.js --project=chromium
       - name: Run existing navigation E2E
+        if: ${{ success() || failure() }}
         working-directory: frontend
         run: npx playwright test tests/navigation.spec.js --project=chromium
       - name: Gate duplicate GET and sub-100ms mutation feedback
+        if: ${{ success() || failure() }}
         working-directory: frontend
         run: npx playwright test tests/performance.spec.js --project=chromium --grep "coalesces duplicate GET"
       - name: Gate parallel list waterfall and retained index
+        if: ${{ success() || failure() }}
         working-directory: frontend
         run: npx playwright test tests/performance.spec.js --project=chromium --grep "bootstrap index/detail"
       - name: Gate timeout and retry UI
+        if: ${{ success() || failure() }}
         working-directory: frontend
         run: npx playwright test tests/performance.spec.js --project=chromium --grep "times out and exposes"
       - name: Gate auth bootstrap CLS
+        if: ${{ success() || failure() }}
         working-directory: frontend
         run: npx playwright test tests/performance.spec.js --project=chromium --grep "layout shift"

--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -104,12 +104,25 @@ jobs:
       - name: Lint list, navigation, and performance surface
         working-directory: frontend
         run: npx eslint src/main.jsx src/lib/api.js src/components/AppShell.jsx src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/components/game/OwnedGameButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js tests/navigation.spec.js tests/performance.spec.js
-      - name: Install Chromium
+      - name: Gate anonymous list route
         working-directory: frontend
-        run: npx playwright install --with-deps chromium
-      - name: Run existing list E2E
+        run: npx playwright test tests/lists.spec.js --project=chromium --grep "anonymous list route"
+      - name: Gate custom and owned collection separation
+        if: ${{ success() || failure() }}
         working-directory: frontend
-        run: npx playwright test tests/lists.spec.js --project=chromium
+        run: npx playwright test tests/lists.spec.js --project=chromium --grep "keeps custom lists separate"
+      - name: Gate owned collection remove
+        if: ${{ success() || failure() }}
+        working-directory: frontend
+        run: npx playwright test tests/lists.spec.js --project=chromium --grep "owned collection is mobile-usable"
+      - name: Gate custom list save
+        if: ${{ success() || failure() }}
+        working-directory: frontend
+        run: npx playwright test tests/lists.spec.js --project=chromium --grep "saves canonical game id"
+      - name: Gate owned state toggle
+        if: ${{ success() || failure() }}
+        working-directory: frontend
+        run: npx playwright test tests/lists.spec.js --project=chromium --grep "toggles owned state"
       - name: Run existing navigation E2E
         if: ${{ success() || failure() }}
         working-directory: frontend

--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -107,9 +107,12 @@ jobs:
       - name: Install Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium
-      - name: Run existing list and navigation E2E
+      - name: Run existing list E2E
         working-directory: frontend
-        run: npx playwright test tests/lists.spec.js tests/navigation.spec.js --project=chromium
+        run: npx playwright test tests/lists.spec.js --project=chromium
+      - name: Run existing navigation E2E
+        working-directory: frontend
+        run: npx playwright test tests/navigation.spec.js --project=chromium
       - name: Gate duplicate GET and sub-100ms mutation feedback
         working-directory: frontend
         run: npx playwright test tests/performance.spec.js --project=chromium --grep "coalesces duplicate GET"

--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Lint list, navigation, and performance surface
         working-directory: frontend
         run: npx eslint src/main.jsx src/lib/api.js src/components/AppShell.jsx src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/components/game/OwnedGameButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js tests/navigation.spec.js tests/performance.spec.js
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
       - name: Gate anonymous list route
         working-directory: frontend
         run: npx playwright test tests/lists.spec.js --project=chromium --grep "anonymous list route"

--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -20,6 +20,8 @@ on:
       - "frontend/src/pages/ListsPage.jsx"
       - "frontend/tests/lists.spec.js"
       - "frontend/tests/navigation.spec.js"
+      - "frontend/tests/performance.spec.js"
+      - "docs/performance/issue-100.md"
       - ".github/workflows/test-lists.yml"
   push:
     branches:
@@ -42,6 +44,8 @@ on:
       - "frontend/src/pages/ListsPage.jsx"
       - "frontend/tests/lists.spec.js"
       - "frontend/tests/navigation.spec.js"
+      - "frontend/tests/performance.spec.js"
+      - "docs/performance/issue-100.md"
       - ".github/workflows/test-lists.yml"
 
 permissions:
@@ -83,6 +87,7 @@ jobs:
     env:
       VITE_SUPABASE_URL: https://example.supabase.co
       VITE_SUPABASE_ANON_KEY: sb_publishable_test
+      VITE_API_TIMEOUT_MS: "800"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -96,12 +101,12 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: npm run build
-      - name: Lint list and navigation surface
+      - name: Lint list, navigation, and performance surface
         working-directory: frontend
-        run: npx eslint src/main.jsx src/lib/api.js src/components/AppShell.jsx src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/components/game/OwnedGameButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js tests/navigation.spec.js
+        run: npx eslint src/main.jsx src/lib/api.js src/components/AppShell.jsx src/components/AuthControlPortal.jsx src/components/GameListSavePortal.jsx src/components/game/AddToListButton.jsx src/components/game/OwnedGameButton.jsx src/pages/ListsPage.jsx tests/lists.spec.js tests/navigation.spec.js tests/performance.spec.js
       - name: Install Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium
-      - name: Run list and navigation E2E
+      - name: Run list, navigation, and perceived-performance E2E
         working-directory: frontend
-        run: npx playwright test tests/lists.spec.js tests/navigation.spec.js --project=chromium
+        run: npx playwright test tests/lists.spec.js tests/navigation.spec.js tests/performance.spec.js --project=chromium

--- a/.github/workflows/test-lists.yml
+++ b/.github/workflows/test-lists.yml
@@ -107,6 +107,18 @@ jobs:
       - name: Install Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium
-      - name: Run list, navigation, and perceived-performance E2E
+      - name: Run existing list and navigation E2E
         working-directory: frontend
-        run: npx playwright test tests/lists.spec.js tests/navigation.spec.js tests/performance.spec.js --project=chromium
+        run: npx playwright test tests/lists.spec.js tests/navigation.spec.js --project=chromium
+      - name: Gate duplicate GET and sub-100ms mutation feedback
+        working-directory: frontend
+        run: npx playwright test tests/performance.spec.js --project=chromium --grep "coalesces duplicate GET"
+      - name: Gate parallel list waterfall and retained index
+        working-directory: frontend
+        run: npx playwright test tests/performance.spec.js --project=chromium --grep "bootstrap index/detail"
+      - name: Gate timeout and retry UI
+        working-directory: frontend
+        run: npx playwright test tests/performance.spec.js --project=chromium --grep "times out and exposes"
+      - name: Gate auth bootstrap CLS
+        working-directory: frontend
+        run: npx playwright test tests/performance.spec.js --project=chromium --grep "layout shift"

--- a/docs/performance/issue-100.md
+++ b/docs/performance/issue-100.md
@@ -1,0 +1,33 @@
+# Issue #100 perceived-performance audit
+
+Date: 2026-08-14
+
+This document records the client-side request waterfall found while auditing `/games/:slug` and `/lists`, together with the regression gates added by #100. Counts below are request initiations implied by the pre-change code and are verified after the change by Playwright route counters.
+
+## Before
+
+| Flow | Pre-change request shape | Problem |
+| --- | --- | --- |
+| Open `/games/:slug` | `GamePage` GET `/api/games/:slug` + `GameListSavePortal` GET of the same path | 2 client GET initiations for one canonical game |
+| Initial `/lists` | GET `/api/lists`, then GET selected list/owned detail | 2 dependent stages; detail waits for index |
+| Switch custom list | GET `/api/lists`, then GET `/api/lists/:id` | Index is fetched again although already known |
+| Mutation feedback | Component-specific `busy` coverage | rename/delete/reorder/remove did not share a complete single-flight contract |
+| Failed request | fetch had no client deadline | UI could wait indefinitely on a stalled request |
+
+## After / release gates
+
+| Metric | Gate |
+| --- | --- |
+| Same game GET while `GamePage` and action portal resolve | exactly **1 underlying fetch**; concurrent GETs are coalesced and a successful GET is reusable for 2 seconds |
+| `/lists` bootstrap | index and selected detail start within **100 ms** of each other in controlled E2E |
+| Custom-list switch | **0 additional `/api/lists` index fetches**; only selected detail is requested |
+| Mutation duplicate-click | identical method/path/body is **single-flight**; controlled double click produces exactly **1 mutation request** |
+| Operation feedback | button enters busy state by the next animation frame, asserted **<100 ms** |
+| API wait bound | production default **15,000 ms**; timeout raises a retryable error instead of waiting indefinitely |
+| Auth/list layout stability | controlled E2E cumulative layout shift **CLS < 0.1** |
+
+## Instrumentation
+
+Every API request dispatches an `api:timing` browser event containing path, method, duration, HTTP status, success/failure, timeout state, and whether the result came from the short-lived GET cache. This is intentionally browser-local telemetry: no user token or response payload is emitted.
+
+Mutations clear the GET cache after success, so the 2-second reuse window cannot serve pre-mutation list state. Server-side uniqueness/RLS constraints remain the authority for data integrity; client single-flight is only a perceived-performance and duplicate-submit guard.

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { Outlet, useLocation, useNavigationType } from 'react-router-dom'
 
 import AuthControlPortal from './AuthControlPortal.jsx'
-import GameListSavePortal from './GameListSavePortal.jsx'
 
 function isPlainPrimaryClick(event) {
   return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
@@ -96,7 +95,6 @@ export default function AppShell() {
       )}
       <Outlet />
       <AuthControlPortal />
-      <GameListSavePortal />
     </>
   )
 }

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Outlet, useLocation, useNavigationType } from 'react-router-dom'
 
 import AuthControlPortal from './AuthControlPortal.jsx'
+import GameListSavePortal from './GameListSavePortal.jsx'
 
 function isPlainPrimaryClick(event) {
   return event.button === 0 && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey
@@ -95,6 +96,7 @@ export default function AppShell() {
       )}
       <Outlet />
       <AuthControlPortal />
+      <GameListSavePortal />
     </>
   )
 }

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,9 +1,25 @@
 import { supabase } from './supabase'
 
+const DEFAULT_TIMEOUT_MS = 15000
+const inflightGets = new Map()
+
+export class ApiError extends Error {
+  constructor(message, { status = 0, code = 'api_error', retryable = false } = {}) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.code = code
+    this.retryable = retryable
+  }
+}
+
 const handleResponse = async (res) => {
   if (!res.ok) {
     const errorBody = await res.json().catch(() => ({}))
-    throw new Error(errorBody.message || errorBody.detail || `API Error: ${res.status} ${res.statusText}`)
+    throw new ApiError(
+      errorBody.message || errorBody.detail || `API Error: ${res.status} ${res.statusText}`,
+      { status: res.status, code: 'http_error', retryable: res.status >= 500 || res.status === 408 || res.status === 429 },
+    )
   }
   if (res.status === 204) return null
   return res.json()
@@ -16,20 +32,54 @@ const getAuthHeaders = async () => {
   return accessToken ? { Authorization: `Bearer ${accessToken}` } : {}
 }
 
+const emitTiming = (detail) => {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new CustomEvent('api:timing', { detail }))
+}
+
 const request = async (path, options = {}) => {
-  const authHeaders = await getAuthHeaders()
-  const res = await fetch(path, {
-    ...options,
-    headers: {
-      ...authHeaders,
-      ...(options.headers || {}),
-    },
-  })
-  return handleResponse(res)
+  const startedAt = performance.now()
+  const controller = new AbortController()
+  const timeoutMs = options.timeoutMs || DEFAULT_TIMEOUT_MS
+  const timeout = window.setTimeout(() => controller.abort('timeout'), timeoutMs)
+  const method = options.method || 'GET'
+
+  try {
+    const authHeaders = await getAuthHeaders()
+    const res = await fetch(path, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        ...authHeaders,
+        ...(options.headers || {}),
+      },
+    })
+    const result = await handleResponse(res)
+    emitTiming({ path, method, durationMs: performance.now() - startedAt, status: res.status, ok: true })
+    return result
+  } catch (error) {
+    const timedOut = controller.signal.aborted
+    emitTiming({ path, method, durationMs: performance.now() - startedAt, status: error.status || 0, ok: false, timedOut })
+    if (timedOut) {
+      throw new ApiError('通信がタイムアウトしました。再試行してください。', { code: 'timeout', retryable: true })
+    }
+    if (error instanceof ApiError) throw error
+    throw new ApiError(error.message || '通信に失敗しました。再試行してください。', { code: 'network_error', retryable: true })
+  } finally {
+    window.clearTimeout(timeout)
+  }
+}
+
+const get = (path) => {
+  const existing = inflightGets.get(path)
+  if (existing) return existing
+  const promise = request(path).finally(() => inflightGets.delete(path))
+  inflightGets.set(path, promise)
+  return promise
 }
 
 export const api = {
-  get: async (path) => request(path),
+  get,
   post: async (path, body) =>
     request(path, {
       method: 'POST',

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,6 +1,6 @@
 import { supabase } from './supabase'
 
-const DEFAULT_TIMEOUT_MS = 15000
+const DEFAULT_TIMEOUT_MS = Number(import.meta.env.VITE_API_TIMEOUT_MS || 15000)
 const GET_CACHE_TTL_MS = 2000
 const inflightGets = new Map()
 const recentGets = new Map()

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -4,6 +4,7 @@ const DEFAULT_TIMEOUT_MS = Number(import.meta.env.VITE_API_TIMEOUT_MS || 15000)
 const GET_CACHE_TTL_MS = 2000
 const inflightGets = new Map()
 const recentGets = new Map()
+const inflightMutations = new Map()
 
 export class ApiError extends Error {
   constructor(message, { status = 0, code = 'api_error', retryable = false } = {}) {
@@ -95,10 +96,19 @@ const get = (path) => {
   return promise
 }
 
-const mutate = async (path, options) => {
-  const result = await request(path, options)
-  clearGetCache()
-  return result
+const mutate = (path, options) => {
+  const key = `${options.method}:${path}:${options.body || ''}`
+  const existing = inflightMutations.get(key)
+  if (existing) return existing
+
+  const promise = request(path, options)
+    .then((result) => {
+      clearGetCache()
+      return result
+    })
+    .finally(() => inflightMutations.delete(key))
+  inflightMutations.set(key, promise)
+  return promise
 }
 
 export const api = {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,7 +1,9 @@
 import { supabase } from './supabase'
 
 const DEFAULT_TIMEOUT_MS = 15000
+const GET_CACHE_TTL_MS = 2000
 const inflightGets = new Map()
+const recentGets = new Map()
 
 export class ApiError extends Error {
   constructor(message, { status = 0, code = 'api_error', retryable = false } = {}) {
@@ -55,11 +57,11 @@ const request = async (path, options = {}) => {
       },
     })
     const result = await handleResponse(res)
-    emitTiming({ path, method, durationMs: performance.now() - startedAt, status: res.status, ok: true })
+    emitTiming({ path, method, durationMs: performance.now() - startedAt, status: res.status, ok: true, cached: false })
     return result
   } catch (error) {
     const timedOut = controller.signal.aborted
-    emitTiming({ path, method, durationMs: performance.now() - startedAt, status: error.status || 0, ok: false, timedOut })
+    emitTiming({ path, method, durationMs: performance.now() - startedAt, status: error.status || 0, ok: false, timedOut, cached: false })
     if (timedOut) {
       throw new ApiError('通信がタイムアウトしました。再試行してください。', { code: 'timeout', retryable: true })
     }
@@ -70,33 +72,55 @@ const request = async (path, options = {}) => {
   }
 }
 
+const clearGetCache = () => recentGets.clear()
+
 const get = (path) => {
+  const cached = recentGets.get(path)
+  if (cached && cached.expiresAt > performance.now()) {
+    emitTiming({ path, method: 'GET', durationMs: 0, status: 200, ok: true, cached: true })
+    return Promise.resolve(cached.value)
+  }
+  if (cached) recentGets.delete(path)
+
   const existing = inflightGets.get(path)
   if (existing) return existing
-  const promise = request(path).finally(() => inflightGets.delete(path))
+
+  const promise = request(path)
+    .then((value) => {
+      recentGets.set(path, { value, expiresAt: performance.now() + GET_CACHE_TTL_MS })
+      return value
+    })
+    .finally(() => inflightGets.delete(path))
   inflightGets.set(path, promise)
   return promise
 }
 
+const mutate = async (path, options) => {
+  const result = await request(path, options)
+  clearGetCache()
+  return result
+}
+
 export const api = {
   get,
+  clearGetCache,
   post: async (path, body) =>
-    request(path, {
+    mutate(path, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
   put: async (path, body) =>
-    request(path, {
+    mutate(path, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
   patch: async (path, body) =>
-    request(path, {
+    mutate(path, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
-  delete: async (path) => request(path, { method: 'DELETE' }),
+  delete: async (path) => mutate(path, { method: 'DELETE' }),
 }

--- a/frontend/src/pages/ListsPage.jsx
+++ b/frontend/src/pages/ListsPage.jsx
@@ -175,19 +175,16 @@ export default function ListsPage() {
     if (!detail || busyAction) return
     setBusyAction(`remove:${item.id}`)
     setError('')
-    const previous = detail
-    const optimistic = { ...detail, items: detail.items.filter((candidate) => candidate.id !== item.id) }
-    detailCache.current.set(selectedId, optimistic)
-    setDetail(optimistic)
     try {
       if (detail.system_key === 'owned' && item.game_id) {
         await api.delete(`/api/owned-games/${item.game_id}`)
       } else if (detail.id) {
         await api.delete(`/api/lists/${detail.id}/items/${item.id}`)
       }
+      const nextDetail = { ...detail, items: detail.items.filter((candidate) => candidate.id !== item.id) }
+      detailCache.current.set(selectedId, nextDetail)
+      setDetail(nextDetail)
     } catch (err) {
-      detailCache.current.set(selectedId, previous)
-      setDetail(previous)
       setError(err.message)
     } finally {
       setBusyAction('')

--- a/frontend/src/pages/ListsPage.jsx
+++ b/frontend/src/pages/ListsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 
 import { useAuth } from '../auth/authContext'
@@ -12,9 +12,12 @@ export default function ListsPage() {
   const selectedId = searchParams.get('list') || OWNED_SELECTION
   const savedNotice = searchParams.get('notice') === 'saved'
   const [lists, setLists] = useState([])
+  const [indexReady, setIndexReady] = useState(false)
   const [detail, setDetail] = useState(null)
+  const detailCache = useRef(new Map())
   const [newName, setNewName] = useState('')
   const [loading, setLoading] = useState(false)
+  const [busyAction, setBusyAction] = useState('')
   const [error, setError] = useState('')
 
   const loadDetail = async (id) => (
@@ -32,21 +35,52 @@ export default function ListsPage() {
     setSearchParams(next, { replace })
   }
 
-  const loadLists = async (preferredId = selectedId) => {
+  const fetchSelectedDetail = async (id, { force = false } = {}) => {
+    if (!force && detailCache.current.has(id)) {
+      setDetail(detailCache.current.get(id))
+      return detailCache.current.get(id)
+    }
     setLoading(true)
     setError('')
     try {
-      const data = await api.get('/api/lists')
-      const next = data.lists || []
-      setLists(next)
-      const validId = preferredId === OWNED_SELECTION || next.some((list) => list.id === preferredId)
-        ? preferredId
-        : OWNED_SELECTION
-      if (validId !== selectedId) {
-        chooseList(validId, { replace: true })
-      }
-      setDetail(await loadDetail(validId))
+      const nextDetail = await loadDetail(id)
+      detailCache.current.set(id, nextDetail)
+      setDetail(nextDetail)
+      return nextDetail
     } catch (err) {
+      setError(err.message)
+      throw err
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const refreshIndex = async () => {
+    const data = await api.get('/api/lists')
+    const next = data.lists || []
+    setLists(next)
+    return next
+  }
+
+  const bootstrap = async (id) => {
+    setLoading(true)
+    setError('')
+    try {
+      const detailPromise = loadDetail(id)
+      const indexPromise = api.get('/api/lists')
+      const [data, nextDetail] = await Promise.all([indexPromise, detailPromise])
+      const nextLists = data.lists || []
+      setLists(nextLists)
+      setIndexReady(true)
+      detailCache.current.set(id, nextDetail)
+      setDetail(nextDetail)
+
+      if (id !== OWNED_SELECTION && !nextLists.some((list) => list.id === id)) {
+        detailCache.current.delete(id)
+        chooseList(OWNED_SELECTION, { replace: true })
+      }
+    } catch (err) {
+      setIndexReady(false)
       setError(err.message)
     } finally {
       setLoading(false)
@@ -54,82 +88,143 @@ export default function ListsPage() {
   }
 
   useEffect(() => {
-    if (user) loadLists(selectedId)
+    detailCache.current.clear()
+    setIndexReady(false)
+    if (user) bootstrap(selectedId)
     else {
       setLists([])
       setDetail(null)
     }
-    // selectedId intentionally drives browser back/forward restoration.
+    // User changes reset the private cache; initial list index/detail load is parallel.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, selectedId])
+  }, [user])
+
+  useEffect(() => {
+    if (!user || !indexReady) return
+    const valid = selectedId === OWNED_SELECTION || lists.some((list) => list.id === selectedId)
+    if (!valid) {
+      chooseList(OWNED_SELECTION, { replace: true })
+      return
+    }
+    fetchSelectedDetail(selectedId).catch(() => {})
+    // Browser back/forward changes only the detail request; the list index is retained.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId, indexReady])
+
+  const retryLoad = () => {
+    api.clearGetCache()
+    if (!indexReady) bootstrap(selectedId)
+    else fetchSelectedDetail(selectedId, { force: true }).catch(() => {})
+  }
 
   const createList = async (event) => {
     event.preventDefault()
     const name = newName.trim()
-    if (!name) return
+    if (!name || busyAction) return
+    setBusyAction('create')
     setError('')
     try {
       const created = await api.post('/api/lists', { name, visibility: 'private' })
       setNewName('')
-      chooseList(created.id)
+      const nextLists = await refreshIndex()
+      setIndexReady(true)
+      if (nextLists.some((list) => list.id === created.id)) chooseList(created.id)
     } catch (err) {
       setError(err.message)
+    } finally {
+      setBusyAction('')
     }
   }
 
   const renameList = async () => {
-    if (!detail || detail.system_key) return
+    if (!detail || detail.system_key || busyAction) return
     const name = window.prompt('新しいリスト名', detail.name)?.trim()
     if (!name || name === detail.name) return
+    setBusyAction('rename')
+    setError('')
     try {
-      await api.patch(`/api/lists/${detail.id}`, { name })
-      await loadLists(detail.id)
+      const renamed = await api.patch(`/api/lists/${detail.id}`, { name })
+      const nextDetail = { ...detail, ...renamed, items: detail.items }
+      detailCache.current.set(selectedId, nextDetail)
+      setDetail(nextDetail)
+      await refreshIndex()
     } catch (err) {
       setError(err.message)
+    } finally {
+      setBusyAction('')
     }
   }
 
   const deleteList = async () => {
-    if (!detail || detail.system_key || !window.confirm(`「${detail.name}」を削除しますか？`)) return
+    if (!detail || detail.system_key || busyAction || !window.confirm(`「${detail.name}」を削除しますか？`)) return
+    setBusyAction('delete')
+    setError('')
     try {
       await api.delete(`/api/lists/${detail.id}`)
-      setDetail(null)
+      detailCache.current.delete(selectedId)
+      await refreshIndex()
       chooseList(OWNED_SELECTION)
     } catch (err) {
       setError(err.message)
+    } finally {
+      setBusyAction('')
     }
   }
 
   const removeItem = async (item) => {
-    if (!detail) return
+    if (!detail || busyAction) return
+    setBusyAction(`remove:${item.id}`)
+    setError('')
+    const previous = detail
+    const optimistic = { ...detail, items: detail.items.filter((candidate) => candidate.id !== item.id) }
+    detailCache.current.set(selectedId, optimistic)
+    setDetail(optimistic)
     try {
       if (detail.system_key === 'owned' && item.game_id) {
         await api.delete(`/api/owned-games/${item.game_id}`)
       } else if (detail.id) {
         await api.delete(`/api/lists/${detail.id}/items/${item.id}`)
       }
-      await loadLists(selectedId)
     } catch (err) {
+      detailCache.current.set(selectedId, previous)
+      setDetail(previous)
       setError(err.message)
+    } finally {
+      setBusyAction('')
     }
   }
 
   const moveItem = async (index, delta) => {
-    if (!detail?.id) return
+    if (!detail?.id || busyAction) return
     const nextIndex = index + delta
     if (nextIndex < 0 || nextIndex >= detail.items.length) return
+    const previous = detail
     const items = [...detail.items]
     ;[items[index], items[nextIndex]] = [items[nextIndex], items[index]]
-    setDetail({ ...detail, items })
+    const optimistic = { ...detail, items }
+    detailCache.current.set(selectedId, optimistic)
+    setDetail(optimistic)
+    setBusyAction('reorder')
+    setError('')
     try {
       await api.put(`/api/lists/${detail.id}/order`, { item_ids: items.map((item) => item.id) })
     } catch (err) {
+      detailCache.current.set(selectedId, previous)
+      setDetail(previous)
       setError(err.message)
-      await loadLists(selectedId)
+    } finally {
+      setBusyAction('')
     }
   }
 
-  if (authLoading) return <main style={{ padding: '3rem' }}>認証状態を確認しています…</main>
+  if (authLoading) {
+    return (
+      <main style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1rem' }} aria-busy="true">
+        <div style={{ minHeight: '48px', marginBottom: '1rem' }}>認証状態を確認しています…</div>
+        <div className="pro-card" style={{ minHeight: '180px', opacity: 0.65 }}>マイリストを準備しています。</div>
+      </main>
+    )
+  }
 
   if (!user) {
     return (
@@ -143,7 +238,7 @@ export default function ListsPage() {
   }
 
   return (
-    <main style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1rem' }}>
+    <main style={{ maxWidth: '1100px', margin: '0 auto', padding: '2rem 1rem' }} aria-busy={loading || Boolean(busyAction)}>
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', flexWrap: 'wrap', marginBottom: '1.5rem' }}>
         <Link to="/" className="back-link">← DIRECTORY</Link>
         <h1 style={{ margin: 0 }}>マイリスト</h1>
@@ -155,16 +250,25 @@ export default function ListsPage() {
           style={{ maxWidth: '360px' }}
           value={newName}
           maxLength={80}
+          disabled={Boolean(busyAction)}
           onChange={(event) => setNewName(event.target.value)}
           placeholder="新しいリスト名"
           aria-label="新しいリスト名"
         />
-        <button className="filter-btn" type="submit">リストを作成</button>
+        <button className="filter-btn" type="submit" disabled={Boolean(busyAction)}>
+          {busyAction === 'create' ? '作成中…' : 'リストを作成'}
+        </button>
       </form>
 
       {savedNotice && <div role="status" style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>保存したリストを表示しています。</div>}
-      {error && <div role="alert" style={{ marginBottom: '1rem', color: '#ff7777' }}>{error}</div>}
-      {loading && <div style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>読み込み中…</div>}
+      {error && (
+        <div role="alert" style={{ marginBottom: '1rem', color: '#ff7777' }}>
+          {error}{' '}
+          <button type="button" className="filter-btn" onClick={retryLoad} disabled={loading || Boolean(busyAction)}>再試行</button>
+        </div>
+      )}
+      {loading && <div role="status" style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>読み込み中…</div>}
+      {busyAction && <div role="status" style={{ marginBottom: '1rem', color: 'var(--text-secondary)' }}>変更を反映しています…</div>}
 
       <div style={{ display: 'grid', gridTemplateColumns: 'minmax(180px, 260px) minmax(0, 1fr)', gap: '16px' }}>
         <aside style={{ position: 'static', width: 'auto', height: 'auto' }}>
@@ -172,6 +276,7 @@ export default function ListsPage() {
             type="button"
             className={`filter-btn ${selectedId === OWNED_SELECTION ? 'active' : ''}`}
             style={{ width: '100%', marginBottom: '8px', textAlign: 'left' }}
+            disabled={loading}
             onClick={() => chooseList(OWNED_SELECTION)}
           >
             所持ゲーム
@@ -182,6 +287,7 @@ export default function ListsPage() {
               key={list.id}
               className={`filter-btn ${selectedId === list.id ? 'active' : ''}`}
               style={{ width: '100%', marginBottom: '8px', textAlign: 'left' }}
+              disabled={loading}
               onClick={() => chooseList(list.id)}
             >
               {list.name}
@@ -194,15 +300,19 @@ export default function ListsPage() {
           )}
         </aside>
 
-        <section>
+        <section style={{ minHeight: '180px' }}>
           {detail && (
             <>
               <div style={{ display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap', marginBottom: '1rem' }}>
                 <h2 style={{ margin: 0 }}>{detail.name}</h2>
                 {!detail.system_key && (
                   <>
-                    <button type="button" className="filter-btn" onClick={renameList}>名前変更</button>
-                    <button type="button" className="filter-btn" onClick={deleteList}>削除</button>
+                    <button type="button" className="filter-btn" disabled={Boolean(busyAction)} onClick={renameList}>
+                      {busyAction === 'rename' ? '変更中…' : '名前変更'}
+                    </button>
+                    <button type="button" className="filter-btn" disabled={Boolean(busyAction)} onClick={deleteList}>
+                      {busyAction === 'delete' ? '削除中…' : '削除'}
+                    </button>
                   </>
                 )}
               </div>
@@ -215,8 +325,9 @@ export default function ListsPage() {
                 </div>
               ) : detail.items.map((item, index) => {
                 const title = item.game?.title_ja || item.game?.title || item.game_title_snapshot
+                const removing = busyAction === `remove:${item.id}`
                 return (
-                  <div key={item.id} className="pro-card" style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '10px', flexWrap: 'wrap' }}>
+                  <div key={item.id} className="pro-card" style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '10px', flexWrap: 'wrap', opacity: removing ? 0.55 : 1 }}>
                     <div style={{ flex: '1 1 220px' }}>
                       {item.game ? <Link to={`/games/${item.game.slug}`}>{title}</Link> : <strong>{title}</strong>}
                       {item.unavailable && <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>現在利用できないゲーム</div>}
@@ -227,10 +338,10 @@ export default function ListsPage() {
                       )}
                     </div>
                     <div style={{ display: 'flex', gap: '6px' }}>
-                      <button type="button" className="filter-btn" aria-label={`${title}を上へ`} disabled={!detail.id || index === 0} onClick={() => moveItem(index, -1)}>↑</button>
-                      <button type="button" className="filter-btn" aria-label={`${title}を下へ`} disabled={!detail.id || index === detail.items.length - 1} onClick={() => moveItem(index, 1)}>↓</button>
-                      <button type="button" className="filter-btn" onClick={() => removeItem(item)}>
-                        {detail.system_key === 'owned' ? '所持解除' : '削除'}
+                      <button type="button" className="filter-btn" aria-label={`${title}を上へ`} disabled={Boolean(busyAction) || index === 0} onClick={() => moveItem(index, -1)}>↑</button>
+                      <button type="button" className="filter-btn" aria-label={`${title}を下へ`} disabled={Boolean(busyAction) || index === detail.items.length - 1} onClick={() => moveItem(index, 1)}>↓</button>
+                      <button type="button" className="filter-btn" disabled={Boolean(busyAction)} onClick={() => removeItem(item)}>
+                        {removing ? '反映中…' : detail.system_key === 'owned' ? '所持解除' : '削除'}
                       </button>
                     </div>
                   </div>

--- a/frontend/tests/performance.spec.js
+++ b/frontend/tests/performance.spec.js
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test'
+
+const USER_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const LIST_ID = 'aaaaaaaa-0000-4000-8000-000000000001'
+const GAME_ID = '11111111-1111-4111-8111-111111111111'
+const TOKEN = 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJhYWFhYWFhYS1hYWFhLTRhYWEtOGFhYS1hYWFhYWFhYWFhYWFhYSIsInJvbGUiOiJhdXRoZW50aWNhdGVkIiwiZXhwIjo0MTAyNDQ0ODAwfQ.'
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function installSession(page) {
+  await page.addInitScript(({ token, userId }) => {
+    localStorage.setItem('sb-example-auth-token', JSON.stringify({
+      access_token: token,
+      token_type: 'bearer',
+      expires_in: 3600,
+      expires_at: 4102444800,
+      refresh_token: 'test-refresh',
+      user: {
+        id: userId,
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: 'user@example.com',
+        user_metadata: { full_name: 'Test User' },
+      },
+    }))
+  }, { token: TOKEN, userId: USER_ID })
+}
+
+test('game detail coalesces duplicate GET and gives mutation feedback within one frame', async ({ page }) => {
+  await installSession(page)
+  let gameRequests = 0
+  let saveRequests = 0
+
+  await page.route('**/api/games/game-one', async (route) => {
+    gameRequests += 1
+    await delay(250)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: GAME_ID, slug: 'game-one', title: 'Game One', title_ja: 'ゲーム1', structured_data: {} }),
+    })
+  })
+  await page.route('**/api/games?limit=50', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+  await page.route('**/api/lists', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private', system_key: null }] }),
+    })
+  })
+  await page.route(`**/api/owned-games/${GAME_ID}`, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ owned: false, item_id: null }) })
+  })
+  await page.route(`**/api/lists/${LIST_ID}/items`, async (route) => {
+    saveRequests += 1
+    await delay(300)
+    await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'item-1', game_id: GAME_ID }) })
+  })
+
+  await page.goto('/games/game-one')
+  await expect(page.getByRole('button', { name: 'リストに保存' })).toBeVisible()
+  expect(gameRequests).toBe(1)
+
+  const feedback = await page.evaluate(() => new Promise((resolve) => {
+    const button = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.includes('リストに保存'))
+    const start = performance.now()
+    button.click()
+    button.click()
+    requestAnimationFrame(() => resolve({ elapsedMs: performance.now() - start, text: button.textContent }))
+  }))
+  expect(feedback.elapsedMs).toBeLessThan(100)
+  expect(feedback.text).toContain('保存中')
+  await expect(page.getByRole('status')).toContainText('保存しました')
+  expect(saveRequests).toBe(1)
+})
+
+test('lists bootstrap index/detail in parallel and list switching does not refetch the index', async ({ page }) => {
+  await installSession(page)
+  let indexRequests = 0
+  let detailRequests = 0
+  let indexStartedAt = 0
+  let ownedStartedAt = 0
+
+  await page.route('**/api/lists', async (route) => {
+    indexRequests += 1
+    indexStartedAt = Date.now()
+    await delay(250)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ lists: [{ id: LIST_ID, name: 'Favorites', visibility: 'private', system_key: null }] }),
+    })
+  })
+  await page.route('**/api/owned-games', async (route) => {
+    ownedStartedAt = Date.now()
+    await delay(250)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: null, name: '所持ゲーム', visibility: 'private', system_key: 'owned', items: [] }),
+    })
+  })
+  await page.route(`**/api/lists/${LIST_ID}`, async (route) => {
+    detailRequests += 1
+    await delay(150)
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: LIST_ID, name: 'Favorites', visibility: 'private', system_key: null, items: [] }),
+    })
+  })
+
+  await page.goto('/lists')
+  await expect(page.getByRole('heading', { name: '所持ゲーム' })).toBeVisible()
+  expect(Math.abs(indexStartedAt - ownedStartedAt)).toBeLessThan(100)
+  expect(indexRequests).toBe(1)
+
+  await page.getByRole('button', { name: 'Favorites' }).click()
+  await expect(page.getByRole('heading', { name: 'Favorites' })).toBeVisible()
+  expect(indexRequests).toBe(1)
+  expect(detailRequests).toBe(1)
+})
+
+test('slow failed list load times out and exposes a retry action instead of waiting forever', async ({ page }) => {
+  await installSession(page)
+  await page.route('**/api/lists', async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ lists: [] }) })
+  })
+  await page.route('**/api/owned-games', async (route) => {
+    await delay(2000)
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: null, name: '所持ゲーム', system_key: 'owned', items: [] }) })
+  })
+
+  await page.goto('/lists')
+  await expect(page.getByRole('alert')).toContainText('タイムアウト', { timeout: 2000 })
+  await expect(page.getByRole('button', { name: '再試行' })).toBeVisible()
+})
+
+test('auth bootstrap keeps cumulative layout shift below the release threshold', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__cls = 0
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (!entry.hadRecentInput) window.__cls += entry.value
+      }
+    }).observe({ type: 'layout-shift', buffered: true })
+  })
+
+  await page.goto('/lists')
+  await expect(page.getByRole('heading', { name: 'マイリスト' })).toBeVisible()
+  await page.waitForTimeout(100)
+  const cls = await page.evaluate(() => window.__cls || 0)
+  expect(cls).toBeLessThan(0.1)
+})


### PR DESCRIPTION
## Summary
- coalesce concurrent identical GETs and reuse fresh GET results for 2 seconds; successful mutations invalidate the GET cache
- make identical mutations single-flight so synchronous duplicate clicks cannot create duplicate network requests
- bound API waits to 15 seconds in production and surface retryable timeout/network errors
- emit browser-local `api:timing` events with request duration/status/cache/timeout metadata, without tokens or response payloads
- bootstrap `/lists` index + selected detail in parallel and retain the list index across list switching/back-forward
- cache already loaded list details, show stable auth/loading shells, and add retry UI
- provide immediate pending states for remove and optimistic reorder with rollback; add busy states for create/rename/delete/reorder/remove
- record before/after waterfall and release thresholds in `docs/performance/issue-100.md`

## Regression gates
- duplicate `GamePage` + action portal GET resolves to exactly 1 underlying `/api/games/:slug` fetch
- `/lists` index/detail requests start within 100 ms of each other
- switching a list performs 0 additional `/api/lists` index requests
- synchronous double-click on list save performs exactly 1 mutation request
- busy feedback is visible by the next animation frame and asserted <100 ms
- stalled API request fails with retry UI instead of hanging indefinitely
- auth/list bootstrap CLS is asserted <0.1
- all pre-existing list and navigation E2E remain green

Refs #100