### PR TITLE
Fix missing-game API 500 and gate the response contract

### DIFF
--- a/.github/workflows/test-games-router.yml
+++ b/.github/workflows/test-games-router.yml
@@ -1,0 +1,40 @@
+name: Test games router
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/routers/games.py"
+      - "backend/app/services/game_service.py"
+      - "backend/app/core/supabase.py"
+      - "backend/tests/test_games_router.py"
+      - ".github/workflows/test-games-router.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/routers/games.py"
+      - "backend/app/services/game_service.py"
+      - "backend/app/core/supabase.py"
+      - "backend/tests/test_games_router.py"
+      - ".github/workflows/test-games-router.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - run: uv sync --frozen --dev
+      - name: Run games router regression tests
+        run: uv run pytest -q backend/tests/test_games_router.py
+        env:
+          PYTHONPATH: backend

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -54,6 +54,8 @@ async def list_recent_games(limit: int = 100, offset: int = 0, service: GameServ
 @router.get("/games/{slug}", response_model=GameDetail)
 async def get_game_details(slug: str, service: GameService = Depends(get_game_service)):
     game = await service.get_game_by_slug(slug)
+    if game is None:
+        raise HTTPException(status_code=404, detail="Game not found")
     return game
 
 

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import games
+
+
+class MissingGameService:
+    async def get_game_by_slug(self, slug: str):
+        return None
+
+
+def test_missing_game_slug_returns_404_instead_of_response_validation_500():
+    app = FastAPI()
+    app.include_router(games.router, prefix="/api")
+    app.dependency_overrides[games.get_game_service] = lambda: MissingGameService()
+
+    client = TestClient(app)
+    response = client.get("/api/games/ipso")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Game not found"}


### PR DESCRIPTION
## Problem
Production Vercel logs show `GET /api/games/ipso` returning 500 even though the Supabase lookups themselves return 200. The route declares `response_model=GameDetail`, while `GameService.get_game_by_slug()` legitimately returns `None` when neither the canonical slug nor an alias exists. FastAPI then raises `ResponseValidationError` while serializing `None`.

## Fix
- return explicit HTTP 404 for an unknown game slug before response-model serialization
- add a regression test proving a missing slug returns `404 {"detail":"Game not found"}` rather than 500
- add a dedicated GitHub Actions gate for the games router/data-provider path

## Verification
- CI must pass on this PR
- after merge, production `/api/games/ipso` must return 404 (or 200 if the game is later added), never response-validation 500
- Vercel runtime errors will be rechecked after deployment
