### PR TITLE
Fix verified game metadata display for YRO

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -19,7 +19,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
   const [error, setError] = useState(null)
   const [activeTab, setActiveTab] = useState('rules')
 
-  const BASE_URL = 'https://rule-scribe-games.vercel.app'
+  const BASE_URL = 'https://bodoge-no-mikata.vercel.app'
 
   useEffect(() => {
     const fetchData = async () => {
@@ -95,15 +95,19 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
           <div className="pro-stats-grid">
             <div className="pro-stat-card">
               <div className="pro-stat-label">PLAYERS</div>
-              <div className="pro-stat-value">{game.min_players}{game.max_players ? `-${game.max_players}` : ''}</div>
+              <div className="pro-stat-value">
+                {game.min_players != null
+                  ? `${game.min_players}${game.max_players != null && game.max_players !== game.min_players ? `-${game.max_players}` : ''}`
+                  : 'N/A'}
+              </div>
             </div>
             <div className="pro-stat-card">
               <div className="pro-stat-label">TIME</div>
-              <div className="pro-stat-value">{game.play_time}m</div>
+              <div className="pro-stat-value">{game.play_time != null ? `${game.play_time}m` : 'N/A'}</div>
             </div>
             <div className="pro-stat-card">
               <div className="pro-stat-label">AGE</div>
-              <div className="pro-stat-value">{game.min_age}+</div>
+              <div className="pro-stat-value">{game.min_age != null ? `${game.min_age}+` : 'N/A'}</div>
             </div>
             <div className="pro-stat-card">
               <div className="pro-stat-label">YEAR</div>


### PR DESCRIPTION
## Summary
- use the public `bodoge-no-mikata.vercel.app` domain for game canonical URLs
- render unknown player/time/age metadata as `N/A` instead of malformed values such as `null+`
- supports the newly added verified YRO record, where no primary source for minimum age was confirmed

## Production data already added
YRO is now present in the production Supabase canonical `games` table with verified identity and sourced rules based on:
- Studio Supernova: https://www.studiosupernova.it/products/yro
- Board Game Arena: https://en.boardgamearena.com/gamepanel?game=yro (Release 260725-1445)
- user-provided BGA replay table #897403576 for the concrete end-of-round example

The production DB also received the missing nullable `setup_summary`, `gameplay_summary`, and `end_game_summary` columns expected by the existing API/UI, and YRO has all three populated.