### PR TITLE
Automate safe cleanup of merged branches

### DIFF
--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -1,0 +1,84 @@
+name: Cleanup merged branches
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cleanup-merged-branches.yml"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Find safely deletable merged branches
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+
+          gh api --paginate "repos/$repo/pulls?state=closed&per_page=100" \
+            --jq '.[] | select(.merged_at != null and .head.repo.full_name == .base.repo.full_name) | [.head.ref, .head.sha] | @tsv' \
+            | sort -u > /tmp/merged-heads.tsv
+
+          gh api --paginate "repos/$repo/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.head.repo.full_name == .base.repo.full_name) | .head.ref' \
+            | sort -u > /tmp/open-heads.txt
+
+          gh api --paginate "repos/$repo/branches?per_page=100" \
+            --jq '.[] | [.name, .commit.sha] | @tsv' \
+            | sort -u > /tmp/current-branches.tsv
+
+          : > /tmp/delete-candidates.tsv
+          while IFS=$'\t' read -r branch sha; do
+            [[ -z "$branch" || "$branch" == "main" ]] && continue
+            grep -Fxq "$branch" /tmp/open-heads.txt && continue
+            if awk -F'\t' -v b="$branch" -v s="$sha" '$1 == b && $2 == s { found=1 } END { exit !found }' /tmp/merged-heads.tsv; then
+              printf '%s\t%s\n' "$branch" "$sha" >> /tmp/delete-candidates.tsv
+            fi
+          done < /tmp/current-branches.tsv
+
+          echo "Safely deletable merged branches:"
+          cat /tmp/delete-candidates.tsv || true
+          echo "candidate_count=$(wc -l < /tmp/delete-candidates.tsv | tr -d ' ')" >> "$GITHUB_OUTPUT"
+        id: candidates
+
+      - name: Delete merged branches after main update
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          while IFS=$'\t' read -r branch sha; do
+            [[ -z "$branch" ]] && continue
+            current_sha="$(gh api "repos/$repo/git/ref/heads/$branch" --jq '.object.sha')"
+            if [[ "$current_sha" != "$sha" ]]; then
+              echo "Skip $branch: ref moved from audited SHA $sha to $current_sha"
+              continue
+            fi
+            echo "Deleting merged branch: $branch ($sha)"
+            gh api --method DELETE "repos/$repo/git/refs/heads/$branch"
+          done < /tmp/delete-candidates.tsv
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "## Merged branch cleanup"
+            echo
+            echo "Candidates: ${{ steps.candidates.outputs.candidate_count }}"
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "PR runs are dry-run only; deletion occurs after the workflow lands on main."
+            else
+              echo "Only same-repository merged PR branches whose current SHA exactly matches the merged PR head SHA are eligible. Open PR branches are excluded."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem
The repository has accumulated many merged work branches. Manual cleanup is not reliable and branch names alone are not enough to decide deletion safely after squash merges.

## Safety contract
This workflow only considers a branch deletable when all of the following are true:
- it belongs to this repository
- it is not `main`
- it is not the head of any open PR
- a merged PR exists with the same head branch name **and the exact same head SHA**
- immediately before deletion, the branch still points at that audited SHA

This protects reused/moved branches and avoids guessing from names.

## Behavior
- PR runs: dry-run and report candidates only
- main push / manual dispatch: delete only audited candidates
- future main updates automatically clean merged PR branches
