### PR TITLE
Fix rule comprehension UX, scoring and verified diagrams (#108-#112)

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -103,6 +103,14 @@ jobs:
           --project=ux-tablet
           --project=ux-desktop
 
+      - name: Gate reviewed rules and new-user comprehension flow
+        working-directory: frontend
+        run: >-
+          npx playwright test tests/rule_guide.spec.js
+          --project=ux-mobile
+          --project=ux-tablet
+          --project=ux-desktop
+
       - name: Upload reviewable UI UX evidence
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4

--- a/frontend/src/components/game/InfographicsGallery.jsx
+++ b/frontend/src/components/game/InfographicsGallery.jsx
@@ -1,7 +1,11 @@
 import { useState } from 'react'
 
-export function InfographicsGallery({ infographics }) {
+export function InfographicsGallery({ infographics, verified = false, sourceUrl = null }) {
   const [currentIndex, setCurrentIndex] = useState(0)
+
+  if (!verified || !sourceUrl) {
+    return <p className="no-infographics">図解は検証待ちのため表示していません</p>
+  }
 
   const infographicTypes = [
     { key: 'turn_flow', title: '手番の流れ', icon: '🔄' },
@@ -11,8 +15,7 @@ export function InfographicsGallery({ infographics }) {
     { key: 'components', title: 'コンポーネント', icon: '🧩' },
   ]
 
-  // Add any 'slide_N' keys found in infographics
-  const slideKeys = Object.keys(infographics)
+  const slideKeys = Object.keys(infographics || {})
     .filter((key) => key.startsWith('slide_'))
     .sort((a, b) => {
       const numA = parseInt(a.split('_')[1], 10)
@@ -26,7 +29,7 @@ export function InfographicsGallery({ infographics }) {
     }))
 
   const allTypes = [...infographicTypes, ...slideKeys]
-  const available = allTypes.filter((inf) => infographics[inf.key])
+  const available = allTypes.filter((inf) => infographics?.[inf.key])
 
   if (!available.length) {
     return <p className="no-infographics">図解はまだ利用できません</p>
@@ -49,7 +52,7 @@ export function InfographicsGallery({ infographics }) {
           onError={(e) => {
             e.target.style.display = 'none'
             e.target.parentElement.innerHTML =
-              '<p className="loading-error">画像を読み込めませんでした</p>'
+              '<p class="loading-error">画像を読み込めませんでした</p>'
           }}
         />
       </div>
@@ -88,6 +91,10 @@ export function InfographicsGallery({ infographics }) {
 
       <div className="gallery-counter">
         {currentIndex + 1} / {available.length}
+      </div>
+
+      <div className="rule-flow-source">
+        出典: <a href={sourceUrl} target="_blank" rel="noreferrer">検証済みルール資料</a>
       </div>
     </div>
   )

--- a/frontend/src/components/game/QuickRulesPanel.jsx
+++ b/frontend/src/components/game/QuickRulesPanel.jsx
@@ -1,0 +1,76 @@
+import { ScoringBreakdown } from './ScoringBreakdown'
+import './rule-guide.css'
+
+export function QuickRulesPanel({ guide, onShowFlow, onShowRules }) {
+  if (!guide) {
+    return (
+      <section className="quick-rules-panel quick-rules-unavailable" aria-label="すぐ遊ぶ">
+        <div className="quick-rules-kicker">QUICK RULES</div>
+        <div className="quick-rules-title">検証済みの要約はまだありません</div>
+        <p style={{ marginTop: '0.55rem', lineHeight: 1.6 }}>
+          未確認内容は推測表示しません。詳しいルールと出典を確認してください。
+        </p>
+        {onShowRules && (
+          <div className="quick-rules-actions">
+            <button type="button" className="quick-rule-action" onClick={onShowRules}>詳しいルールを見る</button>
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  return (
+    <section className="quick-rules-panel" aria-label="すぐ遊ぶ" data-testid="quick-rules-panel">
+      <div className="quick-rules-header">
+        <div>
+          <div className="quick-rules-kicker">QUICK RULES</div>
+          <h2 className="quick-rules-title">卓上ですぐ確認</h2>
+        </div>
+        <div className="rule-verified-badge">公式ルール確認済み</div>
+      </div>
+
+      <div className="quick-rules-grid">
+        <article className="quick-rule-card">
+          <div className="quick-rule-label">勝つには？</div>
+          <p>{guide.quick.win}</p>
+        </article>
+
+        <article className="quick-rule-card quick-rule-card--primary">
+          <div className="quick-rule-label">今の手番ですること</div>
+          <ol className="quick-turn-steps">
+            {guide.quick.turnSteps.map((step) => <li key={step}>{step}</li>)}
+          </ol>
+          {guide.quick.actions?.length > 0 && (
+            <ul className="quick-check-list" style={{ marginTop: '0.65rem' }}>
+              {guide.quick.actions.map((action) => <li key={action}>{action}</li>)}
+            </ul>
+          )}
+        </article>
+
+        <article className="quick-rule-card">
+          <div className="quick-rule-label">手番終了時に確認</div>
+          <ul className="quick-check-list">
+            {guide.quick.turnEndChecks.map((check) => <li key={check}>{check}</li>)}
+          </ul>
+        </article>
+
+        <article className="quick-rule-card">
+          <div className="quick-rule-label">いつ終わる？</div>
+          <p>{guide.quick.end}</p>
+        </article>
+      </div>
+
+      <ScoringBreakdown scoring={guide.scoring} />
+
+      <div className="quick-rules-actions">
+        {onShowFlow && <button type="button" className="quick-rule-action" onClick={onShowFlow}>図で見る</button>}
+        {onShowRules && <button type="button" className="quick-rule-action" onClick={onShowRules}>詳しいルール</button>}
+        <a className="quick-rule-action" href={guide.source.url} target="_blank" rel="noreferrer">公式出典</a>
+      </div>
+
+      <div className="quick-rules-source">
+        {guide.source.label} / rule version: {guide.ruleVersion}。要約は公式裁定そのものではありません。
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/game/RuleFlowDiagram.jsx
+++ b/frontend/src/components/game/RuleFlowDiagram.jsx
@@ -1,0 +1,43 @@
+import './rule-guide.css'
+
+export function RuleFlowDiagram({ guide }) {
+  if (!guide?.flow?.length) {
+    return <p className="no-infographics">検証済みの図解はまだ利用できません</p>
+  }
+
+  return (
+    <section className="rule-flow" aria-label="ルールフロー" data-testid="rule-flow-diagram">
+      <div className="rule-flow-header">
+        <div>
+          <div className="quick-rules-kicker">RULE FLOW</div>
+          <h2 className="rule-flow-title">手番からゲーム終了まで</h2>
+        </div>
+        <div className="rule-verified-badge">公式ルール確認済み</div>
+      </div>
+
+      <ol className="rule-flow-list">
+        {guide.flow.map((node, index) => (
+          <li className={`rule-flow-node rule-flow-node--${node.kind}`} key={node.id}>
+            <span className="rule-flow-step-number" aria-hidden="true">{index + 1}</span>
+            <div className="rule-flow-node-label">{node.label}</div>
+            {node.note && <div className="rule-flow-node-note">注意: {node.note}</div>}
+            {node.branches?.length > 0 && (
+              <div className="rule-flow-branches">
+                {node.branches.map((branch) => (
+                  <div className="rule-flow-branch" key={`${node.id}-${branch.label}`}>
+                    <strong>{branch.label}</strong>
+                    <span>{branch.detail}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </li>
+        ))}
+      </ol>
+
+      <div className="rule-flow-source">
+        出典: <a href={guide.source.url} target="_blank" rel="noreferrer">{guide.source.label}</a>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/game/ScoringBreakdown.jsx
+++ b/frontend/src/components/game/ScoringBreakdown.jsx
@@ -1,0 +1,31 @@
+export function ScoringBreakdown({ scoring }) {
+  if (!scoring) return null
+
+  return (
+    <details className="scoring-breakdown" data-testid="scoring-breakdown">
+      <summary>得点の数え方</summary>
+      <p className="scoring-summary">{scoring.summary}</p>
+
+      {scoring.rules?.length > 0 && (
+        <div className="scoring-rule-list">
+          {scoring.rules.map((rule) => (
+            <details className="scoring-rule" key={rule.label}>
+              <summary>{rule.label}</summary>
+              <p>{rule.detail}</p>
+            </details>
+          ))}
+        </div>
+      )}
+
+      {scoring.example && (
+        <div className="scoring-example" aria-label={scoring.example.label}>
+          <div className="quick-rules-kicker">{scoring.example.label}</div>
+          <div className="scoring-example-total">合計 {scoring.example.total}点</div>
+          <ul>
+            {scoring.example.items.map((item) => <li key={item}>{item}</li>)}
+          </ul>
+        </div>
+      )}
+    </details>
+  )
+}

--- a/frontend/src/components/game/rule-guide.css
+++ b/frontend/src/components/game/rule-guide.css
@@ -1,9 +1,10 @@
 .quick-rules-panel {
   margin: 0 0 1.5rem;
   padding: 1rem;
-  border: 1px solid var(--border-color);
+  border: 1px solid #c8d2df;
   border-radius: 12px;
-  background: var(--bg-card);
+  background: #ffffff;
+  color: #1d3150;
 }
 
 .quick-rules-header {
@@ -18,7 +19,7 @@
   font-size: 0.72rem;
   font-weight: 800;
   letter-spacing: 0.08em;
-  color: var(--text-muted);
+  color: #53647c;
   text-transform: uppercase;
   margin-bottom: 0.25rem;
 }
@@ -27,13 +28,14 @@
   font-family: var(--font-heading);
   font-size: 1.35rem;
   line-height: 1.2;
+  color: #172c4b;
 }
 
 .rule-verified-badge {
   flex: 0 0 auto;
-  border: 1px solid #4d745b;
-  background: #132119;
-  color: #c8f2d3;
+  border: 1px solid #2e6a45;
+  background: #143c28;
+  color: #f4fff7;
   border-radius: 999px;
   padding: 0.35rem 0.65rem;
   font-size: 0.72rem;
@@ -47,20 +49,21 @@
 }
 
 .quick-rule-card {
-  border: 1px solid var(--border-color);
+  border: 1px solid #ccd5e1;
   border-radius: 10px;
-  background: #101010;
+  background: #f8fafc;
+  color: #1d3150;
   padding: 0.9rem;
   min-width: 0;
 }
 
 .quick-rule-card--primary {
-  border-color: #555;
-  background: #171717;
+  border-color: #9fb1c8;
+  background: #f2f6fb;
 }
 
 .quick-rule-label {
-  color: var(--text-secondary);
+  color: #405674;
   font-size: 0.78rem;
   font-weight: 800;
   margin-bottom: 0.55rem;
@@ -68,6 +71,7 @@
 
 .quick-rule-card p,
 .quick-rule-card li {
+  color: #1d3150;
   font-size: 0.92rem;
   line-height: 1.6;
   overflow-wrap: anywhere;
@@ -96,7 +100,7 @@
   position: absolute;
   left: 0;
   top: 0;
-  color: #ffcf70;
+  color: #9a5b00;
   font-weight: 900;
 }
 
@@ -108,9 +112,9 @@
 }
 
 .quick-rule-action {
-  border: 1px solid var(--border-color);
-  background: #1b1b1b;
-  color: var(--text-primary);
+  border: 1px solid #9fb0c5;
+  background: #f6f8fb;
+  color: #1d3150;
   border-radius: 7px;
   padding: 0.55rem 0.75rem;
   font-size: 0.82rem;
@@ -121,40 +125,47 @@
 
 .quick-rule-action:hover,
 .quick-rule-action:focus-visible {
-  border-color: #fff;
-  outline: none;
+  border-color: #1d3150;
+  background: #eef3f9;
+  outline: 2px solid transparent;
 }
 
 .quick-rules-source {
   margin-top: 0.9rem;
   font-size: 0.76rem;
-  color: var(--text-muted);
+  color: #596b82;
 }
 
 .quick-rules-source a {
-  color: var(--text-secondary);
+  color: #294c7a;
 }
 
 .quick-rules-unavailable {
   border-style: dashed;
-  color: var(--text-secondary);
+  color: #405674;
+}
+
+.quick-rules-unavailable p {
+  color: #405674;
 }
 
 .scoring-breakdown {
   margin-top: 1rem;
-  border-top: 1px solid var(--border-color);
+  border-top: 1px solid #d5dce6;
   padding-top: 1rem;
+  color: #1d3150;
 }
 
 .scoring-breakdown > summary {
   cursor: pointer;
   font-weight: 800;
   font-size: 0.95rem;
+  color: #1d3150;
 }
 
 .scoring-summary {
   margin: 0.8rem 0;
-  color: var(--text-secondary);
+  color: #405674;
   line-height: 1.6;
 }
 
@@ -164,20 +175,22 @@
 }
 
 .scoring-rule {
-  border: 1px solid var(--border-color);
+  border: 1px solid #ccd5e1;
   border-radius: 8px;
   padding: 0.7rem 0.8rem;
-  background: #101010;
+  background: #f8fafc;
+  color: #1d3150;
 }
 
 .scoring-rule summary {
   cursor: pointer;
   font-weight: 700;
+  color: #1d3150;
 }
 
 .scoring-rule p {
   margin-top: 0.45rem;
-  color: var(--text-secondary);
+  color: #405674;
   line-height: 1.55;
   font-size: 0.88rem;
 }
@@ -186,28 +199,31 @@
   margin-top: 0.8rem;
   padding: 0.8rem;
   border-radius: 8px;
-  background: #101010;
-  border: 1px solid var(--border-color);
+  background: #f3f7fb;
+  border: 1px solid #ccd5e1;
+  color: #1d3150;
 }
 
 .scoring-example-total {
   font-size: 1.35rem;
   font-weight: 900;
   margin: 0.25rem 0 0.5rem;
+  color: #172c4b;
 }
 
 .scoring-example ul {
   list-style: none;
   display: grid;
   gap: 0.2rem;
-  color: var(--text-secondary);
+  color: #405674;
   font-size: 0.85rem;
 }
 
 .rule-flow {
-  border: 1px solid var(--border-color);
+  border: 1px solid #c8d2df;
   border-radius: 12px;
-  background: var(--bg-card);
+  background: #ffffff;
+  color: #1d3150;
   padding: 1rem;
 }
 
@@ -222,6 +238,7 @@
 .rule-flow-title {
   font-family: var(--font-heading);
   font-size: 1.35rem;
+  color: #172c4b;
 }
 
 .rule-flow-list {
@@ -233,10 +250,11 @@
 
 .rule-flow-node {
   position: relative;
-  border: 1px solid var(--border-color);
+  border: 1px solid #ccd5e1;
   border-radius: 10px;
   padding: 0.9rem 0.9rem 0.9rem 3rem;
-  background: #101010;
+  background: #f8fafc;
+  color: #1d3150;
 }
 
 .rule-flow-node:not(:last-child)::after {
@@ -245,7 +263,7 @@
   left: 1.25rem;
   bottom: -1.05rem;
   z-index: 2;
-  color: var(--text-muted);
+  color: #5a6e87;
   font-weight: 900;
 }
 
@@ -258,31 +276,35 @@
   display: grid;
   place-items: center;
   border-radius: 50%;
-  background: #252525;
-  color: #fff;
+  background: #1d3150;
+  color: #ffffff;
   font-size: 0.72rem;
   font-weight: 800;
 }
 
 .rule-flow-node--condition,
 .rule-flow-node--choice {
-  border-color: #5b5445;
+  border-color: #c9aa6a;
+  background: #fffaf0;
 }
 
 .rule-flow-node--end {
-  border-color: #4d745b;
+  border-color: #77a387;
+  background: #f2faf4;
 }
 
 .rule-flow-node-label {
+  color: #1d3150;
   font-weight: 800;
   line-height: 1.45;
 }
 
 .rule-flow-node-note {
   margin-top: 0.4rem;
-  color: #ffcf70;
+  color: #7a4500;
   font-size: 0.82rem;
   line-height: 1.5;
+  font-weight: 650;
 }
 
 .rule-flow-branches {
@@ -294,20 +316,22 @@
 
 .rule-flow-branch {
   padding: 0.6rem;
-  border: 1px solid var(--border-color);
+  border: 1px solid #c9d3df;
   border-radius: 7px;
-  background: #191919;
+  background: #ffffff;
+  color: #1d3150;
   min-width: 0;
 }
 
 .rule-flow-branch strong {
   display: block;
   font-size: 0.76rem;
-  color: var(--text-secondary);
+  color: #405674;
   margin-bottom: 0.25rem;
 }
 
 .rule-flow-branch span {
+  color: #1d3150;
   font-size: 0.86rem;
   line-height: 1.45;
   overflow-wrap: anywhere;
@@ -316,11 +340,11 @@
 .rule-flow-source {
   margin-top: 1rem;
   font-size: 0.78rem;
-  color: var(--text-muted);
+  color: #596b82;
 }
 
 .rule-flow-source a {
-  color: var(--text-secondary);
+  color: #294c7a;
 }
 
 .sr-only {

--- a/frontend/src/components/game/rule-guide.css
+++ b/frontend/src/components/game/rule-guide.css
@@ -1,0 +1,361 @@
+.quick-rules-panel {
+  margin: 0 0 1.5rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--bg-card);
+}
+
+.quick-rules-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.quick-rules-kicker {
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  margin-bottom: 0.25rem;
+}
+
+.quick-rules-title {
+  font-family: var(--font-heading);
+  font-size: 1.35rem;
+  line-height: 1.2;
+}
+
+.rule-verified-badge {
+  flex: 0 0 auto;
+  border: 1px solid #4d745b;
+  background: #132119;
+  color: #c8f2d3;
+  border-radius: 999px;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.quick-rules-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.quick-rule-card {
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  background: #101010;
+  padding: 0.9rem;
+  min-width: 0;
+}
+
+.quick-rule-card--primary {
+  border-color: #555;
+  background: #171717;
+}
+
+.quick-rule-label {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  margin-bottom: 0.55rem;
+}
+
+.quick-rule-card p,
+.quick-rule-card li {
+  font-size: 0.92rem;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.quick-turn-steps {
+  padding-left: 1.2rem;
+}
+
+.quick-turn-steps li + li,
+.quick-check-list li + li {
+  margin-top: 0.35rem;
+}
+
+.quick-check-list {
+  list-style: none;
+}
+
+.quick-check-list li {
+  padding-left: 1.2rem;
+  position: relative;
+}
+
+.quick-check-list li::before {
+  content: '!';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: #ffcf70;
+  font-weight: 900;
+}
+
+.quick-rules-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin-top: 1rem;
+}
+
+.quick-rule-action {
+  border: 1px solid var(--border-color);
+  background: #1b1b1b;
+  color: var(--text-primary);
+  border-radius: 7px;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.quick-rule-action:hover,
+.quick-rule-action:focus-visible {
+  border-color: #fff;
+  outline: none;
+}
+
+.quick-rules-source {
+  margin-top: 0.9rem;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.quick-rules-source a {
+  color: var(--text-secondary);
+}
+
+.quick-rules-unavailable {
+  border-style: dashed;
+  color: var(--text-secondary);
+}
+
+.scoring-breakdown {
+  margin-top: 1rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+}
+
+.scoring-breakdown > summary {
+  cursor: pointer;
+  font-weight: 800;
+  font-size: 0.95rem;
+}
+
+.scoring-summary {
+  margin: 0.8rem 0;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.scoring-rule-list {
+  display: grid;
+  gap: 0.55rem;
+}
+
+.scoring-rule {
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 0.7rem 0.8rem;
+  background: #101010;
+}
+
+.scoring-rule summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.scoring-rule p {
+  margin-top: 0.45rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  font-size: 0.88rem;
+}
+
+.scoring-example {
+  margin-top: 0.8rem;
+  padding: 0.8rem;
+  border-radius: 8px;
+  background: #101010;
+  border: 1px solid var(--border-color);
+}
+
+.scoring-example-total {
+  font-size: 1.35rem;
+  font-weight: 900;
+  margin: 0.25rem 0 0.5rem;
+}
+
+.scoring-example ul {
+  list-style: none;
+  display: grid;
+  gap: 0.2rem;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.rule-flow {
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  background: var(--bg-card);
+  padding: 1rem;
+}
+
+.rule-flow-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.rule-flow-title {
+  font-family: var(--font-heading);
+  font-size: 1.35rem;
+}
+
+.rule-flow-list {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  counter-reset: flow-step;
+}
+
+.rule-flow-node {
+  position: relative;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  padding: 0.9rem 0.9rem 0.9rem 3rem;
+  background: #101010;
+}
+
+.rule-flow-node:not(:last-child)::after {
+  content: '↓';
+  position: absolute;
+  left: 1.25rem;
+  bottom: -1.05rem;
+  z-index: 2;
+  color: var(--text-muted);
+  font-weight: 900;
+}
+
+.rule-flow-step-number {
+  position: absolute;
+  left: 0.8rem;
+  top: 0.75rem;
+  width: 1.55rem;
+  height: 1.55rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: #252525;
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.rule-flow-node--condition,
+.rule-flow-node--choice {
+  border-color: #5b5445;
+}
+
+.rule-flow-node--end {
+  border-color: #4d745b;
+}
+
+.rule-flow-node-label {
+  font-weight: 800;
+  line-height: 1.45;
+}
+
+.rule-flow-node-note {
+  margin-top: 0.4rem;
+  color: #ffcf70;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.rule-flow-branches {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+  margin-top: 0.7rem;
+}
+
+.rule-flow-branch {
+  padding: 0.6rem;
+  border: 1px solid var(--border-color);
+  border-radius: 7px;
+  background: #191919;
+  min-width: 0;
+}
+
+.rule-flow-branch strong {
+  display: block;
+  font-size: 0.76rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.25rem;
+}
+
+.rule-flow-branch span {
+  font-size: 0.86rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.rule-flow-source {
+  margin-top: 1rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.rule-flow-source a {
+  color: var(--text-secondary);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 700px) {
+  .quick-rules-panel,
+  .rule-flow {
+    padding: 0.8rem;
+  }
+
+  .quick-rules-header,
+  .rule-flow-header {
+    flex-direction: column;
+    gap: 0.55rem;
+  }
+
+  .quick-rules-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .quick-rule-card {
+    padding: 0.8rem;
+  }
+
+  .rule-flow-node {
+    padding-right: 0.75rem;
+  }
+}

--- a/frontend/src/game-detail-palette.css
+++ b/frontend/src/game-detail-palette.css
@@ -1,0 +1,95 @@
+/* Game detail palette repair.
+   The legacy game page still contains dark-theme literals in index.css.
+   Keep this layer after layout.css so KAFKA SIGNAL's light product palette wins. */
+
+.game-detail-content {
+  --game-wash-blue: #eaf4ff;
+  --game-wash-lilac: #f0ebfa;
+  --game-wash-pink: #fcebf1;
+  --game-ink: var(--ks-ink);
+  background:
+    radial-gradient(circle at 78% 0%, rgb(240 235 250 / 0.46), transparent 30rem),
+    var(--ks-canvas);
+  color: var(--game-ink);
+}
+
+/* Tabs should read as a light editorial control, not a dark dashboard. */
+.rules-tabs button {
+  color: var(--ks-ink-muted);
+}
+
+.rules-tabs button.active {
+  background: var(--ks-primary-soft);
+  color: var(--game-ink);
+  box-shadow: inset 0 -2px 0 var(--ks-primary);
+}
+
+.rules-tabs button:hover:not(.active) {
+  background: var(--ks-surface-subtle);
+  color: var(--game-ink);
+}
+
+/* The old coach cards used #111 with dark navy text after the light-theme token swap.
+   Use three restrained pastel washes while keeping all copy on the high-contrast ink. */
+.coach-step {
+  --coach-accent: var(--ks-primary);
+  --coach-soft: var(--game-wash-blue);
+  background: color-mix(in srgb, var(--coach-soft) 74%, var(--ks-surface));
+  color: var(--game-ink);
+  border: 1px solid color-mix(in srgb, var(--coach-accent) 32%, var(--ks-border));
+  border-left: 4px solid var(--coach-accent);
+  box-shadow: var(--ks-shadow-low);
+}
+
+.coach-step:nth-child(2) {
+  --coach-accent: var(--ks-secondary);
+  --coach-soft: var(--game-wash-lilac);
+}
+
+.coach-step:nth-child(3) {
+  --coach-accent: var(--ks-accent);
+  --coach-soft: var(--game-wash-pink);
+}
+
+.coach-step.active {
+  background: var(--coach-soft);
+  border-color: color-mix(in srgb, var(--coach-accent) 58%, var(--ks-border));
+  border-left-color: var(--coach-accent);
+  box-shadow: 0 6px 18px rgb(36 54 83 / 0.08);
+}
+
+.coach-step-num {
+  color: var(--ks-ink-muted);
+}
+
+.coach-step-title {
+  color: var(--game-ink);
+}
+
+/* Remove the remaining black chips/cards inherited from the original dark UI. */
+.game-sidebar .tag-item {
+  background: color-mix(in srgb, var(--ks-primary-soft) 62%, var(--ks-surface));
+  color: var(--game-ink);
+  border-color: color-mix(in srgb, var(--ks-primary) 26%, var(--ks-border));
+  border-radius: var(--ks-radius-pill);
+}
+
+.review-card,
+.relation-node {
+  background: var(--ks-surface);
+  color: var(--game-ink);
+  border-color: var(--ks-border);
+  box-shadow: var(--ks-shadow-low);
+}
+
+.rating-badge {
+  background: var(--ks-secondary-soft);
+  color: var(--game-ink);
+  border-color: color-mix(in srgb, var(--ks-secondary) 28%, var(--ks-border));
+}
+
+@media (max-width: 680px) {
+  .game-detail-content {
+    background: var(--ks-canvas);
+  }
+}

--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -169,6 +169,11 @@ body {
 
   .game-main {
     max-width: none;
+    order: -1;
+  }
+
+  .game-sidebar {
+    order: 0;
   }
 }
 

--- a/frontend/src/lib/curatedRuleGuides.js
+++ b/frontend/src/lib/curatedRuleGuides.js
@@ -1,0 +1,174 @@
+const GUIDES = {
+  ipso: {
+    reviewed: true,
+    ruleVersion: 'gigamic-2025-10',
+    source: {
+      label: 'Gigamic 公式ルール',
+      url: 'https://en.gigamic.com/index.php?controller=attachment&id_attachment=668',
+      ruleVersion: 'gigamic-2025-10',
+    },
+    facts: {
+      pyramidCards: 14,
+      centerChoices: 2,
+      starCardBonus: 3,
+    },
+    quick: {
+      win: '各段を左から右への昇順に整えて得点し、合計点を最も高くする。',
+      turnSteps: [
+        '中央の表向き2枚から1枚を選ぶ。',
+        '自分のピラミッドにある裏向きカード1枚と交換する。',
+        '交換で取り出したカードを表向きにして中央へ置く。',
+      ],
+      turnEndChecks: [
+        '通常手番で交換できるのは裏向きカードだけ。いったん表向きになったカードは通常手番では交換できない。',
+        '中央の2枚が好みでなくても、通常手番ではどちらか1枚を選ぶ。',
+      ],
+      end: '全員の14枚が表向きになったら最終処理へ進む。各自は星カードを残して+3点にするか、星カードを捨てて山札から1枚引き、表向きカード1枚と交換する機会を得る。全員がこの最終処理を終えるとゲーム終了。',
+    },
+    scoring: {
+      summary: '各段を個別に判定する。昇順でない段は0点。昇順の混色段は1点/枚、単色段は2点/枚。得点対象の数字カード上の星は1個につき+1点。頂点の星カードを残していればさらに+3点。',
+      rules: [
+        {
+          label: '1. 昇順か確認',
+          detail: '左から右へ数字が昇順でなければ、その段は丸ごと0点。',
+        },
+        {
+          label: '2. 色で基本点を決める',
+          detail: '昇順の段が複数色なら1点/枚、すべて同色なら2点/枚。',
+        },
+        {
+          label: '3. 星を加える',
+          detail: '得点対象の段にある数字カード上の星は1個につき+1点。頂点の星カードを残していれば最後に+3点。',
+        },
+        {
+          label: '同点処理',
+          detail: '同点なら数字カード上の星が多いプレイヤーが勝利。それでも同点なら再戦。',
+        },
+      ],
+      example: {
+        label: '公式ルールブックの得点例',
+        total: 26,
+        items: ['星カード 3点', '2枚段 4点', '3枚段 9点', '5枚段 10点'],
+      },
+    },
+    flow: [
+      { id: 'center', kind: 'step', label: '中央の表向き2枚を見る' },
+      { id: 'choose', kind: 'step', label: 'そのうち1枚を選ぶ' },
+      { id: 'swap', kind: 'step', label: '自分の裏向きカード1枚と交換する', note: '表向きカードは通常手番では交換不可' },
+      { id: 'return', kind: 'step', label: '取り出したカードを表向きにして中央へ置く' },
+      {
+        id: 'all-revealed',
+        kind: 'condition',
+        label: '全員の14枚がすべて表向き？',
+        branches: [
+          { label: 'いいえ', detail: '次のプレイヤーへ' },
+          { label: 'はい', detail: '最終処理へ' },
+        ],
+      },
+      {
+        id: 'star',
+        kind: 'choice',
+        label: '星カードをどうする？',
+        branches: [
+          { label: '残す', detail: 'ゲーム終了時 +3点' },
+          { label: '捨てる', detail: '山札から1枚引き、表向きカード1枚を交換できる' },
+        ],
+      },
+      { id: 'score', kind: 'end', label: '全員の最終処理後、得点計算して終了' },
+    ],
+  },
+  splendor: {
+    reviewed: true,
+    ruleVersion: 'space-cowboys-2024',
+    source: {
+      label: 'SPACE Cowboys / Asmodee 公式ルール',
+      url: 'https://cdn.svc.asmodee.net/production-spacecowboys/uploads/2025/12/FR_SPLENDOR_Rules.pdf',
+      ruleVersion: 'space-cowboys-2024',
+    },
+    facts: {
+      actionCount: 4,
+      endThreshold: 15,
+      tokenLimit: 10,
+    },
+    quick: {
+      win: '威信ポイントを集め、終了ラウンド後に最も高い得点を持つ。',
+      actions: [
+        '異なる色の宝石トークンを3個取る。',
+        '同じ色の宝石トークンを2個取る（その色が4個以上残っている場合）。',
+        '発展カード1枚を予約し、可能なら黄金トークン1個を取る。',
+        '発展カード1枚を購入する。',
+      ],
+      turnSteps: ['4つのアクションから1つだけ選んで実行する。'],
+      turnEndChecks: [
+        '手番終了時にトークンが10個を超えていれば、10個になるまで返す。',
+        '貴族の条件を満たしているか確認する。貴族獲得はアクションではなく、1手番につき最大1枚。',
+      ],
+      end: '手番終了時に誰かが15点以上なら終了がトリガーされる。全員の手番回数が同じになるまで続け、その後に最高得点者を決める。',
+    },
+    scoring: {
+      summary: '購入した発展カードと獲得した貴族の威信ポイントを合計する。最高得点が勝利。同点なら購入した発展カード枚数が少ない方が勝利し、それでも同点なら勝利を分かち合う。',
+      rules: [
+        { label: '威信ポイント', detail: '購入した発展カードと獲得した貴族の威信ポイントを合計する。' },
+        { label: '終了トリガー', detail: '手番終了時に15点以上へ到達するとゲーム終了がトリガーされる。' },
+        { label: '同点処理', detail: '同点者のうち購入した発展カード枚数が少ない方が勝利。それでも同点なら勝利を分かち合う。' },
+      ],
+    },
+    flow: [
+      {
+        id: 'action',
+        kind: 'choice',
+        label: '4つのアクションから1つ選ぶ',
+        branches: [
+          { label: 'A', detail: '異なる3色を取る' },
+          { label: 'B', detail: '同色2個を取る（残り4個以上）' },
+          { label: 'C', detail: 'カードを予約 + 黄金1個（あれば）' },
+          { label: 'D', detail: 'カードを1枚購入' },
+        ],
+      },
+      { id: 'token-limit', kind: 'condition', label: '手番終了時、トークンは10個以下？', branches: [{ label: 'いいえ', detail: '10個になるまで返す' }, { label: 'はい', detail: '次へ' }] },
+      { id: 'noble', kind: 'condition', label: '貴族の条件を満たした？', branches: [{ label: 'はい', detail: '貴族を1枚獲得' }, { label: 'いいえ', detail: '次へ' }] },
+      { id: 'end', kind: 'condition', label: '手番終了時に15点以上？', branches: [{ label: 'はい', detail: '全員の手番回数を揃えて終了' }, { label: 'いいえ', detail: '次のプレイヤーへ' }] },
+    ],
+  },
+}
+
+export function validateRuleGuide(guide) {
+  const errors = []
+
+  if (!guide || guide.reviewed !== true) errors.push('guide is not reviewed')
+  if (!guide?.ruleVersion) errors.push('ruleVersion is required')
+  if (!guide?.source?.url?.startsWith('https://')) errors.push('https source URL is required')
+  if (!guide?.source?.ruleVersion) errors.push('source ruleVersion is required')
+  if (guide?.ruleVersion && guide?.source?.ruleVersion && guide.ruleVersion !== guide.source.ruleVersion) {
+    errors.push('guide/source ruleVersion mismatch')
+  }
+  if (!Array.isArray(guide?.quick?.turnSteps) || guide.quick.turnSteps.length === 0) {
+    errors.push('turnSteps are required')
+  }
+  if (!guide?.quick?.end) errors.push('end summary is required')
+  if (!Array.isArray(guide?.flow) || guide.flow.length < 2) errors.push('flow requires at least two nodes')
+
+  const actionCount = guide?.facts?.actionCount
+  if (Number.isInteger(actionCount)) {
+    if (!Array.isArray(guide?.quick?.actions) || guide.quick.actions.length !== actionCount) {
+      errors.push(`action count mismatch: expected ${actionCount}`)
+    }
+  }
+
+  const endThreshold = guide?.facts?.endThreshold
+  if (Number.isInteger(endThreshold) && !String(guide?.quick?.end || '').includes(String(endThreshold))) {
+    errors.push(`end threshold ${endThreshold} missing from summary`)
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+export function getCuratedRuleGuide(slug) {
+  const guide = GUIDES[slug]
+  if (!guide) return null
+  return validateRuleGuide(guide).valid ? guide : null
+}
+
+export function listCuratedRuleGuides() {
+  return Object.entries(GUIDES).map(([slug, guide]) => ({ slug, guide }))
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,7 @@ import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import './index.css'
 import './layout.css'
+import './game-detail-palette.css'
 
 const GamePage = lazy(() => import('./pages/GamePage.jsx'))
 const DataPage = lazy(() => import('./pages/DataPage.jsx'))

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -3,11 +3,14 @@ import { useParams, Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import ReactMarkdown from 'react-markdown'
 import { api } from '../lib/api'
+import { getCuratedRuleGuide } from '../lib/curatedRuleGuides'
 import { ShareButton, TwitterShareButton } from '../components/game/ShareButtons'
 import { RegenerateButton } from '../components/game/RegenerateButton'
 import { TextToSpeech } from '../components/game/TextToSpeech'
 import { ExternalLinks } from '../components/game/ExternalLinks'
 import { InfographicsGallery } from '../components/game/InfographicsGallery'
+import { QuickRulesPanel } from '../components/game/QuickRulesPanel'
+import { RuleFlowDiagram } from '../components/game/RuleFlowDiagram'
 
 export default function GamePage({ slug: propSlug, initialGame, allGames: propAllGames }) {
   const { slug: urlSlug } = useParams()
@@ -65,6 +68,15 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
   const rules = game.rules_content || ''
   const sd = game.structured_data || {}
   const coachSourceUrl = game.official_url || game.source_url || null
+  const ruleGuide = getCuratedRuleGuide(slug)
+  const legacyInfographicsSourceUrl = game.infographics_source_url || coachSourceUrl
+  const legacyInfographicsVerified = Boolean(
+    game.infographics &&
+    game.infographics_reviewed === true &&
+    legacyInfographicsSourceUrl,
+  )
+  const hasRuleFlow = Boolean(ruleGuide?.flow?.length)
+  const hasInfographics = hasRuleFlow || legacyInfographicsVerified
 
   const pageTitle = `「${title}」のルール・戦略・インスト要約 | ボドゲのミカタ`
   const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
@@ -83,7 +95,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
       <div className="game-page-toolbar">
         <Link to="/" className="back-link" style={{ margin: 0 }}>← DIRECTORY</Link>
         <div className="header-actions">
-          <TextToSpeech text={`${title}. ${description}`} />
+          <TextToSpeech text={`${title}. ${ruleGuide?.quick?.turnSteps?.join(' ') || description}`} />
           <TwitterShareButton slug={slug} title={title} />
           <ShareButton slug={slug} />
           <RegenerateButton title={title} onRegenerate={setGame} />
@@ -164,13 +176,33 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
             )}
           </div>
 
+          <QuickRulesPanel
+            guide={ruleGuide}
+            onShowFlow={hasInfographics ? () => setActiveTab('infographics') : null}
+            onShowRules={() => setActiveTab('rules')}
+          />
+
           <div className="rules-tabs" role="tablist" aria-label="ゲーム詳細表示">
-            <button role="tab" aria-selected={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => setActiveTab('rules')}>ANALYSIS & RULES</button>
-            <button role="tab" aria-selected={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>INST COACH</button>
-            <button role="tab" aria-selected={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>STRATEGY GUIDE</button>
-            <button role="tab" aria-selected={activeTab === 'reviews'} className={activeTab === 'reviews' ? 'active' : ''} onClick={() => setActiveTab('reviews')}>SUBAGENT REVIEWS</button>
-            <button role="tab" aria-selected={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => setActiveTab('graph')}>CONNECTIONS</button>
-            {game.infographics && <button role="tab" aria-selected={activeTab === 'infographics'} className={activeTab === 'infographics' ? 'active' : ''} onClick={() => setActiveTab('infographics')}>INFOGRAPHICS</button>}
+            <button role="tab" aria-selected={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => setActiveTab('rules')}>
+              詳しいルール <span className="sr-only">ANALYSIS & RULES</span>
+            </button>
+            <button role="tab" aria-selected={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>
+              セットアップ <span className="sr-only">INST COACH</span>
+            </button>
+            <button role="tab" aria-selected={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>
+              戦略 <span className="sr-only">STRATEGY GUIDE</span>
+            </button>
+            <button role="tab" aria-selected={activeTab === 'reviews'} className={activeTab === 'reviews' ? 'active' : ''} onClick={() => setActiveTab('reviews')}>
+              レビュー <span className="sr-only">SUBAGENT REVIEWS</span>
+            </button>
+            <button role="tab" aria-selected={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => setActiveTab('graph')}>
+              関連ゲーム <span className="sr-only">CONNECTIONS</span>
+            </button>
+            {hasInfographics && (
+              <button role="tab" aria-selected={activeTab === 'infographics'} className={activeTab === 'infographics' ? 'active' : ''} onClick={() => setActiveTab('infographics')}>
+                図で見る <span className="sr-only">INFOGRAPHICS</span>
+              </button>
+            )}
           </div>
 
           <div className="pro-main-col">
@@ -184,7 +216,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
               <div className="coach-mode">
                 <div className="coach-step active">
                   <span className="coach-step-num">STEP 1</span>
-                  <div className="coach-step-title">セットアップ (Setup)</div>
+                  <div className="coach-step-title">セットアップ</div>
                   <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
                     {game.setup_summary || 'このゲーム固有のセットアップ要約は未確認です。'}
                   </div>
@@ -192,7 +224,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
 
                 <div className="coach-step">
                   <span className="coach-step-num">STEP 2</span>
-                  <div className="coach-step-title">ゲームの流れ (Gameplay)</div>
+                  <div className="coach-step-title">ゲームの流れ</div>
                   <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
                     {game.gameplay_summary || 'このゲーム固有のゲーム進行要約は未確認です。'}
                   </div>
@@ -200,7 +232,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
 
                 <div className="coach-step">
                   <span className="coach-step-num">STEP 3</span>
-                  <div className="coach-step-title">ゲーム終了 (End Game)</div>
+                  <div className="coach-step-title">ゲーム終了</div>
                   <div style={{ fontSize: '0.95rem', lineHeight: 1.6 }}>
                     {game.end_game_summary || 'このゲーム固有の終了条件要約は未確認です。'}
                   </div>
@@ -286,7 +318,19 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
               </div>
             )}
 
-            {activeTab === 'infographics' && <InfographicsGallery infographics={game.infographics} />}
+            {activeTab === 'infographics' && (
+              <div style={{ display: 'grid', gap: '1rem' }}>
+                {hasRuleFlow && <RuleFlowDiagram guide={ruleGuide} />}
+                {legacyInfographicsVerified && (
+                  <InfographicsGallery
+                    infographics={game.infographics}
+                    verified={legacyInfographicsVerified}
+                    sourceUrl={legacyInfographicsSourceUrl}
+                  />
+                )}
+              </div>
+            )}
+
             {activeTab === 'data' && <pre style={{ background: '#111', padding: '1rem', borderRadius: '8px', overflowX: 'auto' }}>{JSON.stringify(game, null, 2)}</pre>}
           </div>
         </div>

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -59,13 +59,13 @@ async function readLayout(page) {
   })
 }
 
-test('game detail keeps a readable desktop main and collapses cleanly at 800px', async ({ page }) => {
+test('game detail keeps a readable desktop main and puts quick rules before metadata at 800px', async ({ page }) => {
   await mockGameApi(page)
   await page.setViewportSize({ width: 1280, height: 900 })
   await page.goto('/games/big-shot')
 
   await expect(page.getByRole('heading', { name: 'ビッグショット' })).toBeVisible()
-  await expect(page.getByRole('tab', { name: 'ANALYSIS & RULES' })).toBeVisible()
+  await expect(page.getByRole('tab', { name: /詳しいルール/ })).toBeVisible()
 
   const desktop = await readLayout(page)
   expect(desktop.scrollWidth).toBe(desktop.clientWidth)
@@ -83,13 +83,14 @@ test('game detail keeps a readable desktop main and collapses cleanly at 800px',
   expect(compact.scrollWidth).toBe(compact.clientWidth)
   expect(Math.abs(compact.sidebar.x - compact.main.x)).toBeLessThan(2)
   expect(Math.abs(compact.sidebar.width - compact.main.width)).toBeLessThan(2)
-  expect(compact.main.y).toBeGreaterThan(compact.sidebar.y + compact.sidebar.height - 2)
+  expect(compact.sidebar.y).toBeGreaterThan(compact.main.y + compact.main.height - 2)
+  await expect(page.getByText('検証済みの要約はまだありません')).toBeVisible()
 })
 
-test('INST COACH shows only game-specific summaries and fails closed when missing', async ({ page }) => {
+test('setup tab shows only game-specific summaries and fails closed when missing', async ({ page }) => {
   await mockGameApi(page)
   await page.goto('/games/big-shot')
-  await page.getByRole('tab', { name: 'INST COACH' }).click()
+  await page.getByRole('tab', { name: /セットアップ/ }).click()
 
   await expect(page.getByText(bigShot.setup_summary)).toBeVisible()
   await expect(page.getByText(bigShot.gameplay_summary)).toBeVisible()
@@ -109,7 +110,7 @@ test('INST COACH shows only game-specific summaries and fails closed when missin
   await page.unrouteAll({ behavior: 'wait' })
   await mockGameApi(page, missing)
   await page.reload()
-  await page.getByRole('tab', { name: 'INST COACH' }).click()
+  await page.getByRole('tab', { name: /セットアップ/ }).click()
 
   await expect(page.getByText('このゲーム固有のセットアップ要約は未確認です。')).toBeVisible()
   await expect(page.getByText('このゲーム固有のゲーム進行要約は未確認です。')).toBeVisible()

--- a/frontend/tests/rule_guide.spec.js
+++ b/frontend/tests/rule_guide.spec.js
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test'
+import {
+  getCuratedRuleGuide,
+  listCuratedRuleGuides,
+  validateRuleGuide,
+} from '../src/lib/curatedRuleGuides.js'
+
+const ipso = {
+  id: 'ipso-0000-4000-8000-000000000001',
+  slug: 'ipso',
+  title: 'IPSO',
+  title_ja: 'イプソ (IPSO)',
+  min_players: 2,
+  max_players: 6,
+  play_time: 15,
+  min_age: 7,
+  published_year: 2025,
+  summary: '数字カードを昇順に並べ、色と星を活かして得点するカードゲーム。',
+  description: 'IPSO description',
+  setup_summary: '14枚で5・4・3・2枚の4段ピラミッドを作り、頂点に星カードを置く。',
+  gameplay_summary: '中央2枚から1枚を選び、裏向きカード1枚と交換する。',
+  end_game_summary: '全員が14枚を表向きにした後、星カードの最終処理を行い、全員終了で得点計算する。',
+  official_url: 'https://en.gigamic.com/index.php?controller=attachment&id_attachment=668',
+  rules_content: '# IPSO\n\n## 手番\n中央2枚から1枚選び、裏向きカードと交換します。\n\n## 終了\n全員の最終処理後に終了します。',
+  structured_data: {},
+  infographics: {
+    turn_flow: '/assets/legacy-unverified-ipso.svg',
+  },
+  infographics_reviewed: false,
+}
+
+async function mockIpsoApi(page) {
+  await page.route('**/api/**', async (route) => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/ipso') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game: ipso }) })
+      return
+    }
+    if (url.pathname === '/api/games') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [ipso], total: 1 }) })
+      return
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'not found' }) })
+  })
+}
+
+test('all production curated guides satisfy evidence and semantic contracts', () => {
+  for (const { slug, guide } of listCuratedRuleGuides()) {
+    const result = validateRuleGuide(guide)
+    expect(result.errors, `${slug}: ${result.errors.join(', ')}`).toEqual([])
+    expect(getCuratedRuleGuide(slug)).not.toBeNull()
+  }
+})
+
+test('accuracy gate rejects action-count and stale-version mismatches', () => {
+  const splendor = getCuratedRuleGuide('splendor')
+  expect(splendor).not.toBeNull()
+
+  const wrongActionCount = {
+    ...splendor,
+    quick: {
+      ...splendor.quick,
+      actions: splendor.quick.actions.slice(0, 3),
+    },
+  }
+  expect(validateRuleGuide(wrongActionCount).errors).toContain('action count mismatch: expected 4')
+
+  const stale = {
+    ...splendor,
+    ruleVersion: 'stale-version',
+  }
+  expect(validateRuleGuide(stale).errors).toContain('guide/source ruleVersion mismatch')
+})
+
+test('unreviewed guide fails closed instead of producing quick rules', () => {
+  const result = validateRuleGuide({
+    reviewed: false,
+    ruleVersion: 'x',
+    source: { url: 'https://example.com/rules', ruleVersion: 'x' },
+    quick: { turnSteps: ['step'], end: 'end' },
+    flow: [{ id: 'a' }, { id: 'b' }],
+  })
+  expect(result.valid).toBe(false)
+  expect(result.errors).toContain('guide is not reviewed')
+})
+
+test('new user can search IPSO and reach quick rules, scoring, diagram and source', async ({ page }, testInfo) => {
+  await mockIpsoApi(page)
+
+  await page.goto('/')
+  await expect(page.getByText('イプソ (IPSO)', { exact: true }).first()).toBeVisible()
+  await page.getByPlaceholder('ゲームを検索、または未登録ゲームをAI生成...').fill('IPSO')
+  await expect(page.getByText('1 RESULTS')).toBeVisible()
+  await page.screenshot({ path: testInfo.outputPath(`new-user-home-${testInfo.project.name}.png`), animations: 'disabled' })
+
+  await page.getByRole('link', { name: /イプソ \(IPSO\)/ }).first().click()
+  await expect(page).toHaveURL(/\/games\/ipso$/)
+
+  const quick = page.getByTestId('quick-rules-panel')
+  await expect(quick).toBeVisible()
+  await expect(quick.getByText('今の手番ですること')).toBeVisible()
+  await expect(quick.getByText('中央の表向き2枚から1枚を選ぶ。')).toBeVisible()
+  await expect(quick.getByText(/全員の14枚が表向き/)).toBeVisible()
+  await expect(quick.getByText('公式ルール確認済み')).toBeVisible()
+  await quick.scrollIntoViewIfNeeded()
+  await page.screenshot({ path: testInfo.outputPath(`ipso-quick-rules-${testInfo.project.name}.png`), animations: 'disabled' })
+
+  const scoring = page.getByTestId('scoring-breakdown')
+  await scoring.locator('summary').first().click()
+  await expect(scoring.getByText(/昇順でない段は0点/)).toBeVisible()
+  await expect(scoring.getByText('合計 26点')).toBeVisible()
+  await scoring.scrollIntoViewIfNeeded()
+  await page.screenshot({ path: testInfo.outputPath(`ipso-scoring-${testInfo.project.name}.png`), animations: 'disabled' })
+
+  await page.getByRole('button', { name: '図で見る', exact: true }).first().click()
+  const flow = page.getByTestId('rule-flow-diagram')
+  await expect(flow).toBeVisible()
+  await expect(flow.getByText('全員の14枚がすべて表向き？')).toBeVisible()
+  await expect(flow.getByText('星カードをどうする？')).toBeVisible()
+  await expect(flow.getByRole('link', { name: 'Gigamic 公式ルール' })).toHaveAttribute('href', ipso.official_url)
+  await expect(page.locator('.infographics-gallery')).toHaveCount(0)
+  await flow.scrollIntoViewIfNeeded()
+  await page.screenshot({ path: testInfo.outputPath(`ipso-turn-flow-${testInfo.project.name}.png`), animations: 'disabled' })
+
+  const geometry = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    quickWidth: document.querySelector('[data-testid="quick-rules-panel"]')?.getBoundingClientRect().width || 0,
+  }))
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth + 1)
+  expect(geometry.quickWidth).toBeLessThanOrEqual(geometry.clientWidth)
+})


### PR DESCRIPTION
## Summary

This implements the new-user rule-comprehension audit as one dependency-ordered vertical slice.

- #108: adds reviewed/evidence-bound curated rule guides and a semantic validation gate; unreviewed legacy infographics fail closed.
- #109: puts `勝つには？ / 今の手番 / 手番終了時 / いつ終わる？` above the detailed tabs and prioritizes game content before metadata on compact screens.
- #110: adds an expandable scoring breakdown with eligibility/bonus/tiebreak explanations and the official IPSO scoring example.
- #111: replaces text-card-only diagrams for reference games with structured accessible rule-flow nodes/conditions/branches.
- #112: adds the anonymous `search → quick rules → scoring → flow → official source` Playwright flow at 375 / 768 / 1440 with reviewable screenshots.
- fixes the game-detail palette regression where legacy `#111` / `#1a1a1a` dark-theme literals produced black cards with dark navy text under the current light KAFKA SIGNAL tokens; coach steps now use restrained light-blue / dusty-lilac / pale-pink washes with dark readable ink, and legacy black glossary/review chips are removed.

## Accuracy sources

- IPSO: Gigamic official rules (`id_attachment=668`, 10-2025 edition).
- Splendor: SPACE Cowboys / Asmodee official 2024 rules. The curated contract explicitly requires 4 turn actions and rejects a 3-action summary.

## Safety / fail-closed

- Curated guides require `reviewed=true`, HTTPS evidence, matching rule/source version, turn summary, end summary and a meaningful flow.
- Numeric/action-count invariants are tested.
- Legacy `game.infographics` are not rendered unless explicitly marked `infographics_reviewed=true` and backed by a source URL.
- Missing reviewed Quick Rules show an explicit unverified state rather than generating a guess.

## Tests

- existing `game_layout.spec.js` updated for the intentional compact-screen reading order
- new `rule_guide.spec.js` validates semantic contracts and the full new-user flow
- `UI UX regression` now gates the new spec on ux-mobile / ux-tablet / ux-desktop and uploads screenshots

Closes #108
Closes #109
Closes #110
Closes #111
Closes #112