### PR TITLE
Fix comprehensive light-palette and contrast regressions

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -111,6 +111,14 @@ jobs:
           --project=ux-tablet
           --project=ux-desktop
 
+      - name: Gate palette contrast and legacy dark-state regressions
+        working-directory: frontend
+        run: >-
+          npx playwright test tests/palette_regression.spec.js
+          --project=ux-mobile
+          --project=ux-tablet
+          --project=ux-desktop
+
       - name: Upload reviewable UI UX evidence
         if: ${{ success() || failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -57,6 +57,15 @@ jobs:
           fi
           grep -Fq "AI生成・要約を含む情報は公式資料と区別して確認してください" index.html
 
+      - name: Reject retired dark palette literals in JSX surfaces
+        working-directory: frontend
+        shell: bash
+        run: |
+          if grep -RniE --include='*.jsx' "background[^\n]*(#000([;,'\" }]|$)|#0a0a0a|#0b1221|#111([;,'\" }]|$)|#141414|#1a1a1a|#222([;,'\" }]|$)|#2a2a2a|rgba?\(0,[[:space:]]*0,[[:space:]]*0)" src; then
+            echo "Retired dark-theme background literal found in a JSX surface. Use KAFKA SIGNAL tokens/classes instead."
+            exit 1
+          fi
+
       - name: Diagnose src lint
         continue-on-error: true
         working-directory: frontend

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,8 @@
       name="keywords"
       content="ボードゲーム, ルール, セットアップ, 遊び方, ボドゲ, 検索, インスト, ゲーム情報"
     />
-    <meta name="theme-color" content="#0b1221" />
+    <meta name="theme-color" content="#FBFAF7" />
+    <meta name="color-scheme" content="light" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://bodoge-no-mikata.vercel.app/" />
     <link rel="icon" type="image/webp" href="/favicon.webp" />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,21 +5,19 @@ import { api } from './lib/api'
 function App() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
-  
+
   const [initialGames, setInitialGames] = useState([])
   const [totalGamesCount, setTotalGamesCount] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [generating, setGenerating] = useState(false)
 
-  // Filters state
   const [query, setQuery] = useState(searchParams.get('q') || '')
   const [activePlayers, setActivePlayers] = useState(null)
   const [activeTime, setActiveTime] = useState(null)
   const [activeTier, setActiveTier] = useState(null)
   const [sortOption, setSortOption] = useState('recent')
 
-  // Comparison State
   const [compareList, setCompareList] = useState([])
   const [isBattleMode, setIsBattleMode] = useState(false)
 
@@ -59,17 +57,14 @@ function App() {
     loadAllGames()
   }, [])
 
-  // Derived unique values
   const availableTiers = useMemo(() => {
     const tiers = new Set(initialGames.map(g => g.strategy_tier).filter(Boolean))
     return Array.from(tiers).sort()
   }, [initialGames])
 
-  // Filtering Logic
   const filteredGames = useMemo(() => {
     let result = [...initialGames]
 
-    // Search Query
     if (query) {
       const q = query.trim().normalize('NFKC').toLowerCase()
       result = result.filter((game) => {
@@ -81,7 +76,6 @@ function App() {
       })
     }
 
-    // Player Count Filter
     if (activePlayers) {
       const p = parseInt(activePlayers)
       result = result.filter(g => {
@@ -92,7 +86,6 @@ function App() {
       })
     }
 
-    // Play Time Filter
     if (activeTime) {
       result = result.filter(g => {
         const t = g.play_time || 0
@@ -104,12 +97,10 @@ function App() {
       })
     }
 
-    // Tier Filter
     if (activeTier) {
       result = result.filter(g => g.strategy_tier === activeTier)
     }
 
-    // Sorting
     result.sort((a, b) => {
       if (sortOption === 'recent') {
         const dateA = a.created_at ? new Date(a.created_at).getTime() : 0
@@ -137,7 +128,6 @@ function App() {
     return result
   }, [initialGames, query, activePlayers, activeTime, activeTier, sortOption])
 
-  // Sync Search Query to URL
   useEffect(() => {
     const timer = setTimeout(() => {
       if (query) {
@@ -195,9 +185,9 @@ function App() {
       <div className="game-detail-content" style={{ overflowY: 'auto', height: '100dvh', padding: '2rem' }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem' }}>
           <h1 className="game-title">COMPARISON BATTLE</h1>
-          <button className="filter-btn" style={{ borderColor: '#fff' }} onClick={() => setIsBattleMode(false)}>CLOSE BATTLE</button>
+          <button className="filter-btn" onClick={() => setIsBattleMode(false)}>CLOSE BATTLE</button>
         </div>
-        
+
         <div className="battle-grid">
           {compareList.map(game => (
             <div key={game.id} className="battle-col">
@@ -228,7 +218,7 @@ function App() {
                   </div>
                 </div>
               )}
-              
+
               <div style={{ marginTop: '2rem' }}>
                 <Link to={`/games/${game.slug}`} className="filter-btn" style={{ width: '100%', display: 'block', textDecoration: 'none' }}>VIEW FULL ANALYSIS</Link>
               </div>
@@ -245,11 +235,11 @@ function App() {
         <Link to="/" className="logo">
           <div className="logo-text">ボドゲのミカタ</div>
         </Link>
-        
+
         <form className="search-container" onSubmit={handleSearchSubmit}>
-          <input 
-            type="text" 
-            className="search-input" 
+          <input
+            type="text"
+            className="search-input"
             placeholder="ゲームを検索、または未登録ゲームをAI生成..."
             value={query}
             onChange={(e) => setQuery(e.target.value)}
@@ -267,8 +257,8 @@ function App() {
           <h3>プレイ人数</h3>
           <div className="filter-grid">
             {['1', '2', '3', '4', '5+'].map(p => (
-              <button 
-                key={p} 
+              <button
+                key={p}
                 className={`filter-btn ${activePlayers === p ? 'active' : ''}`}
                 onClick={() => setActivePlayers(activePlayers === p ? null : p)}
               >
@@ -287,8 +277,8 @@ function App() {
               { id: '60-120', label: '60-120分' },
               { id: '120+', label: '120分以上' }
             ].map(t => (
-              <button 
-                key={t.id} 
+              <button
+                key={t.id}
                 className={`filter-btn ${activeTime === t.id ? 'active' : ''}`}
                 onClick={() => setActiveTime(activeTime === t.id ? null : t.id)}
               >
@@ -303,8 +293,8 @@ function App() {
             <h3>戦略ティア</h3>
             <div className="filter-grid">
               {availableTiers.map(t => (
-                <button 
-                  key={t} 
+                <button
+                  key={t}
                   className={`filter-btn ${activeTier === t ? 'active' : ''}`}
                   onClick={() => setActiveTier(activeTier === t ? null : t)}
                 >
@@ -316,8 +306,8 @@ function App() {
         )}
 
         <div className="filter-section">
-          <button 
-            className="filter-btn" 
+          <button
+            className="filter-btn"
             style={{ width: '100%', borderColor: 'var(--accent-secondary)' }}
             onClick={clearFilters}
           >
@@ -336,10 +326,10 @@ function App() {
             {activeTime && <div className="filter-chip">時間: {activeTime} <button onClick={() => setActiveTime(null)}>×</button></div>}
             {activeTier && <div className="filter-chip">Tier: {activeTier} <button onClick={() => setActiveTier(null)}>×</button></div>}
           </div>
-          
-          <select 
-            className="sort-select" 
-            value={sortOption} 
+
+          <select
+            className="sort-select"
+            value={sortOption}
             onChange={(e) => setSortOption(e.target.value)}
           >
             <option value="recent">最近追加</option>
@@ -349,11 +339,11 @@ function App() {
           </select>
         </div>
 
-        {error && <div style={{ color: '#ff4444', padding: '1rem', background: '#2a0000', borderRadius: '8px' }}>{error}</div>}
-        {generating && <div style={{ padding: '1rem', background: '#1a1a1a', borderRadius: '8px', border: '1px solid #444', color: '#aaa', textAlign: 'center' }}>AIが新しいゲーム情報を生成しています...</div>}
+        {error && <div className="app-feedback app-feedback--error" role="alert">{error}</div>}
+        {generating && <div className="app-feedback app-feedback--progress" role="status">AIが新しいゲーム情報を生成しています...</div>}
 
         {loading ? (
-          <div style={{ textAlign: 'center', padding: '2rem', color: '#666' }}>ARCHIVE INITIALIZING...</div>
+          <div className="app-loading-state" role="status">ARCHIVE INITIALIZING...</div>
         ) : (
           <div className="asset-grid">
             {filteredGames.map(game => (
@@ -361,9 +351,9 @@ function App() {
                 <Link to={`/games/${game.slug}`} className="asset-card" style={{ height: '100%' }}>
                   <div className="asset-thumb-container">
                     {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
-                    <img 
-                      src={game.image_url || '/assets/no-image.webp'} 
-                      alt={game.title_ja || game.title} 
+                    <img
+                      src={game.image_url || '/assets/no-image.webp'}
+                      alt={game.title_ja || game.title}
                       className="asset-thumb"
                       loading="lazy"
                     />
@@ -378,7 +368,7 @@ function App() {
                     <div className="asset-summary">{game.summary || game.description}</div>
                   </div>
                 </Link>
-                <button 
+                <button
                   onClick={(e) => { e.preventDefault(); toggleCompare(game); }}
                   className={`filter-btn ${compareList.find(g => g.id === game.id) ? 'active' : ''}`}
                   style={{ position: 'absolute', top: '8px', right: '8px', zIndex: 10, padding: '4px 8px', fontSize: '0.65rem' }}
@@ -388,17 +378,17 @@ function App() {
               </div>
             ))}
             {filteredGames.length === 0 && !loading && (
-              <div style={{ gridColumn: '1 / -1', textAlign: 'center', padding: '3rem', color: '#666' }}>
+              <div className="app-empty-state">
                 条件に一致するゲームが見つかりません。
               </div>
             )}
           </div>
         )}
-        
+
         {!loading && initialGames.length < totalGamesCount && (
           <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <button 
-              className="filter-btn" 
+            <button
+              className="filter-btn"
               style={{ padding: '10px 24px', fontSize: '0.9rem', borderColor: 'var(--accent)' }}
               onClick={handleLoadMore}
             >
@@ -410,7 +400,7 @@ function App() {
 
       {compareList.length > 0 && (
         <div className="comparison-tray">
-          <div style={{ fontSize: '0.75rem', fontWeight: 700, color: '#666' }}>BATTLE TRAY</div>
+          <div className="comparison-tray__label" style={{ fontSize: '0.75rem', fontWeight: 700 }}>BATTLE TRAY</div>
           {compareList.map(g => (
             <div key={g.id} className="compare-item">
               <img src={g.image_url || '/assets/no-image.webp'} style={{ width: '100%', height: '100%', objectFit: 'cover' }} alt="Compare Item" />
@@ -418,8 +408,8 @@ function App() {
             </div>
           ))}
           {compareList.length >= 2 && (
-            <button 
-              className="filter-btn active" 
+            <button
+              className="filter-btn active"
               style={{ padding: '6px 16px', borderRadius: '20px' }}
               onClick={() => setIsBattleMode(true)}
             >

--- a/frontend/src/components/EditGameModal.jsx
+++ b/frontend/src/components/EditGameModal.jsx
@@ -78,7 +78,7 @@ export default function EditGameModal({ game, isOpen, onClose, onSave }) {
       <div className="modal-content" onClick={(e) => e.stopPropagation()}>
         <div className="modal-header">
           <h3>ゲーム情報を編集</h3>
-          <button className="close-btn" onClick={onClose}>
+          <button className="close-btn" onClick={onClose} aria-label="編集画面を閉じる">
             &times;
           </button>
         </div>
@@ -97,51 +97,26 @@ export default function EditGameModal({ game, isOpen, onClose, onSave }) {
           <div className="form-row">
             <div className="form-group">
               <label>最小人数</label>
-              <input
-                type="number"
-                name="min_players"
-                value={formData.min_players}
-                onChange={handleChange}
-              />
+              <input type="number" name="min_players" value={formData.min_players} onChange={handleChange} />
             </div>
             <div className="form-group">
               <label>最大人数</label>
-              <input
-                type="number"
-                name="max_players"
-                value={formData.max_players}
-                onChange={handleChange}
-              />
+              <input type="number" name="max_players" value={formData.max_players} onChange={handleChange} />
             </div>
             <div className="form-group">
               <label>プレイ時間(分)</label>
-              <input
-                type="number"
-                name="play_time"
-                value={formData.play_time}
-                onChange={handleChange}
-              />
+              <input type="number" name="play_time" value={formData.play_time} onChange={handleChange} />
             </div>
           </div>
 
           <div className="form-row">
             <div className="form-group">
               <label>対象年齢</label>
-              <input
-                type="number"
-                name="min_age"
-                value={formData.min_age}
-                onChange={handleChange}
-              />
+              <input type="number" name="min_age" value={formData.min_age} onChange={handleChange} />
             </div>
             <div className="form-group">
               <label>発行年</label>
-              <input
-                type="number"
-                name="published_year"
-                value={formData.published_year}
-                onChange={handleChange}
-              />
+              <input type="number" name="published_year" value={formData.published_year} onChange={handleChange} />
             </div>
           </div>
 
@@ -152,51 +127,26 @@ export default function EditGameModal({ game, isOpen, onClose, onSave }) {
 
           <div className="form-group">
             <label>詳細説明 (Description)</label>
-            <textarea
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              rows={5}
-            />
+            <textarea name="description" value={formData.description} onChange={handleChange} rows={5} />
           </div>
 
           <div className="form-group">
             <label>ルール詳細 (Rules Content Markdown)</label>
-            <textarea
-              name="rules_content"
-              value={formData.rules_content}
-              onChange={handleChange}
-              rows={8}
-            />
+            <textarea name="rules_content" value={formData.rules_content} onChange={handleChange} rows={8} />
           </div>
 
           <div className="form-group">
             <label>キーワード (Keywords)</label>
             <div style={{ marginBottom: '10px' }}>
               {(formData.structured_data?.keywords || []).map((k, i) => (
-                <div
-                  key={i}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: '10px',
-                    marginBottom: '5px',
-                  }}
-                >
-                  <input
-                    readOnly
-                    value={k.term}
-                    style={{ width: '120px', background: '#f5f5f5' }}
-                  />
-                  <input
-                    readOnly
-                    value={k.description}
-                    style={{ flex: 1, background: '#f5f5f5' }}
-                  />
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '5px' }}>
+                  <input readOnly value={k.term} style={{ width: '120px' }} />
+                  <input readOnly value={k.description} style={{ flex: 1 }} />
                   <button
                     type="button"
                     onClick={() => handleRemoveKeyword(i)}
-                    style={{ color: 'red', border: 'none', background: 'none', cursor: 'pointer' }}
+                    className="keyword-remove-button"
+                    aria-label={`${k.term || 'キーワード'}を削除`}
                   >
                     ×
                   </button>
@@ -216,12 +166,7 @@ export default function EditGameModal({ game, isOpen, onClose, onSave }) {
                 onChange={(e) => setNewKeyword({ ...newKeyword, description: e.target.value })}
                 style={{ flex: 1 }}
               />
-              <button
-                type="button"
-                onClick={handleAddKeyword}
-                className="btn-secondary"
-                style={{ padding: '0 15px' }}
-              >
+              <button type="button" onClick={handleAddKeyword} className="btn-secondary" style={{ padding: '0 15px' }}>
                 追加
               </button>
             </div>

--- a/frontend/src/components/LoadingFallback.jsx
+++ b/frontend/src/components/LoadingFallback.jsx
@@ -1,15 +1,7 @@
 export default function LoadingFallback() {
   return (
-    <div
-      style={{
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        minHeight: '100vh',
-        background: 'var(--bg-primary, #0b1221)',
-      }}
-    >
-      <p style={{ color: 'var(--text-primary, #fff)' }}>読み込み中...</p>
+    <div className="loading-fallback" role="status" aria-live="polite">
+      <p>読み込み中...</p>
     </div>
   )
 }

--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -18,12 +18,7 @@ export const ExternalLinks = ({ game }) => {
     { url: yahoo, label: 'Yahoo!で見る', class: 'yahoo' },
     { url: official_url, label: '公式サイト', class: 'official' },
     { url: bgg_url, label: 'BoardGameGeek', class: 'bgg' },
-    {
-      url: game.bga_url,
-      label: 'Board Game Arena',
-      class: 'bga',
-      style: { backgroundColor: '#000', color: '#fff' },
-    },
+    { url: game.bga_url, label: 'Board Game Arena', class: 'bga' },
   ].filter((link) => isValidUrl(link.url))
 
   if (links.length === 0) return null
@@ -38,8 +33,7 @@ export const ExternalLinks = ({ game }) => {
             href={link.url}
             target="_blank"
             rel="noopener noreferrer sponsored"
-            className={`link-button ${link.class} `}
-            style={link.style || {}}
+            className={`link-button ${link.class}`}
           >
             {link.label}
           </a>

--- a/frontend/src/components/game/TextToSpeech.jsx
+++ b/frontend/src/components/game/TextToSpeech.jsx
@@ -23,8 +23,8 @@ export const TextToSpeech = ({ text }) => {
 
     const utterance = new SpeechSynthesisUtterance(text)
     utterance.lang = 'ja-JP'
-    utterance.rate = 0.9 // Slower for clarity
-    utterance.pitch = 1.0 // Neutral pitch
+    utterance.rate = 0.9
+    utterance.pitch = 1.0
     utterance.onend = () => setSpeaking(false)
     utterance.onerror = () => setSpeaking(false)
 
@@ -40,7 +40,7 @@ export const TextToSpeech = ({ text }) => {
       className={`share-btn ${speaking ? 'speaking' : ''}`}
       title={speaking ? '読み上げ停止' : '読み上げ開始'}
       aria-label="Text to speech"
-      style={speaking ? { backgroundColor: '#e7f5ff', color: '#007bff' } : {}}
+      aria-pressed={speaking}
     >
       {speaking ? '⏹️ 停止' : '🔊 読上'}
     </button>

--- a/frontend/src/components/game/rule-guide.css
+++ b/frontend/src/components/game/rule-guide.css
@@ -1,10 +1,11 @@
 .quick-rules-panel {
   margin: 0 0 1.5rem;
   padding: 1rem;
-  border: 1px solid #c8d2df;
-  border-radius: 12px;
-  background: #ffffff;
-  color: #1d3150;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface);
+  color: var(--ks-ink);
+  box-shadow: var(--ks-shadow-low);
 }
 
 .quick-rules-header {
@@ -19,7 +20,7 @@
   font-size: 0.72rem;
   font-weight: 800;
   letter-spacing: 0.08em;
-  color: #53647c;
+  color: var(--ks-ink-muted);
   text-transform: uppercase;
   margin-bottom: 0.25rem;
 }
@@ -28,15 +29,15 @@
   font-family: var(--font-heading);
   font-size: 1.35rem;
   line-height: 1.2;
-  color: #172c4b;
+  color: var(--ks-ink);
 }
 
 .rule-verified-badge {
   flex: 0 0 auto;
-  border: 1px solid #2e6a45;
-  background: #143c28;
-  color: #f4fff7;
-  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--ks-verified) 48%, var(--ks-border));
+  background: var(--ks-verified-soft);
+  color: var(--ks-verified);
+  border-radius: var(--ks-radius-pill);
   padding: 0.35rem 0.65rem;
   font-size: 0.72rem;
   font-weight: 700;
@@ -49,21 +50,21 @@
 }
 
 .quick-rule-card {
-  border: 1px solid #ccd5e1;
-  border-radius: 10px;
-  background: #f8fafc;
-  color: #1d3150;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink);
   padding: 0.9rem;
   min-width: 0;
 }
 
 .quick-rule-card--primary {
-  border-color: #9fb1c8;
-  background: #f2f6fb;
+  border-color: color-mix(in srgb, var(--ks-primary) 38%, var(--ks-border));
+  background: color-mix(in srgb, var(--ks-primary-soft) 56%, var(--ks-surface));
 }
 
 .quick-rule-label {
-  color: #405674;
+  color: var(--ks-ink-muted);
   font-size: 0.78rem;
   font-weight: 800;
   margin-bottom: 0.55rem;
@@ -71,7 +72,7 @@
 
 .quick-rule-card p,
 .quick-rule-card li {
-  color: #1d3150;
+  color: var(--ks-ink);
   font-size: 0.92rem;
   line-height: 1.6;
   overflow-wrap: anywhere;
@@ -100,7 +101,7 @@
   position: absolute;
   left: 0;
   top: 0;
-  color: #9a5b00;
+  color: var(--ks-attention);
   font-weight: 900;
 }
 
@@ -112,10 +113,10 @@
 }
 
 .quick-rule-action {
-  border: 1px solid #9fb0c5;
-  background: #f6f8fb;
-  color: #1d3150;
-  border-radius: 7px;
+  border: 1px solid var(--ks-border);
+  background: var(--ks-surface);
+  color: var(--ks-primary);
+  border-radius: var(--ks-radius-md);
   padding: 0.55rem 0.75rem;
   font-size: 0.82rem;
   font-weight: 700;
@@ -125,47 +126,49 @@
 
 .quick-rule-action:hover,
 .quick-rule-action:focus-visible {
-  border-color: #1d3150;
-  background: #eef3f9;
+  border-color: var(--ks-primary);
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
   outline: 2px solid transparent;
 }
 
 .quick-rules-source {
   margin-top: 0.9rem;
   font-size: 0.76rem;
-  color: #596b82;
+  color: var(--ks-ink-muted);
 }
 
 .quick-rules-source a {
-  color: #294c7a;
+  color: var(--ks-primary);
 }
 
 .quick-rules-unavailable {
   border-style: dashed;
-  color: #405674;
+  background: var(--ks-unavailable-soft);
+  color: var(--ks-unavailable);
 }
 
 .quick-rules-unavailable p {
-  color: #405674;
+  color: var(--ks-unavailable);
 }
 
 .scoring-breakdown {
   margin-top: 1rem;
-  border-top: 1px solid #d5dce6;
+  border-top: 1px solid var(--ks-border);
   padding-top: 1rem;
-  color: #1d3150;
+  color: var(--ks-ink);
 }
 
 .scoring-breakdown > summary {
   cursor: pointer;
   font-weight: 800;
   font-size: 0.95rem;
-  color: #1d3150;
+  color: var(--ks-ink);
 }
 
 .scoring-summary {
   margin: 0.8rem 0;
-  color: #405674;
+  color: var(--ks-ink-muted);
   line-height: 1.6;
 }
 
@@ -175,22 +178,22 @@
 }
 
 .scoring-rule {
-  border: 1px solid #ccd5e1;
-  border-radius: 8px;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
   padding: 0.7rem 0.8rem;
-  background: #f8fafc;
-  color: #1d3150;
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink);
 }
 
 .scoring-rule summary {
   cursor: pointer;
   font-weight: 700;
-  color: #1d3150;
+  color: var(--ks-ink);
 }
 
 .scoring-rule p {
   margin-top: 0.45rem;
-  color: #405674;
+  color: var(--ks-ink-muted);
   line-height: 1.55;
   font-size: 0.88rem;
 }
@@ -198,33 +201,34 @@
 .scoring-example {
   margin-top: 0.8rem;
   padding: 0.8rem;
-  border-radius: 8px;
-  background: #f3f7fb;
-  border: 1px solid #ccd5e1;
-  color: #1d3150;
+  border-radius: var(--ks-radius-md);
+  background: color-mix(in srgb, var(--ks-primary-soft) 48%, var(--ks-surface));
+  border: 1px solid color-mix(in srgb, var(--ks-primary) 28%, var(--ks-border));
+  color: var(--ks-ink);
 }
 
 .scoring-example-total {
   font-size: 1.35rem;
   font-weight: 900;
   margin: 0.25rem 0 0.5rem;
-  color: #172c4b;
+  color: var(--ks-ink);
 }
 
 .scoring-example ul {
   list-style: none;
   display: grid;
   gap: 0.2rem;
-  color: #405674;
+  color: var(--ks-ink-muted);
   font-size: 0.85rem;
 }
 
 .rule-flow {
-  border: 1px solid #c8d2df;
-  border-radius: 12px;
-  background: #ffffff;
-  color: #1d3150;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface);
+  color: var(--ks-ink);
   padding: 1rem;
+  box-shadow: var(--ks-shadow-low);
 }
 
 .rule-flow-header {
@@ -238,7 +242,7 @@
 .rule-flow-title {
   font-family: var(--font-heading);
   font-size: 1.35rem;
-  color: #172c4b;
+  color: var(--ks-ink);
 }
 
 .rule-flow-list {
@@ -250,11 +254,11 @@
 
 .rule-flow-node {
   position: relative;
-  border: 1px solid #ccd5e1;
-  border-radius: 10px;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
   padding: 0.9rem 0.9rem 0.9rem 3rem;
-  background: #f8fafc;
-  color: #1d3150;
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink);
 }
 
 .rule-flow-node:not(:last-child)::after {
@@ -263,7 +267,7 @@
   left: 1.25rem;
   bottom: -1.05rem;
   z-index: 2;
-  color: #5a6e87;
+  color: var(--ks-ink-muted);
   font-weight: 900;
 }
 
@@ -276,32 +280,32 @@
   display: grid;
   place-items: center;
   border-radius: 50%;
-  background: #1d3150;
-  color: #ffffff;
+  background: var(--ks-primary);
+  color: var(--ks-surface);
   font-size: 0.72rem;
   font-weight: 800;
 }
 
 .rule-flow-node--condition,
 .rule-flow-node--choice {
-  border-color: #c9aa6a;
-  background: #fffaf0;
+  border-color: color-mix(in srgb, var(--ks-estimated) 38%, var(--ks-border));
+  background: var(--ks-estimated-soft);
 }
 
 .rule-flow-node--end {
-  border-color: #77a387;
-  background: #f2faf4;
+  border-color: color-mix(in srgb, var(--ks-verified) 36%, var(--ks-border));
+  background: var(--ks-verified-soft);
 }
 
 .rule-flow-node-label {
-  color: #1d3150;
+  color: var(--ks-ink);
   font-weight: 800;
   line-height: 1.45;
 }
 
 .rule-flow-node-note {
   margin-top: 0.4rem;
-  color: #7a4500;
+  color: var(--ks-attention);
   font-size: 0.82rem;
   line-height: 1.5;
   font-weight: 650;
@@ -316,22 +320,22 @@
 
 .rule-flow-branch {
   padding: 0.6rem;
-  border: 1px solid #c9d3df;
-  border-radius: 7px;
-  background: #ffffff;
-  color: #1d3150;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface);
+  color: var(--ks-ink);
   min-width: 0;
 }
 
 .rule-flow-branch strong {
   display: block;
   font-size: 0.76rem;
-  color: #405674;
+  color: var(--ks-ink-muted);
   margin-bottom: 0.25rem;
 }
 
 .rule-flow-branch span {
-  color: #1d3150;
+  color: var(--ks-ink);
   font-size: 0.86rem;
   line-height: 1.45;
   overflow-wrap: anywhere;
@@ -340,11 +344,11 @@
 .rule-flow-source {
   margin-top: 1rem;
   font-size: 0.78rem;
-  color: #596b82;
+  color: var(--ks-ink-muted);
 }
 
 .rule-flow-source a {
-  color: #294c7a;
+  color: var(--ks-primary);
 }
 
 .sr-only {

--- a/frontend/src/game-detail-palette.css
+++ b/frontend/src/game-detail-palette.css
@@ -1,19 +1,21 @@
-/* Game detail palette repair.
-   The legacy game page still contains dark-theme literals in index.css.
-   Keep this layer after layout.css so KAFKA SIGNAL's light product palette wins. */
+/* Game-detail color system.
+   This file is intentionally token-only so detail states cannot drift back to the retired dark palette. */
 
 .game-detail-content {
-  --game-wash-blue: #eaf4ff;
-  --game-wash-lilac: #f0ebfa;
-  --game-wash-pink: #fcebf1;
   --game-ink: var(--ks-ink);
+  --game-wash-blue: color-mix(in srgb, var(--ks-primary-soft) 72%, var(--ks-surface));
+  --game-wash-lilac: color-mix(in srgb, var(--ks-secondary-soft) 72%, var(--ks-surface));
+  --game-wash-pink: color-mix(in srgb, var(--ks-accent-soft) 72%, var(--ks-surface));
   background:
-    radial-gradient(circle at 78% 0%, rgb(240 235 250 / 0.46), transparent 30rem),
+    radial-gradient(
+      circle at 78% 0%,
+      color-mix(in srgb, var(--ks-secondary-soft) 46%, transparent),
+      transparent 30rem
+    ),
     var(--ks-canvas);
   color: var(--game-ink);
 }
 
-/* Tabs should read as a light editorial control, not a dark dashboard. */
 .rules-tabs button {
   color: var(--ks-ink-muted);
 }
@@ -29,12 +31,10 @@
   color: var(--game-ink);
 }
 
-/* The old coach cards used #111 with dark navy text after the light-theme token swap.
-   Use three restrained pastel washes while keeping all copy on the high-contrast ink. */
 .coach-step {
   --coach-accent: var(--ks-primary);
   --coach-soft: var(--game-wash-blue);
-  background: color-mix(in srgb, var(--coach-soft) 74%, var(--ks-surface));
+  background: var(--coach-soft);
   color: var(--game-ink);
   border: 1px solid color-mix(in srgb, var(--coach-accent) 32%, var(--ks-border));
   border-left: 4px solid var(--coach-accent);
@@ -52,7 +52,6 @@
 }
 
 .coach-step.active {
-  background: var(--coach-soft);
   border-color: color-mix(in srgb, var(--coach-accent) 58%, var(--ks-border));
   border-left-color: var(--coach-accent);
   box-shadow: 0 6px 18px rgb(36 54 83 / 0.08);
@@ -66,7 +65,6 @@
   color: var(--game-ink);
 }
 
-/* Remove the remaining black chips/cards inherited from the original dark UI. */
 .game-sidebar .tag-item {
   background: color-mix(in srgb, var(--ks-primary-soft) 62%, var(--ks-surface));
   color: var(--game-ink);
@@ -86,6 +84,56 @@
   background: var(--ks-secondary-soft);
   color: var(--game-ink);
   border-color: color-mix(in srgb, var(--ks-secondary) 28%, var(--ks-border));
+}
+
+.pro-card--synopsis {
+  border-left: 4px solid var(--ks-primary);
+}
+
+.game-empty-state,
+.game-data-dump {
+  padding: 1.25rem;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink-muted);
+  box-shadow: var(--ks-shadow-low);
+}
+
+.game-empty-state {
+  min-height: 6rem;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  line-height: 1.65;
+}
+
+.game-empty-note {
+  padding: 0.625rem 0;
+  color: var(--ks-ink-muted);
+  font-size: 0.82rem;
+}
+
+.game-data-dump {
+  overflow-x: auto;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  font-family: var(--ks-font-mono);
+  font-size: 0.78rem;
+}
+
+.page-state {
+  min-height: 40vh;
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+  text-align: center;
+  background: var(--ks-canvas);
+  color: var(--ks-ink-muted);
+}
+
+.page-state--error {
+  color: var(--ks-rejected);
 }
 
 @media (max-width: 680px) {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,15 +1,16 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@500;700;900&display=swap');
 
+/* Legacy class names remain for compatibility, but every color resolves through KAFKA SIGNAL. */
 :root {
-  --bg-dark: #0a0a0a;
-  --bg-card: #141414;
-  --border-color: #2a2a2a;
-  --border-hover: #555555;
-  --text-primary: #ffffff;
-  --text-secondary: #a0a0a0;
-  --text-muted: #666666;
-  --accent: #ffffff;
-  --accent-secondary: #aaaaaa;
+  --bg-dark: var(--ks-canvas);
+  --bg-card: var(--ks-surface);
+  --border-color: var(--ks-border);
+  --border-hover: var(--ks-primary);
+  --text-primary: var(--ks-ink);
+  --text-secondary: var(--ks-ink-muted);
+  --text-muted: var(--ks-ink-muted);
+  --accent: var(--ks-primary);
+  --accent-secondary: var(--ks-secondary);
   --font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-heading: 'Outfit', sans-serif;
 }
@@ -37,7 +38,7 @@ body {
 /* Header */
 header {
   grid-area: header;
-  background: var(--bg-dark);
+  background: var(--bg-card);
   border-bottom: 1px solid var(--border-color);
   padding: 0.75rem 1.5rem;
   display: flex;
@@ -70,11 +71,11 @@ header {
 
 .search-input {
   width: 100%;
-  background: #1a1a1a;
+  background: var(--ks-surface);
   border: 1px solid var(--border-color);
   border-radius: 8px;
   padding: 0.6rem 1rem;
-  color: #ffffff;
+  color: var(--ks-ink);
   font-size: 0.9rem;
   outline: none;
   transition: all 0.2s ease;
@@ -91,7 +92,8 @@ header {
   font-size: 0.8rem;
   font-weight: 600;
   padding: 6px 12px;
-  background: #1a1a1a;
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
   border: 1px solid var(--border-color);
   border-radius: 6px;
 }
@@ -99,7 +101,7 @@ header {
 /* Sidebar */
 aside {
   grid-area: sidebar;
-  background: var(--bg-dark);
+  background: var(--ks-surface-subtle);
   border-right: 1px solid var(--border-color);
   padding: 1.5rem;
   overflow-y: auto;
@@ -124,7 +126,7 @@ aside {
 }
 
 .filter-btn {
-  background: #1a1a1a;
+  background: var(--ks-surface);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 6px 8px;
@@ -137,14 +139,15 @@ aside {
 }
 
 .filter-btn:hover {
-  border-color: var(--text-secondary);
-  color: #ffffff;
+  background: var(--ks-primary-soft);
+  border-color: var(--ks-primary);
+  color: var(--ks-primary);
 }
 
 .filter-btn.active {
-  background: #2a2a2a;
-  border-color: #ffffff;
-  color: #ffffff;
+  background: var(--ks-primary);
+  border-color: var(--ks-primary);
+  color: var(--ks-surface);
 }
 
 .tag-cloud {
@@ -178,8 +181,9 @@ main {
 }
 
 .filter-chip {
-  background: #1a1a1a;
-  border: 1px solid var(--border-color);
+  background: var(--ks-secondary-soft);
+  color: var(--ks-secondary);
+  border: 1px solid color-mix(in srgb, var(--ks-secondary) 32%, var(--ks-border));
   border-radius: 4px;
   padding: 4px 8px;
   font-size: 0.75rem;
@@ -191,20 +195,20 @@ main {
 .filter-chip button {
   background: none;
   border: none;
-  color: var(--text-muted);
+  color: currentColor;
   cursor: pointer;
 }
 
 .filter-chip button:hover {
-  color: #fff;
+  color: var(--ks-ink);
 }
 
 .sort-select {
-  background: #1a1a1a;
+  background: var(--ks-surface);
   border: 1px solid var(--border-color);
   border-radius: 6px;
   padding: 6px 12px;
-  color: #ffffff;
+  color: var(--ks-ink);
   font-size: 0.8rem;
   outline: none;
   cursor: pointer;
@@ -233,14 +237,14 @@ main {
 
 .asset-card:hover {
   transform: translateY(-4px);
-  border-color: var(--text-secondary);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+  border-color: var(--ks-primary);
+  box-shadow: 0 8px 24px rgb(36 54 83 / 0.12);
 }
 
 .asset-thumb-container {
   width: 100%;
   aspect-ratio: 4/3;
-  background: #000;
+  background: var(--ks-surface-subtle);
   overflow: hidden;
   position: relative;
 }
@@ -260,9 +264,9 @@ main {
   position: absolute;
   top: 8px;
   left: 8px;
-  background: rgba(0, 0, 0, 0.8);
-  border: 1px solid var(--border-color);
-  color: #fff;
+  background: var(--ks-secondary);
+  border: 1px solid var(--ks-secondary);
+  color: var(--ks-surface);
   padding: 2px 8px;
   border-radius: 4px;
   font-size: 0.7rem;
@@ -299,10 +303,10 @@ main {
   display: flex;
   align-items: center;
   gap: 4px;
-  background: #1a1a1a;
+  background: transparent;
   padding: 2px 6px;
   border-radius: 4px;
-  border: 1px solid var(--border-color);
+  border: 0;
 }
 
 .asset-summary {
@@ -315,44 +319,50 @@ main {
   margin-top: auto;
 }
 
-/* --- Game Page Styles (Zero-Fat) --- */
+/* --- Game Page Styles --- */
 .game-detail-content {
   padding: 2rem;
   max-width: 1200px;
   margin: 0 auto;
 }
+
 .game-hero-image {
   width: 100%;
   height: 300px;
   border-radius: 12px;
   overflow: hidden;
   margin-bottom: 2rem;
-  background: #000;
+  background: var(--ks-surface-subtle);
   border: 1px solid var(--border-color);
 }
+
 .game-hero-image img {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  opacity: 0.8;
 }
+
 .game-content {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   margin-bottom: 2rem;
 }
+
 .game-title {
   font-family: var(--font-heading);
   font-size: 2.5rem;
   font-weight: 900;
   color: var(--text-primary);
 }
+
 .header-actions {
   display: flex;
   gap: 8px;
 }
-.header-actions button, .header-actions a {
+
+.header-actions button,
+.header-actions a {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
   color: var(--text-primary);
@@ -364,10 +374,14 @@ main {
   font-size: 0.85rem;
   transition: all 0.2s ease;
 }
-.header-actions button:hover, .header-actions a:hover {
-  background: #2a2a2a;
-  border-color: var(--text-secondary);
+
+.header-actions button:hover,
+.header-actions a:hover {
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
+  border-color: var(--ks-primary);
 }
+
 .info-section {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
@@ -375,16 +389,19 @@ main {
   border-radius: 8px;
   margin-bottom: 2rem;
 }
+
 .info-section h3 {
   font-size: 0.9rem;
   color: var(--text-secondary);
   text-transform: uppercase;
   margin-bottom: 1rem;
 }
+
 .summary-text {
   font-size: 1.1rem;
   line-height: 1.6;
 }
+
 .rules-tabs {
   display: flex;
   gap: 8px;
@@ -392,6 +409,7 @@ main {
   margin-bottom: 1.5rem;
   padding-bottom: 8px;
 }
+
 .rules-tabs button {
   background: transparent;
   border: none;
@@ -402,18 +420,22 @@ main {
   border-radius: 6px;
   transition: all 0.2s ease;
 }
+
 .rules-tabs button.active {
-  background: var(--text-primary);
-  color: var(--bg-dark);
+  background: var(--ks-primary-soft);
+  color: var(--ks-ink);
 }
+
 .rules-tabs button:hover:not(.active) {
-  background: var(--bg-card);
-  color: var(--text-primary);
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink);
 }
+
 .markdown-content {
   line-height: 1.8;
   font-size: 1.05rem;
 }
+
 .markdown-content h2 {
   margin-top: 2rem;
   margin-bottom: 1rem;
@@ -421,14 +443,18 @@ main {
   border-bottom: 1px solid var(--border-color);
   color: var(--accent);
 }
+
 .markdown-content h3 {
   margin-top: 1.5rem;
   margin-bottom: 1rem;
 }
-.markdown-content ul, .markdown-content ol {
+
+.markdown-content ul,
+.markdown-content ol {
   padding-left: 1.5rem;
   margin-bottom: 1rem;
 }
+
 .back-link {
   display: inline-block;
   margin-bottom: 1rem;
@@ -436,8 +462,9 @@ main {
   text-decoration: none;
   font-weight: 600;
 }
+
 .back-link:hover {
-  color: var(--text-primary);
+  color: var(--ks-primary);
 }
 
 /* --- Pro Dashboard / High-Density Layout --- */
@@ -447,6 +474,7 @@ main {
   gap: 12px;
   margin-bottom: 2rem;
 }
+
 .pro-stat-card {
   background: var(--bg-card);
   border: 1px solid var(--border-color);
@@ -454,6 +482,7 @@ main {
   border-radius: 8px;
   text-align: center;
 }
+
 .pro-stat-label {
   font-size: 0.7rem;
   color: var(--text-muted);
@@ -461,6 +490,7 @@ main {
   letter-spacing: 0.5px;
   margin-bottom: 4px;
 }
+
 .pro-stat-value {
   font-size: 1.1rem;
   font-weight: 700;
@@ -472,6 +502,7 @@ main {
   grid-template-columns: 2fr 1fr;
   gap: 2rem;
 }
+
 @media (max-width: 900px) {
   .pro-section-grid {
     grid-template-columns: 1fr;
@@ -485,6 +516,7 @@ main {
   padding: 1.5rem;
   margin-bottom: 1.5rem;
 }
+
 .pro-card-title {
   font-size: 0.9rem;
   font-weight: 700;
@@ -503,18 +535,19 @@ main {
   font-size: 0.9rem;
   color: var(--text-primary);
 }
+
 .tip-bullet {
   color: var(--accent);
   font-weight: bold;
 }
 
 .mistake-item {
-  background: rgba(255, 68, 68, 0.05);
-  border-left: 3px solid #ff4444;
+  background: var(--ks-rejected-soft);
+  border-left: 3px solid var(--ks-rejected);
   padding: 10px 12px;
   margin-bottom: 8px;
   font-size: 0.85rem;
-  color: #ffcccc;
+  color: var(--ks-rejected);
 }
 
 .tag-list {
@@ -522,43 +555,49 @@ main {
   flex-wrap: wrap;
   gap: 8px;
 }
+
 .tag-item {
-  background: #1a1a1a;
-  border: 1px solid var(--border-color);
+  background: var(--ks-primary-soft);
+  border: 1px solid color-mix(in srgb, var(--ks-primary) 28%, var(--ks-border));
   padding: 2px 8px;
   border-radius: 4px;
   font-size: 0.75rem;
-  color: var(--text-secondary);
+  color: var(--ks-ink);
 }
 
 /* --- Review Persona Styles --- */
 .review-card {
-  background: #1a1a1a;
+  background: var(--ks-surface);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 1.25rem;
   margin-bottom: 1rem;
 }
+
 .review-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.75rem;
 }
+
 .persona-badge {
   font-size: 0.75rem;
   font-weight: 700;
   color: var(--accent);
   text-transform: uppercase;
 }
+
 .rating-badge {
-  background: var(--bg-dark);
-  border: 1px solid var(--border-color);
+  background: var(--ks-secondary-soft);
+  color: var(--ks-ink);
+  border: 1px solid color-mix(in srgb, var(--ks-secondary) 28%, var(--ks-border));
   padding: 2px 8px;
   border-radius: 4px;
   font-size: 0.9rem;
   font-weight: 900;
 }
+
 .review-text {
   font-size: 0.9rem;
   line-height: 1.5;
@@ -566,10 +605,9 @@ main {
   font-style: italic;
 }
 
-
 /* --- Coach Mode Styles --- */
 .coach-step {
-  background: #111;
+  background: var(--ks-surface-subtle);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   padding: 1.5rem;
@@ -577,10 +615,12 @@ main {
   position: relative;
   transition: all 0.2s ease;
 }
+
 .coach-step.active {
-  border-color: #fff;
-  box-shadow: 0 0 20px rgba(255, 255, 255, 0.05);
+  border-color: var(--ks-primary);
+  box-shadow: 0 6px 18px rgb(36 54 83 / 0.08);
 }
+
 .coach-step-num {
   font-family: var(--font-heading);
   font-size: 0.8rem;
@@ -589,6 +629,7 @@ main {
   margin-bottom: 0.5rem;
   display: block;
 }
+
 .coach-step-title {
   font-size: 1.2rem;
   font-weight: 700;
@@ -602,7 +643,7 @@ main {
   bottom: 2rem;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(0, 0, 0, 0.9);
+  background: color-mix(in srgb, var(--ks-surface) 96%, transparent);
   backdrop-filter: blur(12px);
   border: 1px solid var(--border-color);
   border-radius: 40px;
@@ -611,23 +652,25 @@ main {
   align-items: center;
   gap: 16px;
   z-index: 1000;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 10px 30px rgb(36 54 83 / 0.16);
 }
+
 .compare-item {
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  border: 1px solid #444;
+  border: 1px solid var(--ks-border);
   overflow: hidden;
-  background: #222;
+  background: var(--ks-surface-subtle);
   position: relative;
 }
+
 .compare-item button {
   position: absolute;
   top: -2px;
   right: -2px;
-  background: #ff4444;
-  color: #fff;
+  background: var(--ks-rejected);
+  color: var(--ks-surface);
   border: none;
   border-radius: 50%;
   width: 14px;
@@ -645,14 +688,17 @@ main {
   border-radius: 12px;
   overflow: hidden;
 }
+
 .battle-col {
-  background: var(--bg-dark);
+  background: var(--ks-canvas);
   padding: 2rem;
 }
+
 .battle-attr {
   padding: 1rem 0;
-  border-bottom: 1px solid #1a1a1a;
+  border-bottom: 1px solid var(--ks-border);
 }
+
 .battle-attr-label {
   font-size: 0.7rem;
   color: var(--text-muted);
@@ -673,11 +719,10 @@ main {
   text-decoration: none;
   color: inherit;
 }
+
 .relation-line {
   width: 2px;
   height: 20px;
   background: var(--border-color);
   margin-left: 2rem;
 }
-
-

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,6 +6,7 @@ import App from './App.jsx'
 import './index.css'
 import './layout.css'
 import './game-detail-palette.css'
+import './ui-palette.css'
 
 const GamePage = lazy(() => import('./pages/GamePage.jsx'))
 const DataPage = lazy(() => import('./pages/DataPage.jsx'))

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -53,13 +53,17 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
     fetchData()
   }, [slug, initialGame, allGames.length])
 
-  if (loading) return <div style={{ padding: '4rem', textAlign: 'center', color: '#666' }}>ARCHIVE LOADING...</div>
+  if (loading) {
+    return <div className="page-state page-state--loading" role="status">ARCHIVE LOADING...</div>
+  }
 
   if (error || !game) {
     return (
-      <div style={{ padding: '4rem', textAlign: 'center' }}>
-        <p>{error || 'Game not found'}</p>
-        <Link to="/" className="back-link">ディレクトリに戻る</Link>
+      <div className="page-state page-state--error" role="alert">
+        <div>
+          <p>{error || 'Game not found'}</p>
+          <Link to="/" className="back-link">ディレクトリに戻る</Link>
+        </div>
       </div>
     )
   }
@@ -127,7 +131,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
             </div>
           </div>
 
-          <div className="pro-card" style={{ borderLeft: '4px solid #fff' }}>
+          <div className="pro-card pro-card--synopsis">
             <div className="pro-card-title">SYNOPSIS</div>
             <div className="summary-text">{game.summary || game.description}</div>
           </div>
@@ -259,8 +263,8 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
                 {sd.strategy_analysis ? (
                   <ReactMarkdown>{sd.strategy_analysis}</ReactMarkdown>
                 ) : (
-                  <div style={{ padding: '2rem', textAlign: 'center', background: '#111', borderRadius: '8px', color: '#666' }}>
-                    No deep strategy analysis available yet. Try regenerating.
+                  <div className="game-empty-state" role="status">
+                    戦略解説はまだ登録されていません。必要に応じて再生成してください。
                   </div>
                 )}
               </div>
@@ -282,8 +286,8 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
                     <div className="review-text">「{rev.review_text}」</div>
                   </div>
                 )) : (
-                  <div style={{ padding: '2rem', textAlign: 'center', background: '#111', borderRadius: '8px', color: '#666' }}>
-                    No persona reviews available yet. Try regenerating.
+                  <div className="game-empty-state" role="status">
+                    レビューはまだ登録されていません。必要に応じて再生成してください。
                   </div>
                 )}
               </div>
@@ -314,7 +318,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
                           </div>
                         </Link>
                       )) : (
-                        <div style={{ fontSize: '0.8rem', color: '#444', padding: '10px' }}>No direct connections found in archive.</div>
+                        <div className="game-empty-note">関連ゲームはまだ見つかっていません。</div>
                       )}
                     </div>
                   )
@@ -335,7 +339,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
               </div>
             )}
 
-            {activeTab === 'data' && <pre style={{ background: '#111', padding: '1rem', borderRadius: '8px', overflowX: 'auto' }}>{JSON.stringify(game, null, 2)}</pre>}
+            {activeTab === 'data' && <pre className="game-data-dump">{JSON.stringify(game, null, 2)}</pre>}
           </div>
         </div>
       </div>

--- a/frontend/src/ui-palette.css
+++ b/frontend/src/ui-palette.css
@@ -1,0 +1,334 @@
+/* Canonical light palette bindings for every route and transient UI state.
+   KAFKA SIGNAL tokens are the source of truth; legacy names remain aliases only. */
+
+:root {
+  --bg-dark: var(--ks-canvas);
+  --bg-card: var(--ks-surface);
+  --border-color: var(--ks-border);
+  --border-hover: var(--ks-primary);
+  --text-primary: var(--ks-ink);
+  --text-secondary: var(--ks-ink-muted);
+  --text-muted: var(--ks-ink-muted);
+  --accent: var(--ks-primary);
+  --accent-secondary: var(--ks-secondary);
+
+  /* Compatibility aliases used by older route components. */
+  --bg-primary: var(--ks-canvas);
+  --bg-secondary: var(--ks-surface);
+  --bg-tertiary: var(--ks-surface-subtle);
+  --border-subtle: var(--ks-border);
+  --accent-primary: var(--ks-primary);
+}
+
+html,
+body,
+#root {
+  background: var(--ks-canvas);
+  color: var(--ks-ink);
+}
+
+/* Header, navigation, filters and form controls. */
+header,
+aside,
+main {
+  color: var(--ks-ink);
+}
+
+.search-input,
+.sort-select,
+.filter-btn,
+.button-secondary,
+.btn-secondary,
+.btn-primary,
+.share-btn,
+.gallery-btn,
+.quick-rule-action {
+  background: var(--ks-surface);
+  color: var(--ks-ink);
+  border-color: var(--ks-border);
+}
+
+.search-input:hover,
+.sort-select:hover,
+.filter-btn:hover:not(:disabled),
+.button-secondary:hover:not(:disabled),
+.btn-secondary:hover:not(:disabled),
+.share-btn:hover:not(:disabled),
+.gallery-btn:hover:not(:disabled) {
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
+  border-color: var(--ks-primary);
+}
+
+.filter-btn.active,
+.filter-btn[aria-pressed="true"],
+.btn-primary {
+  background: var(--ks-primary);
+  color: var(--ks-surface);
+  border-color: var(--ks-primary);
+}
+
+button:disabled,
+select:disabled,
+input:disabled,
+textarea:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.filter-chip {
+  background: var(--ks-secondary-soft);
+  color: var(--ks-secondary);
+  border-color: color-mix(in srgb, var(--ks-secondary) 32%, var(--ks-border));
+}
+
+.filter-chip button {
+  color: currentColor;
+}
+
+.db-status {
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
+  border-color: color-mix(in srgb, var(--ks-primary) 34%, var(--ks-border));
+}
+
+/* Catalogue cards and comparison mode. */
+.asset-card,
+.pro-card,
+.pro-stat-card,
+.info-section,
+.review-card,
+.relation-node,
+.stat-card {
+  background: var(--ks-surface);
+  color: var(--ks-ink);
+  border-color: var(--ks-border);
+  box-shadow: var(--ks-shadow-low);
+}
+
+.asset-thumb-container,
+.game-hero-image {
+  background: var(--ks-surface-subtle);
+}
+
+.asset-card:hover {
+  border-color: color-mix(in srgb, var(--ks-primary) 48%, var(--ks-border));
+  box-shadow: 0 8px 24px rgb(36 54 83 / 0.12);
+}
+
+.tier-badge {
+  background: var(--ks-secondary);
+  color: var(--ks-surface);
+  border-color: var(--ks-secondary);
+}
+
+.tag-item {
+  background: var(--ks-primary-soft);
+  color: var(--ks-ink);
+  border-color: color-mix(in srgb, var(--ks-primary) 28%, var(--ks-border));
+}
+
+.mistake-item {
+  background: var(--ks-rejected-soft);
+  color: var(--ks-rejected);
+  border-left-color: var(--ks-rejected);
+}
+
+.comparison-tray {
+  background: color-mix(in srgb, var(--ks-surface) 96%, transparent);
+  color: var(--ks-ink);
+  border-color: var(--ks-border);
+  box-shadow: 0 10px 30px rgb(36 54 83 / 0.16);
+}
+
+.comparison-tray__label {
+  color: var(--ks-ink-muted);
+}
+
+.compare-item {
+  background: var(--ks-surface-subtle);
+  border-color: var(--ks-border);
+}
+
+.compare-item button {
+  background: var(--ks-rejected);
+  color: var(--ks-surface);
+}
+
+.battle-grid {
+  background: var(--ks-border);
+  border-color: var(--ks-border);
+}
+
+.battle-col {
+  background: var(--ks-canvas);
+}
+
+.battle-attr {
+  border-bottom-color: var(--ks-border);
+}
+
+/* Route-level feedback, loading and empty states. */
+.app-feedback,
+.app-loading-state,
+.app-empty-state {
+  width: 100%;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink-muted);
+  padding: 1rem;
+}
+
+.app-feedback--error {
+  background: var(--ks-rejected-soft);
+  color: var(--ks-rejected);
+  border-color: color-mix(in srgb, var(--ks-rejected) 48%, var(--ks-border));
+}
+
+.app-feedback--progress {
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
+  border-color: color-mix(in srgb, var(--ks-primary) 38%, var(--ks-border));
+  text-align: center;
+}
+
+.app-loading-state,
+.app-empty-state {
+  text-align: center;
+}
+
+.app-empty-state {
+  grid-column: 1 / -1;
+  padding-block: 3rem;
+}
+
+.loading-fallback {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100dvh;
+  background: var(--ks-canvas);
+  color: var(--ks-ink);
+}
+
+/* Game actions, external links and media states. */
+.share-btn.speaking {
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
+  border-color: var(--ks-primary);
+}
+
+.link-button,
+.link-button.bga {
+  background: var(--ks-surface);
+  color: var(--ks-primary);
+  border: 1px solid var(--ks-border);
+}
+
+.link-button:hover,
+.link-button.bga:hover {
+  background: var(--ks-primary-soft);
+  color: var(--ks-primary);
+  border-color: var(--ks-primary);
+}
+
+.no-infographics,
+.loading-error {
+  padding: 1rem;
+  border: 1px dashed var(--ks-border);
+  border-radius: var(--ks-radius-md);
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink-muted);
+}
+
+.gallery-image {
+  background: var(--ks-surface-subtle);
+  border-color: var(--ks-border);
+}
+
+.gallery-dot {
+  background: var(--ks-border);
+}
+
+.gallery-dot.active {
+  background: var(--ks-primary);
+}
+
+.gallery-counter,
+.rule-flow-source {
+  color: var(--ks-ink-muted);
+}
+
+/* Editor modal. */
+.modal-overlay {
+  background: rgb(36 54 83 / 0.28);
+}
+
+.modal-content {
+  background: var(--ks-surface);
+  color: var(--ks-ink);
+  border: 1px solid var(--ks-border);
+  box-shadow: 0 18px 48px rgb(36 54 83 / 0.18);
+}
+
+.modal-header,
+.modal-actions {
+  border-color: var(--ks-border);
+}
+
+.edit-form input,
+.edit-form textarea,
+.edit-form select {
+  background: var(--ks-surface);
+  color: var(--ks-ink);
+  border-color: var(--ks-border);
+}
+
+.edit-form input[readonly] {
+  background: var(--ks-surface-subtle);
+  color: var(--ks-ink-muted);
+}
+
+.keyword-remove-button {
+  color: var(--ks-rejected);
+  background: transparent;
+  border: 0;
+}
+
+/* Data route. */
+.app-container,
+.main-header,
+.main-footer {
+  background: var(--ks-canvas);
+  color: var(--ks-ink);
+}
+
+.main-header,
+.main-footer {
+  border-color: var(--ks-border);
+}
+
+.stat-card {
+  padding: 1.25rem;
+  border: 1px solid var(--ks-border);
+  border-radius: var(--ks-radius-md);
+}
+
+.spinner {
+  width: 2rem;
+  height: 2rem;
+  margin: 2rem auto;
+  border: 3px solid var(--ks-border);
+  border-top-color: var(--ks-primary);
+  border-radius: 50%;
+  animation: ui-palette-spin 800ms linear infinite;
+}
+
+@keyframes ui-palette-spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner { animation: none; }
+}

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test'
+
+const games = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    slug: 'palette-audit',
+    title: 'Palette Audit',
+    title_ja: '配色監査',
+    summary: '配色回帰監査用ゲーム',
+    description: '配色回帰監査用ゲーム',
+    rules_content: '## 目的\n最後まで残る。',
+    setup_summary: 'カードを配る。',
+    gameplay_summary: '手番を順番に行う。',
+    end_game_summary: '終了条件を満たしたら終了。',
+    min_players: 2,
+    max_players: 4,
+    play_time: 30,
+    min_age: 10,
+    published_year: 2026,
+    official_url: 'https://example.com/rules',
+    structured_data: {
+      mechanics: ['Bluffing', 'Roles'],
+      keywords: [
+        { term: 'ブラフ', description: '主張を読み合う' },
+        { term: '役職', description: '固有能力を持つ' },
+      ],
+      pro_tips: [],
+      rule_mistakes: [],
+      persona_reviews: [],
+      strategy_analysis: null,
+    },
+  },
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    slug: 'palette-second',
+    title: 'Palette Second',
+    title_ja: '配色監査2',
+    summary: '比較トレイ監査用ゲーム',
+    min_players: 2,
+    max_players: 5,
+    play_time: 45,
+    published_year: 2025,
+    structured_data: { mechanics: ['Different Mechanic'] },
+  },
+]
+
+async function mockApi(page) {
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const path = url.pathname
+
+    if (path === '/api/games' && request.method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ games, total: games.length }),
+      })
+      return
+    }
+
+    const match = path.match(/^\/api\/games\/([^/]+)$/)
+    if (match && request.method() === 'GET') {
+      const game = games.find((candidate) => candidate.slug === decodeURIComponent(match[1]))
+      await route.fulfill({
+        status: game ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(game || { detail: 'not found' }),
+      })
+      return
+    }
+
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+}
+
+function channelToLinear(channel) {
+  const normalized = channel <= 1 ? channel : channel / 255
+  return normalized <= 0.04045
+    ? normalized / 12.92
+    : ((normalized + 0.055) / 1.055) ** 2.4
+}
+
+function relativeLuminance([r, g, b]) {
+  return (0.2126 * channelToLinear(r)) + (0.7152 * channelToLinear(g)) + (0.0722 * channelToLinear(b))
+}
+
+function parseColor(value) {
+  const rgb = value.match(/rgba?\(([^)]+)\)/)
+  if (rgb) {
+    return rgb[1].split(/[ ,/]+/).filter(Boolean).slice(0, 3).map(Number)
+  }
+
+  const srgb = value.match(/color\(srgb\s+([\d.]+)\s+([\d.]+)\s+([\d.]+)/)
+  if (srgb) return srgb.slice(1, 4).map(Number)
+
+  throw new Error(`Unsupported computed color: ${value}`)
+}
+
+async function expectLightSurface(locator, label) {
+  await expect(locator, `${label} should be visible`).toBeVisible()
+  const colors = await locator.evaluate((element) => {
+    const style = getComputedStyle(element)
+    return { background: style.backgroundColor, color: style.color }
+  })
+  const backgroundLum = relativeLuminance(parseColor(colors.background))
+  const textLum = relativeLuminance(parseColor(colors.color))
+  const contrast = (Math.max(backgroundLum, textLum) + 0.05) / (Math.min(backgroundLum, textLum) + 0.05)
+
+  expect(backgroundLum, `${label} background ${colors.background} must stay in the light palette`).toBeGreaterThan(0.65)
+  expect(contrast, `${label} contrast ${contrast.toFixed(2)} must remain readable`).toBeGreaterThanOrEqual(4.5)
+}
+
+test('every game-detail tab avoids legacy dark surfaces', async ({ page }, testInfo) => {
+  await mockApi(page)
+  await page.goto('/games/palette-audit')
+  await expect(page.getByRole('heading', { name: '配色監査' })).toBeVisible()
+
+  await page.getByRole('tab', { name: /セットアップ/ }).click()
+  const coachSteps = page.locator('.coach-step')
+  await expect(coachSteps).toHaveCount(3)
+  for (let index = 0; index < 3; index += 1) {
+    await expectLightSurface(coachSteps.nth(index), `coach step ${index + 1}`)
+  }
+
+  await page.getByRole('tab', { name: /戦略/ }).click()
+  await expectLightSurface(page.locator('.game-empty-state'), 'strategy empty state')
+
+  await page.getByRole('tab', { name: /レビュー/ }).click()
+  await expectLightSurface(page.locator('.game-empty-state'), 'review empty state')
+  await page.screenshot({ path: testInfo.outputPath('review-light-state.png'), fullPage: true, animations: 'disabled' })
+
+  await page.getByRole('tab', { name: /関連ゲーム/ }).click()
+  await expect(page.getByText('関連ゲームはまだ見つかっていません。').first()).toBeVisible()
+
+  const legacyDark = await page.locator('.game-detail-content').evaluate((root) => {
+    const visible = [...root.querySelectorAll('*')].filter((element) => {
+      const rect = element.getBoundingClientRect()
+      const style = getComputedStyle(element)
+      return rect.width >= 80 && rect.height >= 40 && style.visibility !== 'hidden' && style.display !== 'none'
+    })
+    return visible
+      .map((element) => ({
+        tag: element.tagName,
+        className: element.className?.toString?.() || '',
+        background: getComputedStyle(element).backgroundColor,
+      }))
+      .filter(({ background }) => background === 'rgb(17, 17, 17)' || background === 'rgb(26, 26, 26)' || background === 'rgb(10, 10, 10)')
+  })
+  expect(legacyDark, JSON.stringify(legacyDark, null, 2)).toEqual([])
+})
+
+test('directory empty state and comparison tray use the same light palette', async ({ page }, testInfo) => {
+  await mockApi(page)
+  await page.goto('/')
+  await expect(page.getByText('配色監査', { exact: true })).toBeVisible()
+
+  const compareButtons = page.getByRole('button', { name: 'COMPARE' })
+  await compareButtons.nth(0).click()
+  await compareButtons.nth(1).click()
+  await expectLightSurface(page.locator('.comparison-tray'), 'comparison tray')
+
+  const search = page.getByPlaceholder('ゲームを検索、または未登録ゲームをAI生成...')
+  await search.fill('no-match-palette-audit')
+  await expect(page.getByText('条件に一致するゲームが見つかりません。')).toBeVisible()
+  await expectLightSurface(page.locator('.app-empty-state'), 'directory empty state')
+  await page.screenshot({ path: testInfo.outputPath('directory-light-empty-state.png'), fullPage: true, animations: 'disabled' })
+})

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -155,9 +155,9 @@ test('directory empty state and comparison tray use the same light palette', asy
   await page.goto('/')
   await expect(page.getByText('配色監査', { exact: true })).toBeVisible()
 
-  const compareButtons = page.getByRole('button', { name: 'COMPARE' })
-  await compareButtons.nth(0).click()
-  await compareButtons.nth(1).click()
+  await page.getByRole('button', { name: 'COMPARE' }).first().click()
+  await page.getByRole('button', { name: 'COMPARE' }).first().click()
+  await expect(page.getByRole('button', { name: 'BATTLE START' })).toBeVisible()
   await expectLightSurface(page.locator('.comparison-tray'), 'comparison tray')
 
   const search = page.getByPlaceholder('ゲームを検索、または未登録ゲームをAI生成...')


### PR DESCRIPTION
## Scope

Comprehensive color/contrast audit across the frontend after the legacy dark-theme leak seen on game detail pages.

- make KAFKA SIGNAL light tokens the canonical runtime palette for all routes and transient states
- replace dark inline surfaces in game detail, directory, comparison, loading/error/empty states, BGA links, and text-to-speech state
- convert rule-guide/flow/scoring surfaces to semantic design tokens
- align browser `theme-color` / `color-scheme` with the light UI
- remove modal color literals and use semantic rejected/read-only states
- keep compatibility aliases for older components while preventing dark fallback leakage

## Regression prevention

- add responsive Playwright coverage for every game-detail tab, empty strategy/review states, directory empty state, and comparison tray
- assert light-surface luminance and WCAG-style text contrast for critical surfaces
- detect the retired `#111/#1a1a1a/...` backgrounds at runtime
- fail CI when retired dark background literals are introduced directly into JSX
- retain screenshots in the existing UI/UX evidence artifact

## Color contract

- `COMMON ERRORS`: `--ks-rejected` (`#8B3244`) on `--ks-rejected-soft` (`#F6D9E0`), contrast ≈ 6.04:1
- normal-size text gate: WCAG 2.2 AA >= 4.5:1
- synopsis border uses semantic primary token rather than white-on-white literal

## Acceptance

The visible black review/strategy empty states are removed, warning text remains legible on the light surface, and the same class of regression is gated at 375 / 768 / 1440 widths.

Resolves #117
Resolves #118