### PR TITLE
Fix audited mobile, accessibility, compare and search UX

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -85,6 +85,10 @@ jobs:
         working-directory: frontend
         run: npm run lint
 
+      - name: Gate UI UX accessibility source contracts
+        working-directory: frontend
+        run: node scripts/check-uiux-accessibility-contracts.mjs
+
       - name: Install Chromium
         working-directory: frontend
         run: npx playwright install --with-deps chromium
@@ -104,10 +108,12 @@ jobs:
         working-directory: frontend
         run: npx playwright test tests/lists_layout.spec.js --project=chromium
 
-      - name: Gate cross-flow UX at 375 768 and 1440 widths
+      - name: Gate cross-flow UX and accessibility at 375 768 and 1440 widths
         working-directory: frontend
         run: >-
-          npx playwright test tests/ui_ux_regression.spec.js
+          npx playwright test
+          tests/ui_ux_regression.spec.js
+          tests/uiux_a11y_regression.spec.js
           --project=ux-mobile
           --project=ux-tablet
           --project=ux-desktop

--- a/frontend/scripts/check-uiux-accessibility-contracts.mjs
+++ b/frontend/scripts/check-uiux-accessibility-contracts.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+
+const files = {
+  app: readFileSync(new URL('../src/App.jsx', import.meta.url), 'utf8'),
+  shell: readFileSync(new URL('../src/components/AppShell.jsx', import.meta.url), 'utf8'),
+  modal: readFileSync(new URL('../src/components/EditGameModal.jsx', import.meta.url), 'utf8'),
+}
+
+const requirements = [
+  ['mobile filter toggle', files.app, /aria-controls="directory-filters"/],
+  ['explicit directory search label', files.app, /htmlFor="game-directory-search"/],
+  ['explicit sort label', files.app, /htmlFor="game-sort"/],
+  ['explicit AI generation CTA', files.app, /未登録ゲームをAIで追加/],
+  ['compare pressed state', files.app, /aria-pressed=\{selected\}/],
+  ['compare limit state', files.app, /比較できるゲームは3件まで/],
+  ['tab right-arrow keyboard support', files.shell, /ArrowRight/],
+  ['tab roving tabindex', files.shell, /tab\.tabIndex = tab === activeTab \? 0 : -1/],
+  ['tab panel semantics', files.shell, /setAttribute\('role', 'tabpanel'\)/],
+  ['modal dialog role', files.modal, /role="dialog"/],
+  ['modal aria-modal', files.modal, /aria-modal="true"/],
+  ['modal labelledby', files.modal, /aria-labelledby="edit-game-dialog-title"/],
+  ['modal focus trap', files.modal, /focusableElements\(dialogRef\.current\)/],
+  ['modal Escape close', files.modal, /event\.key === 'Escape'/],
+  ['modal focus return', files.modal, /previousFocusRef/],
+  ['explicit modal field labels', files.modal, /htmlFor="edit-game-title"/],
+]
+
+const failures = requirements.filter(([, source, pattern]) => !pattern.test(source)).map(([name]) => name)
+if (failures.length > 0) {
+  console.error(`UI/UX accessibility contract failures:\n- ${failures.join('\n- ')}`)
+  process.exit(1)
+}
+
+console.log(`UI/UX accessibility contracts: ${requirements.length} checks passed`)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,88 @@
-import { useEffect, useState, useMemo } from 'react'
-import { useSearchParams, Link, useNavigate } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { api } from './lib/api'
+
+const PLAYER_FILTERS = ['1', '2', '3', '4', '5+']
+const TIME_FILTERS = [
+  { id: '30-', label: '30分以内' },
+  { id: '30-60', label: '30-60分' },
+  { id: '60-120', label: '60-120分' },
+  { id: '120+', label: '120分以上' },
+]
+
+function Filters({
+  activePlayers,
+  activeTime,
+  activeTier,
+  availableTiers,
+  setActivePlayers,
+  setActiveTime,
+  setActiveTier,
+  clearFilters,
+}) {
+  return (
+    <>
+      <div className="filter-section">
+        <h3>プレイ人数</h3>
+        <div className="filter-grid">
+          {PLAYER_FILTERS.map((player) => (
+            <button
+              key={player}
+              type="button"
+              className={`filter-btn ${activePlayers === player ? 'active' : ''}`}
+              aria-pressed={activePlayers === player}
+              onClick={() => setActivePlayers(activePlayers === player ? null : player)}
+            >
+              {player}人
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="filter-section">
+        <h3>プレイ時間</h3>
+        <div className="filter-grid filter-grid--single">
+          {TIME_FILTERS.map((time) => (
+            <button
+              key={time.id}
+              type="button"
+              className={`filter-btn ${activeTime === time.id ? 'active' : ''}`}
+              aria-pressed={activeTime === time.id}
+              onClick={() => setActiveTime(activeTime === time.id ? null : time.id)}
+            >
+              {time.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {availableTiers.length > 0 && (
+        <div className="filter-section">
+          <h3>戦略ティア</h3>
+          <div className="filter-grid">
+            {availableTiers.map((tier) => (
+              <button
+                key={tier}
+                type="button"
+                className={`filter-btn ${activeTier === tier ? 'active' : ''}`}
+                aria-pressed={activeTier === tier}
+                onClick={() => setActiveTier(activeTier === tier ? null : tier)}
+              >
+                Tier {tier}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="filter-section">
+        <button type="button" className="filter-btn filter-reset-button" onClick={clearFilters}>
+          フィルターをリセット
+        </button>
+      </div>
+    </>
+  )
+}
 
 function App() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -17,20 +99,19 @@ function App() {
   const [activeTime, setActiveTime] = useState(null)
   const [activeTier, setActiveTier] = useState(null)
   const [sortOption, setSortOption] = useState('recent')
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false)
 
   const [compareList, setCompareList] = useState([])
+  const [compareNotice, setCompareNotice] = useState('')
   const [isBattleMode, setIsBattleMode] = useState(false)
 
   const loadAllGames = async () => {
     setError(null)
     setLoading(true)
     try {
-      const data = await api.get(`/api/games?limit=20000&offset=0`)
-      const list = data.games || []
-      const total = data.total || 0
-
-      setInitialGames(list)
-      setTotalGamesCount(total)
+      const data = await api.get('/api/games?limit=20000&offset=0')
+      setInitialGames(data.games || [])
+      setTotalGamesCount(data.total || 0)
     } catch (err) {
       console.error('Failed to load games:', err)
       setError('ゲームの読み込みに失敗しました。')
@@ -45,9 +126,10 @@ function App() {
     try {
       const data = await api.get(`/api/games?limit=1000&offset=${initialGames.length}`)
       const newGames = data.games || []
-      setInitialGames([...initialGames, ...newGames])
+      setInitialGames((current) => [...current, ...newGames])
     } catch (err) {
       console.error('Failed to load more games:', err)
+      setError('追加ゲームの読み込みに失敗しました。')
     } finally {
       setLoading(false)
     }
@@ -57,8 +139,17 @@ function App() {
     loadAllGames()
   }, [])
 
+  useEffect(() => {
+    if (!mobileFiltersOpen) return undefined
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') setMobileFiltersOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [mobileFiltersOpen])
+
   const availableTiers = useMemo(() => {
-    const tiers = new Set(initialGames.map(g => g.strategy_tier).filter(Boolean))
+    const tiers = new Set(initialGames.map((game) => game.strategy_tier).filter(Boolean))
     return Array.from(tiers).sort()
   }, [initialGames])
 
@@ -66,62 +157,46 @@ function App() {
     let result = [...initialGames]
 
     if (query) {
-      const q = query.trim().normalize('NFKC').toLowerCase()
+      const normalized = query.trim().normalize('NFKC').toLowerCase()
       result = result.filter((game) => {
         const title = (game.title || '').normalize('NFKC').toLowerCase()
         const titleJa = (game.title_ja || '').normalize('NFKC').toLowerCase()
         const titleEn = (game.title_en || '').normalize('NFKC').toLowerCase()
         const summary = (game.summary || '').normalize('NFKC').toLowerCase()
-        return title.includes(q) || titleJa.includes(q) || titleEn.includes(q) || summary.includes(q)
+        return title.includes(normalized) || titleJa.includes(normalized) || titleEn.includes(normalized) || summary.includes(normalized)
       })
     }
 
     if (activePlayers) {
-      const p = parseInt(activePlayers)
-      result = result.filter(g => {
-        const min = g.min_players || 1
-        const max = g.max_players || 99
+      const playerCount = Number.parseInt(activePlayers, 10)
+      result = result.filter((game) => {
+        const min = game.min_players || 1
+        const max = game.max_players || 99
         if (activePlayers === '5+') return max >= 5
-        return p >= min && p <= max
+        return playerCount >= min && playerCount <= max
       })
     }
 
     if (activeTime) {
-      result = result.filter(g => {
-        const t = g.play_time || 0
-        if (activeTime === '30-') return t > 0 && t <= 30
-        if (activeTime === '30-60') return t > 30 && t <= 60
-        if (activeTime === '60-120') return t > 60 && t <= 120
-        if (activeTime === '120+') return t > 120
+      result = result.filter((game) => {
+        const time = game.play_time || 0
+        if (activeTime === '30-') return time > 0 && time <= 30
+        if (activeTime === '30-60') return time > 30 && time <= 60
+        if (activeTime === '60-120') return time > 60 && time <= 120
+        if (activeTime === '120+') return time > 120
         return true
       })
     }
 
-    if (activeTier) {
-      result = result.filter(g => g.strategy_tier === activeTier)
-    }
+    if (activeTier) result = result.filter((game) => game.strategy_tier === activeTier)
 
     result.sort((a, b) => {
       if (sortOption === 'recent') {
-        const dateA = a.created_at ? new Date(a.created_at).getTime() : 0
-        const dateB = b.created_at ? new Date(b.created_at).getTime() : 0
-        return dateB - dateA
+        return (b.created_at ? new Date(b.created_at).getTime() : 0) - (a.created_at ? new Date(a.created_at).getTime() : 0)
       }
-      if (sortOption === 'title') {
-        const ta = a.title_ja || a.title || ''
-        const tb = b.title_ja || b.title || ''
-        return ta.localeCompare(tb)
-      }
-      if (sortOption === 'year') {
-        const ya = a.published_year || 0
-        const yb = b.published_year || 0
-        return yb - ya
-      }
-      if (sortOption === 'play_time') {
-        const ta = a.play_time || 0
-        const tb = b.play_time || 0
-        return ta - tb
-      }
+      if (sortOption === 'title') return (a.title_ja || a.title || '').localeCompare(b.title_ja || b.title || '')
+      if (sortOption === 'year') return (b.published_year || 0) - (a.published_year || 0)
+      if (sortOption === 'play_time') return (a.play_time || 0) - (b.play_time || 0)
       return 0
     })
 
@@ -129,35 +204,37 @@ function App() {
   }, [initialGames, query, activePlayers, activeTime, activeTier, sortOption])
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      if (query) {
-        setSearchParams({ q: query }, { replace: true })
-      } else {
-        setSearchParams({}, { replace: true })
-      }
+    const timer = window.setTimeout(() => {
+      if (query) setSearchParams({ q: query }, { replace: true })
+      else setSearchParams({}, { replace: true })
     }, 300)
-    return () => clearTimeout(timer)
+    return () => window.clearTimeout(timer)
   }, [query, setSearchParams])
 
-  const handleSearchSubmit = async (e) => {
-    e.preventDefault()
-    if (!query.trim()) return
+  const handleDirectorySearch = (event) => {
+    event.preventDefault()
+    // Filtering is intentionally local. AI generation is a separate explicit action.
+  }
+
+  const handleGenerateGame = async () => {
+    const normalized = query.trim()
+    if (!normalized || generating) return
 
     setGenerating(true)
     setError(null)
     try {
-      const data = await api.post('/api/search', { query, generate: true })
+      const data = await api.post('/api/search', { query: normalized, generate: true })
       const list = Array.isArray(data) ? data : data.games || []
-      if (list.length > 0) {
-        const newGame = list[0]
-        const exists = initialGames.find((g) => g.slug === newGame.slug)
-        if (!exists) {
-          setInitialGames([newGame, ...initialGames])
-        }
-        navigate(`/games/${newGame.slug}`)
+      if (list.length === 0) {
+        setError('未登録ゲームを生成できませんでした。名称を確認してください。')
+        return
       }
-    } catch (e) {
-      console.error(e)
+
+      const newGame = list[0]
+      setInitialGames((current) => current.some((game) => game.slug === newGame.slug) ? current : [newGame, ...current])
+      navigate(`/games/${newGame.slug}`)
+    } catch (err) {
+      console.error(err)
       setError('AI生成リクエストに失敗しました。')
     } finally {
       setGenerating(false)
@@ -172,41 +249,49 @@ function App() {
   }
 
   const toggleCompare = (game) => {
-    if (compareList.find(g => g.id === game.id)) {
-      setCompareList(compareList.filter(g => g.id !== game.id))
-    } else {
-      if (compareList.length >= 3) return
-      setCompareList([...compareList, game])
+    const selected = compareList.some((candidate) => candidate.id === game.id)
+    if (selected) {
+      setCompareList((current) => current.filter((candidate) => candidate.id !== game.id))
+      setCompareNotice('')
+      return
     }
+
+    if (compareList.length >= 3) {
+      setCompareNotice('比較できるゲームは3件までです。1件外してから追加してください。')
+      return
+    }
+
+    setCompareList((current) => [...current, game])
+    setCompareNotice('')
   }
 
   if (isBattleMode) {
     return (
-      <div className="game-detail-content" style={{ overflowY: 'auto', height: '100dvh', padding: '2rem' }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '2rem' }}>
+      <div className="game-detail-content comparison-page">
+        <div className="comparison-page__header">
           <h1 className="game-title">COMPARISON BATTLE</h1>
-          <button className="filter-btn" onClick={() => setIsBattleMode(false)}>CLOSE BATTLE</button>
+          <button type="button" className="filter-btn" onClick={() => setIsBattleMode(false)}>CLOSE BATTLE</button>
         </div>
 
         <div className="battle-grid">
-          {compareList.map(game => (
+          {compareList.map((game) => (
             <div key={game.id} className="battle-col">
-              <div className="pro-card" style={{ textAlign: 'center' }}>
-                <img src={game.image_url || '/assets/no-image.webp'} style={{ width: '100%', borderRadius: '8px', marginBottom: '1rem' }} alt={game.title_ja} />
+              <div className="pro-card comparison-game-card">
+                <img src={game.image_url || '/assets/no-image.webp'} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
                 <div className="pro-stat-value">{game.title_ja || game.title}</div>
-                {game.strategy_tier && <div className="tier-badge" style={{ position: 'static', marginTop: '8px' }}>TIER {game.strategy_tier}</div>}
+                {game.strategy_tier && <div className="tier-badge comparison-tier">TIER {game.strategy_tier}</div>}
               </div>
 
               <div className="battle-attr">
                 <div className="battle-attr-label">Synopsis</div>
-                <div style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>{game.summary || 'No summary available.'}</div>
+                <div className="comparison-summary">{game.summary || 'No summary available.'}</div>
               </div>
 
               <div className="battle-attr">
                 <div className="battle-attr-label">Specs</div>
-                <div className="pro-stats-grid" style={{ marginBottom: 0 }}>
-                  <div className="pro-stat-card"><div className="pro-stat-label">P</div><div className="pro-stat-value" style={{ fontSize: '0.9rem' }}>{game.min_players}-{game.max_players}</div></div>
-                  <div className="pro-stat-card"><div className="pro-stat-label">T</div><div className="pro-stat-value" style={{ fontSize: '0.9rem' }}>{game.play_time}m</div></div>
+                <div className="pro-stats-grid comparison-specs">
+                  <div className="pro-stat-card"><div className="pro-stat-label">P</div><div className="pro-stat-value comparison-stat">{game.min_players}-{game.max_players}</div></div>
+                  <div className="pro-stat-card"><div className="pro-stat-label">T</div><div className="pro-stat-value comparison-stat">{game.play_time}m</div></div>
                 </div>
               </div>
 
@@ -214,19 +299,28 @@ function App() {
                 <div className="battle-attr">
                   <div className="battle-attr-label">Mechanics</div>
                   <div className="tag-list">
-                    {game.structured_data.mechanics.slice(0, 5).map(m => <span key={m} className="tag-item">{m}</span>)}
+                    {game.structured_data.mechanics.slice(0, 5).map((mechanic) => <span key={mechanic} className="tag-item">{mechanic}</span>)}
                   </div>
                 </div>
               )}
 
-              <div style={{ marginTop: '2rem' }}>
-                <Link to={`/games/${game.slug}`} className="filter-btn" style={{ width: '100%', display: 'block', textDecoration: 'none' }}>VIEW FULL ANALYSIS</Link>
-              </div>
+              <Link to={`/games/${game.slug}`} className="filter-btn comparison-detail-link">VIEW FULL ANALYSIS</Link>
             </div>
           ))}
         </div>
       </div>
     )
+  }
+
+  const filterProps = {
+    activePlayers,
+    activeTime,
+    activeTier,
+    availableTiers,
+    setActivePlayers,
+    setActiveTime,
+    setActiveTier,
+    clearFilters,
   }
 
   return (
@@ -236,102 +330,68 @@ function App() {
           <div className="logo-text">ボドゲのミカタ</div>
         </Link>
 
-        <form className="search-container" onSubmit={handleSearchSubmit}>
+        <form className="search-container directory-search" role="search" onSubmit={handleDirectorySearch}>
+          <label htmlFor="game-directory-search" className="sr-only">ゲームを検索</label>
           <input
-            type="text"
+            id="game-directory-search"
+            type="search"
             className="search-input"
-            placeholder="ゲームを検索、または未登録ゲームをAI生成..."
+            placeholder="ゲーム名・概要で検索"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(event) => setQuery(event.target.value)}
           />
+          <button
+            type="button"
+            className="filter-btn generate-game-button"
+            disabled={!query.trim() || generating}
+            onClick={handleGenerateGame}
+          >
+            {generating ? '生成中…' : '未登録ゲームをAIで追加'}
+          </button>
         </form>
 
-        <div className="db-status">
+        <div className="db-status" aria-label={loading ? 'ゲーム一覧を同期中' : `${totalGamesCount}件のゲーム`}>
           <div className="status-dot connected"></div>
           {loading ? 'SYNCING...' : `${totalGamesCount} GAMES`}
         </div>
       </header>
 
-      <aside>
-        <div className="filter-section">
-          <h3>プレイ人数</h3>
-          <div className="filter-grid">
-            {['1', '2', '3', '4', '5+'].map(p => (
-              <button
-                key={p}
-                className={`filter-btn ${activePlayers === p ? 'active' : ''}`}
-                onClick={() => setActivePlayers(activePlayers === p ? null : p)}
-              >
-                {p}人
-              </button>
-            ))}
-          </div>
-        </div>
+      {mobileFiltersOpen && (
+        <button
+          type="button"
+          className="mobile-filter-backdrop"
+          aria-label="フィルターを閉じる"
+          onClick={() => setMobileFiltersOpen(false)}
+        />
+      )}
 
-        <div className="filter-section">
-          <h3>プレイ時間</h3>
-          <div className="filter-grid" style={{ gridTemplateColumns: '1fr' }}>
-            {[
-              { id: '30-', label: '30分以内' },
-              { id: '30-60', label: '30-60分' },
-              { id: '60-120', label: '60-120分' },
-              { id: '120+', label: '120分以上' }
-            ].map(t => (
-              <button
-                key={t.id}
-                className={`filter-btn ${activeTime === t.id ? 'active' : ''}`}
-                onClick={() => setActiveTime(activeTime === t.id ? null : t.id)}
-              >
-                {t.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {availableTiers.length > 0 && (
-          <div className="filter-section">
-            <h3>戦略ティア</h3>
-            <div className="filter-grid">
-              {availableTiers.map(t => (
-                <button
-                  key={t}
-                  className={`filter-btn ${activeTier === t ? 'active' : ''}`}
-                  onClick={() => setActiveTier(activeTier === t ? null : t)}
-                >
-                  Tier {t}
-                </button>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <div className="filter-section">
-          <button
-            className="filter-btn"
-            style={{ width: '100%', borderColor: 'var(--accent-secondary)' }}
-            onClick={clearFilters}
-          >
-            フィルターをリセット
-          </button>
-        </div>
+      <aside id="directory-filters" className={`filter-sidebar-shell ${mobileFiltersOpen ? 'mobile-open' : ''}`} aria-label="ゲーム絞り込み">
+        <button type="button" className="filter-btn mobile-filter-close" onClick={() => setMobileFiltersOpen(false)}>
+          フィルターを閉じる
+        </button>
+        <Filters {...filterProps} />
       </aside>
 
       <main>
         <div className="control-panel">
-          <div className="active-filters" style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-            <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)', fontWeight: '700' }}>
-              {filteredGames.length} RESULTS
-            </span>
-            {activePlayers && <div className="filter-chip">人数: {activePlayers} <button onClick={() => setActivePlayers(null)}>×</button></div>}
-            {activeTime && <div className="filter-chip">時間: {activeTime} <button onClick={() => setActiveTime(null)}>×</button></div>}
-            {activeTier && <div className="filter-chip">Tier: {activeTier} <button onClick={() => setActiveTier(null)}>×</button></div>}
+          <div className="active-filters">
+            <button
+              type="button"
+              className="filter-btn mobile-filter-toggle"
+              aria-expanded={mobileFiltersOpen}
+              aria-controls="directory-filters"
+              onClick={() => setMobileFiltersOpen(true)}
+            >
+              フィルター
+            </button>
+            <span className="results-count">{filteredGames.length} RESULTS</span>
+            {activePlayers && <div className="filter-chip">人数: {activePlayers} <button type="button" aria-label="人数フィルターを解除" onClick={() => setActivePlayers(null)}>×</button></div>}
+            {activeTime && <div className="filter-chip">時間: {activeTime} <button type="button" aria-label="時間フィルターを解除" onClick={() => setActiveTime(null)}>×</button></div>}
+            {activeTier && <div className="filter-chip">Tier: {activeTier} <button type="button" aria-label="戦略Tierフィルターを解除" onClick={() => setActiveTier(null)}>×</button></div>}
           </div>
 
-          <select
-            className="sort-select"
-            value={sortOption}
-            onChange={(e) => setSortOption(e.target.value)}
-          >
+          <label htmlFor="game-sort" className="sr-only">ゲームの並び順</label>
+          <select id="game-sort" className="sort-select" value={sortOption} onChange={(event) => setSortOption(event.target.value)}>
             <option value="recent">最近追加</option>
             <option value="title">タイトル順</option>
             <option value="year">発売年順</option>
@@ -340,58 +400,55 @@ function App() {
         </div>
 
         {error && <div className="app-feedback app-feedback--error" role="alert">{error}</div>}
-        {generating && <div className="app-feedback app-feedback--progress" role="status">AIが新しいゲーム情報を生成しています...</div>}
+        {generating && <div className="app-feedback app-feedback--progress" role="status">未登録ゲームの情報を生成しています…</div>}
+        {compareNotice && <div className="app-feedback compare-feedback" role="status">{compareNotice}</div>}
 
         {loading ? (
           <div className="app-loading-state" role="status">ARCHIVE INITIALIZING...</div>
         ) : (
           <div className="asset-grid">
-            {filteredGames.map(game => (
-              <div key={game.id} style={{ position: 'relative' }}>
-                <Link to={`/games/${game.slug}`} className="asset-card" style={{ height: '100%' }}>
-                  <div className="asset-thumb-container">
-                    {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
-                    <img
-                      src={game.image_url || '/assets/no-image.webp'}
-                      alt={game.title_ja || game.title}
-                      className="asset-thumb"
-                      loading="lazy"
-                    />
-                  </div>
-                  <div className="asset-info">
-                    <div className="asset-title">{game.title_ja || game.title}</div>
-                    <div className="asset-meta">
-                      {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
-                      {game.play_time && <span className="meta-item">⏳ {game.play_time}m</span>}
-                      {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}
+            {filteredGames.map((game) => {
+              const selected = compareList.some((candidate) => candidate.id === game.id)
+              const limitReached = compareList.length >= 3 && !selected
+              const title = game.title_ja || game.title || 'このゲーム'
+              return (
+                <div key={game.id} className="asset-card-shell">
+                  <Link to={`/games/${game.slug}`} className="asset-card asset-card-link">
+                    <div className="asset-thumb-container">
+                      {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
+                      <img src={game.image_url || '/assets/no-image.webp'} alt={title} className="asset-thumb" loading="lazy" />
                     </div>
-                    <div className="asset-summary">{game.summary || game.description}</div>
-                  </div>
-                </Link>
-                <button
-                  onClick={(e) => { e.preventDefault(); toggleCompare(game); }}
-                  className={`filter-btn ${compareList.find(g => g.id === game.id) ? 'active' : ''}`}
-                  style={{ position: 'absolute', top: '8px', right: '8px', zIndex: 10, padding: '4px 8px', fontSize: '0.65rem' }}
-                >
-                  {compareList.find(g => g.id === game.id) ? 'READY' : 'COMPARE'}
-                </button>
-              </div>
-            ))}
-            {filteredGames.length === 0 && !loading && (
-              <div className="app-empty-state">
-                条件に一致するゲームが見つかりません。
-              </div>
-            )}
+                    <div className="asset-info">
+                      <div className="asset-title">{title}</div>
+                      <div className="asset-meta">
+                        {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
+                        {game.play_time && <span className="meta-item">⏳ {game.play_time}m</span>}
+                        {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}
+                      </div>
+                      <div className="asset-summary">{game.summary || game.description}</div>
+                    </div>
+                  </Link>
+                  <button
+                    type="button"
+                    className={`filter-btn compare-toggle ${selected ? 'active' : ''}`}
+                    aria-pressed={selected}
+                    aria-label={selected ? `${title}を比較から外す` : `${title}を比較に追加`}
+                    disabled={limitReached}
+                    title={limitReached ? '比較は3件までです' : undefined}
+                    onClick={() => toggleCompare(game)}
+                  >
+                    {selected ? 'READY' : limitReached ? 'MAX 3' : 'COMPARE'}
+                  </button>
+                </div>
+              )
+            })}
+            {filteredGames.length === 0 && !loading && <div className="app-empty-state">条件に一致するゲームが見つかりません。</div>}
           </div>
         )}
 
         {!loading && initialGames.length < totalGamesCount && (
-          <div style={{ textAlign: 'center', padding: '2rem' }}>
-            <button
-              className="filter-btn"
-              style={{ padding: '10px 24px', fontSize: '0.9rem', borderColor: 'var(--accent)' }}
-              onClick={handleLoadMore}
-            >
+          <div className="load-more-wrap">
+            <button type="button" className="filter-btn load-more-button" onClick={handleLoadMore}>
               さらに読み込む ({initialGames.length} / {totalGamesCount})
             </button>
           </div>
@@ -399,20 +456,19 @@ function App() {
       </main>
 
       {compareList.length > 0 && (
-        <div className="comparison-tray">
-          <div className="comparison-tray__label" style={{ fontSize: '0.75rem', fontWeight: 700 }}>BATTLE TRAY</div>
-          {compareList.map(g => (
-            <div key={g.id} className="compare-item">
-              <img src={g.image_url || '/assets/no-image.webp'} style={{ width: '100%', height: '100%', objectFit: 'cover' }} alt="Compare Item" />
-              <button onClick={() => toggleCompare(g)}>×</button>
-            </div>
-          ))}
+        <div className="comparison-tray" role="region" aria-label={`比較トレイ ${compareList.length}/3`}>
+          <div className="comparison-tray__label">BATTLE TRAY · {compareList.length}/3</div>
+          {compareList.map((game) => {
+            const title = game.title_ja || game.title || 'ゲーム'
+            return (
+              <div key={game.id} className="compare-item">
+                <img src={game.image_url || '/assets/no-image.webp'} alt={title} />
+                <button type="button" aria-label={`${title}を比較から外す`} onClick={() => toggleCompare(game)}>×</button>
+              </div>
+            )
+          })}
           {compareList.length >= 2 && (
-            <button
-              className="filter-btn active"
-              style={{ padding: '6px 16px', borderRadius: '20px' }}
-              onClick={() => setIsBattleMode(true)}
-            >
+            <button type="button" className="filter-btn active battle-start-button" onClick={() => setIsBattleMode(true)}>
               BATTLE START
             </button>
           )}

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -16,6 +16,49 @@ function focusRouteContent() {
   return true
 }
 
+function syncGameTabs() {
+  const tablist = document.querySelector('.rules-tabs[role="tablist"]')
+  const panel = document.querySelector('.game-main .pro-main-col')
+  if (!tablist || !panel) return
+
+  const tabs = [...tablist.querySelectorAll('[role="tab"]')]
+  if (tabs.length === 0) return
+
+  const activeTab = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabs[0]
+  tabs.forEach((tab, index) => {
+    tab.id = `game-detail-tab-${index}`
+    tab.tabIndex = tab === activeTab ? 0 : -1
+    tab.setAttribute('aria-controls', 'game-detail-tabpanel')
+  })
+
+  panel.id = 'game-detail-tabpanel'
+  panel.setAttribute('role', 'tabpanel')
+  panel.setAttribute('aria-labelledby', activeTab.id)
+  panel.tabIndex = 0
+}
+
+function handleGameTabKeyDown(event) {
+  const current = event.target.closest?.('.rules-tabs [role="tab"]')
+  if (!current) return
+
+  const tabs = [...current.closest('[role="tablist"]').querySelectorAll('[role="tab"]')]
+  const index = tabs.indexOf(current)
+  if (index < 0) return
+
+  let nextIndex = null
+  if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length
+  if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length
+  if (event.key === 'Home') nextIndex = 0
+  if (event.key === 'End') nextIndex = tabs.length - 1
+  if (nextIndex === null) return
+
+  event.preventDefault()
+  const next = tabs[nextIndex]
+  next.focus()
+  next.click()
+  window.requestAnimationFrame(syncGameTabs)
+}
+
 export default function AppShell() {
   const location = useLocation()
   const navigationType = useNavigationType()
@@ -80,6 +123,28 @@ export default function AppShell() {
     }
   }, [location.key, navigationType])
 
+  useEffect(() => {
+    if (!location.pathname.startsWith('/games/')) return undefined
+
+    const root = document.getElementById('root') || document.body
+    const scheduleSync = () => window.requestAnimationFrame(syncGameTabs)
+    const onClick = (event) => {
+      if (event.target.closest?.('.rules-tabs [role="tab"]')) scheduleSync()
+    }
+
+    scheduleSync()
+    document.addEventListener('keydown', handleGameTabKeyDown)
+    document.addEventListener('click', onClick)
+    const observer = new MutationObserver(scheduleSync)
+    observer.observe(root, { childList: true, subtree: true })
+
+    return () => {
+      document.removeEventListener('keydown', handleGameTabKeyDown)
+      document.removeEventListener('click', onClick)
+      observer.disconnect()
+    }
+  }, [location.pathname])
+
   return (
     <>
       {navigating && (
@@ -89,9 +154,7 @@ export default function AppShell() {
           data-navigation-feedback
           style={{ position: 'fixed', top: 0, left: 0, right: 0, zIndex: 10000, height: '3px', overflow: 'hidden', background: 'var(--accent-primary, currentColor)' }}
         >
-          <span style={{ position: 'absolute', width: '1px', height: '1px', overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap' }}>
-            画面を切り替えています
-          </span>
+          <span className="sr-only">画面を切り替えています</span>
         </div>
       )}
       <Outlet />

--- a/frontend/src/components/EditGameModal.jsx
+++ b/frontend/src/components/EditGameModal.jsx
@@ -1,62 +1,94 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+function initialFormData(game) {
+  if (!game) return {}
+  let structuredData = { keywords: [] }
+  if (game.structured_data && !Array.isArray(game.structured_data)) {
+    structuredData = { ...game.structured_data }
+    if (!structuredData.keywords) structuredData.keywords = []
+  }
+  return {
+    title: game.title || '',
+    title_ja: game.title_ja || '',
+    description: game.description || '',
+    summary: game.summary || '',
+    rules_content: game.rules_content || '',
+    min_players: game.min_players || '',
+    max_players: game.max_players || '',
+    play_time: game.play_time || '',
+    min_age: game.min_age || '',
+    published_year: game.published_year || '',
+    image_url: game.image_url || '',
+    official_url: game.official_url || '',
+    bgg_url: game.bgg_url || '',
+    structured_data: structuredData,
+  }
+}
+
+function focusableElements(container) {
+  if (!container) return []
+  return [...container.querySelectorAll(
+    'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+  )].filter((element) => !element.hidden && element.getAttribute('aria-hidden') !== 'true')
+}
 
 export default function EditGameModal({ game, isOpen, onClose, onSave }) {
-  const [formData, setFormData] = useState(() => {
-    if (!game) return {}
-    let structuredData = { keywords: [] }
-    if (game.structured_data && !Array.isArray(game.structured_data)) {
-      structuredData = { ...game.structured_data }
-      if (!structuredData.keywords) structuredData.keywords = []
-    }
-    return {
-      title: game.title || '',
-      title_ja: game.title_ja || '',
-      description: game.description || '',
-      summary: game.summary || '',
-      rules_content: game.rules_content || '',
-      min_players: game.min_players || '',
-      max_players: game.max_players || '',
-      play_time: game.play_time || '',
-      min_age: game.min_age || '',
-      published_year: game.published_year || '',
-      image_url: game.image_url || '',
-      official_url: game.official_url || '',
-      bgg_url: game.bgg_url || '',
-      structured_data: structuredData,
-    }
-  })
+  const [formData, setFormData] = useState(() => initialFormData(game))
   const [saving, setSaving] = useState(false)
   const [newKeyword, setNewKeyword] = useState({ term: '', description: '' })
+  const dialogRef = useRef(null)
+  const previousFocusRef = useRef(null)
 
-  const handleChange = (e) => {
-    const { name, value } = e.target
-    setFormData((prev) => ({ ...prev, [name]: value }))
+  useEffect(() => {
+    if (isOpen) setFormData(initialFormData(game))
+  }, [game, isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return undefined
+    previousFocusRef.current = document.activeElement
+    const frame = window.requestAnimationFrame(() => {
+      const firstField = dialogRef.current?.querySelector('#edit-game-title')
+      if (firstField) firstField.focus()
+      else dialogRef.current?.focus()
+    })
+
+    return () => {
+      window.cancelAnimationFrame(frame)
+      const previous = previousFocusRef.current
+      if (previous instanceof HTMLElement && previous.isConnected) previous.focus()
+    }
+  }, [isOpen])
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setFormData((previous) => ({ ...previous, [name]: value }))
   }
 
   const handleAddKeyword = () => {
-    setFormData((prev) => ({
-      ...prev,
+    if (!newKeyword.term.trim()) return
+    setFormData((previous) => ({
+      ...previous,
       structured_data: {
-        ...prev.structured_data,
-        keywords: [...(prev.structured_data?.keywords || []), newKeyword],
+        ...previous.structured_data,
+        keywords: [...(previous.structured_data?.keywords || []), newKeyword],
       },
     }))
     setNewKeyword({ term: '', description: '' })
   }
 
   const handleRemoveKeyword = (index) => {
-    setFormData((prev) => {
-      const keywords = [...(prev.structured_data?.keywords || [])]
+    setFormData((previous) => {
+      const keywords = [...(previous.structured_data?.keywords || [])]
       keywords.splice(index, 1)
       return {
-        ...prev,
-        structured_data: { ...prev.structured_data, keywords },
+        ...previous,
+        structured_data: { ...previous.structured_data, keywords },
       }
     })
   }
 
-  const handleSubmit = async (e) => {
-    e.preventDefault()
+  const handleSubmit = async (event) => {
+    event.preventDefault()
     setSaving(true)
     const payload = { ...formData }
     const numericFields = ['min_players', 'max_players', 'play_time', 'min_age', 'published_year']
@@ -66,134 +98,172 @@ export default function EditGameModal({ game, isOpen, onClose, onSave }) {
       else payload[field] = Number(payload[field])
     })
 
-    await onSave(payload)
-    onClose()
-    setSaving(false)
+    try {
+      await onSave(payload)
+      onClose()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDialogKeyDown = (event) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      if (!saving) onClose()
+      return
+    }
+    if (event.key !== 'Tab') return
+
+    const focusable = focusableElements(dialogRef.current)
+    if (focusable.length === 0) {
+      event.preventDefault()
+      dialogRef.current?.focus()
+      return
+    }
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
   }
 
   if (!isOpen) return null
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+      <div
+        ref={dialogRef}
+        className="modal-content"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="edit-game-dialog-title"
+        tabIndex={-1}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={handleDialogKeyDown}
+      >
         <div className="modal-header">
-          <h3>ゲーム情報を編集</h3>
-          <button className="close-btn" onClick={onClose} aria-label="編集画面を閉じる">
+          <h3 id="edit-game-dialog-title">ゲーム情報を編集</h3>
+          <button type="button" className="close-btn" onClick={onClose} aria-label="編集画面を閉じる" disabled={saving}>
             &times;
           </button>
         </div>
 
         <form onSubmit={handleSubmit} className="edit-form">
           <div className="form-group">
-            <label>タイトル (英語/原題)</label>
-            <input name="title" value={formData.title} onChange={handleChange} required />
+            <label htmlFor="edit-game-title">タイトル (英語/原題)</label>
+            <input id="edit-game-title" name="title" value={formData.title || ''} onChange={handleChange} required />
           </div>
 
           <div className="form-group">
-            <label>タイトル (日本語)</label>
-            <input name="title_ja" value={formData.title_ja} onChange={handleChange} />
+            <label htmlFor="edit-game-title-ja">タイトル (日本語)</label>
+            <input id="edit-game-title-ja" name="title_ja" value={formData.title_ja || ''} onChange={handleChange} />
           </div>
 
           <div className="form-row">
             <div className="form-group">
-              <label>最小人数</label>
-              <input type="number" name="min_players" value={formData.min_players} onChange={handleChange} />
+              <label htmlFor="edit-game-min-players">最小人数</label>
+              <input id="edit-game-min-players" type="number" name="min_players" value={formData.min_players ?? ''} onChange={handleChange} />
             </div>
             <div className="form-group">
-              <label>最大人数</label>
-              <input type="number" name="max_players" value={formData.max_players} onChange={handleChange} />
+              <label htmlFor="edit-game-max-players">最大人数</label>
+              <input id="edit-game-max-players" type="number" name="max_players" value={formData.max_players ?? ''} onChange={handleChange} />
             </div>
             <div className="form-group">
-              <label>プレイ時間(分)</label>
-              <input type="number" name="play_time" value={formData.play_time} onChange={handleChange} />
+              <label htmlFor="edit-game-play-time">プレイ時間(分)</label>
+              <input id="edit-game-play-time" type="number" name="play_time" value={formData.play_time ?? ''} onChange={handleChange} />
             </div>
           </div>
 
           <div className="form-row">
             <div className="form-group">
-              <label>対象年齢</label>
-              <input type="number" name="min_age" value={formData.min_age} onChange={handleChange} />
+              <label htmlFor="edit-game-min-age">対象年齢</label>
+              <input id="edit-game-min-age" type="number" name="min_age" value={formData.min_age ?? ''} onChange={handleChange} />
             </div>
             <div className="form-group">
-              <label>発行年</label>
-              <input type="number" name="published_year" value={formData.published_year} onChange={handleChange} />
+              <label htmlFor="edit-game-year">発行年</label>
+              <input id="edit-game-year" type="number" name="published_year" value={formData.published_year ?? ''} onChange={handleChange} />
             </div>
           </div>
 
           <div className="form-group">
-            <label>概要 (Summary)</label>
-            <textarea name="summary" value={formData.summary} onChange={handleChange} rows={3} />
+            <label htmlFor="edit-game-summary">概要 (Summary)</label>
+            <textarea id="edit-game-summary" name="summary" value={formData.summary || ''} onChange={handleChange} rows={3} />
           </div>
 
           <div className="form-group">
-            <label>詳細説明 (Description)</label>
-            <textarea name="description" value={formData.description} onChange={handleChange} rows={5} />
+            <label htmlFor="edit-game-description">詳細説明 (Description)</label>
+            <textarea id="edit-game-description" name="description" value={formData.description || ''} onChange={handleChange} rows={5} />
           </div>
 
           <div className="form-group">
-            <label>ルール詳細 (Rules Content Markdown)</label>
-            <textarea name="rules_content" value={formData.rules_content} onChange={handleChange} rows={8} />
+            <label htmlFor="edit-game-rules">ルール詳細 (Rules Content Markdown)</label>
+            <textarea id="edit-game-rules" name="rules_content" value={formData.rules_content || ''} onChange={handleChange} rows={8} />
           </div>
 
-          <div className="form-group">
-            <label>キーワード (Keywords)</label>
-            <div style={{ marginBottom: '10px' }}>
-              {(formData.structured_data?.keywords || []).map((k, i) => (
-                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '5px' }}>
-                  <input readOnly value={k.term} style={{ width: '120px' }} />
-                  <input readOnly value={k.description} style={{ flex: 1 }} />
+          <fieldset className="form-group keyword-fieldset">
+            <legend>キーワード (Keywords)</legend>
+            <div className="keyword-list">
+              {(formData.structured_data?.keywords || []).map((keyword, index) => (
+                <div key={`${keyword.term}-${index}`} className="keyword-row">
+                  <input readOnly value={keyword.term} aria-label={`キーワード ${index + 1} の用語`} className="keyword-term" />
+                  <input readOnly value={keyword.description} aria-label={`キーワード ${index + 1} の説明`} className="keyword-description" />
                   <button
                     type="button"
-                    onClick={() => handleRemoveKeyword(i)}
+                    onClick={() => handleRemoveKeyword(index)}
                     className="keyword-remove-button"
-                    aria-label={`${k.term || 'キーワード'}を削除`}
+                    aria-label={`${keyword.term || 'キーワード'}を削除`}
                   >
                     ×
                   </button>
                 </div>
               ))}
             </div>
-            <div style={{ display: 'flex', gap: '10px' }}>
+            <div className="keyword-row keyword-row--new">
+              <label className="sr-only" htmlFor="edit-game-new-keyword">追加するキーワード</label>
               <input
+                id="edit-game-new-keyword"
                 placeholder="用語 (例: デッキ構築)"
                 value={newKeyword.term}
-                onChange={(e) => setNewKeyword({ ...newKeyword, term: e.target.value })}
-                style={{ width: '120px' }}
+                onChange={(event) => setNewKeyword({ ...newKeyword, term: event.target.value })}
+                className="keyword-term"
               />
+              <label className="sr-only" htmlFor="edit-game-new-keyword-description">追加するキーワードの説明</label>
               <input
+                id="edit-game-new-keyword-description"
                 placeholder="説明"
                 value={newKeyword.description}
-                onChange={(e) => setNewKeyword({ ...newKeyword, description: e.target.value })}
-                style={{ flex: 1 }}
+                onChange={(event) => setNewKeyword({ ...newKeyword, description: event.target.value })}
+                className="keyword-description"
               />
-              <button type="button" onClick={handleAddKeyword} className="btn-secondary" style={{ padding: '0 15px' }}>
+              <button type="button" onClick={handleAddKeyword} className="btn-secondary keyword-add-button" disabled={!newKeyword.term.trim()}>
                 追加
               </button>
             </div>
+          </fieldset>
+
+          <div className="form-group">
+            <label htmlFor="edit-game-image-url">画像URL</label>
+            <input id="edit-game-image-url" name="image_url" value={formData.image_url || ''} onChange={handleChange} />
           </div>
 
           <div className="form-group">
-            <label>画像URL</label>
-            <input name="image_url" value={formData.image_url} onChange={handleChange} />
+            <label htmlFor="edit-game-official-url">公式サイトURL</label>
+            <input id="edit-game-official-url" name="official_url" value={formData.official_url || ''} onChange={handleChange} />
           </div>
 
           <div className="form-group">
-            <label>公式サイトURL</label>
-            <input name="official_url" value={formData.official_url} onChange={handleChange} />
-          </div>
-
-          <div className="form-group">
-            <label>BGG URL</label>
-            <input name="bgg_url" value={formData.bgg_url} onChange={handleChange} />
+            <label htmlFor="edit-game-bgg-url">BGG URL</label>
+            <input id="edit-game-bgg-url" name="bgg_url" value={formData.bgg_url || ''} onChange={handleChange} />
           </div>
 
           <div className="modal-actions">
-            <button type="button" onClick={onClose} className="btn-secondary" disabled={saving}>
-              キャンセル
-            </button>
-            <button type="submit" className="btn-primary" disabled={saving}>
-              {saving ? '保存中...' : '保存'}
-            </button>
+            <button type="button" onClick={onClose} className="btn-secondary" disabled={saving}>キャンセル</button>
+            <button type="submit" className="btn-primary" disabled={saving}>{saving ? '保存中...' : '保存'}</button>
           </div>
         </form>
       </div>

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,6 +7,7 @@ import './index.css'
 import './layout.css'
 import './game-detail-palette.css'
 import './ui-palette.css'
+import './uiux-accessibility.css'
 
 const GamePage = lazy(() => import('./pages/GamePage.jsx'))
 const DataPage = lazy(() => import('./pages/DataPage.jsx'))

--- a/frontend/src/uiux-accessibility.css
+++ b/frontend/src/uiux-accessibility.css
@@ -1,0 +1,290 @@
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.directory-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.generate-game-button {
+  white-space: nowrap;
+  min-height: var(--ks-control-min);
+}
+
+.filter-grid--single {
+  grid-template-columns: 1fr;
+}
+
+.filter-reset-button {
+  width: 100%;
+  border-color: var(--ks-secondary);
+}
+
+.mobile-filter-toggle,
+.mobile-filter-close,
+.mobile-filter-backdrop {
+  display: none;
+}
+
+.results-count {
+  font-size: 0.8rem;
+  color: var(--ks-ink-muted);
+  font-weight: 700;
+}
+
+.asset-card-shell {
+  position: relative;
+  min-width: 0;
+}
+
+.asset-card-link {
+  height: 100%;
+}
+
+.compare-toggle {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  padding: 4px 8px;
+  font-size: 0.65rem;
+}
+
+.compare-toggle:disabled {
+  background: var(--ks-unavailable-soft);
+  color: var(--ks-unavailable);
+  border-color: var(--ks-border);
+  opacity: 1;
+}
+
+.compare-feedback {
+  background: var(--ks-attention-soft);
+  color: var(--ks-attention);
+  border-color: color-mix(in srgb, var(--ks-attention) 42%, var(--ks-border));
+}
+
+.load-more-wrap {
+  text-align: center;
+  padding: 2rem;
+}
+
+.load-more-button {
+  padding: 10px 24px;
+  font-size: 0.9rem;
+  border-color: var(--ks-primary);
+}
+
+.comparison-page {
+  overflow-y: auto;
+  height: 100dvh;
+  padding: 2rem;
+}
+
+.comparison-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.comparison-game-card {
+  text-align: center;
+}
+
+.comparison-game-image {
+  width: 100%;
+  border-radius: var(--ks-radius-md);
+  margin-bottom: 1rem;
+}
+
+.comparison-tier {
+  position: static;
+  margin-top: 8px;
+  display: inline-block;
+}
+
+.comparison-summary {
+  font-size: 0.85rem;
+  color: var(--ks-ink-muted);
+}
+
+.comparison-specs {
+  margin-bottom: 0;
+}
+
+.comparison-stat {
+  font-size: 0.9rem;
+}
+
+.comparison-detail-link {
+  width: 100%;
+  display: block;
+  text-decoration: none;
+  margin-top: 2rem;
+}
+
+.comparison-tray {
+  max-width: calc(100vw - 2rem);
+}
+
+.comparison-tray__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.compare-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.battle-start-button {
+  padding: 6px 16px;
+  border-radius: var(--ks-radius-pill);
+  white-space: nowrap;
+}
+
+.modal-content[role='dialog'] {
+  max-height: min(90dvh, 900px);
+  overflow-y: auto;
+}
+
+.keyword-fieldset {
+  min-width: 0;
+  border: 0;
+  padding: 0;
+}
+
+.keyword-fieldset legend {
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.keyword-list {
+  display: grid;
+  gap: 0.4rem;
+  margin-bottom: 0.6rem;
+}
+
+.keyword-row {
+  display: grid;
+  grid-template-columns: minmax(7.5rem, 0.35fr) minmax(0, 1fr) auto;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.keyword-term,
+.keyword-description {
+  min-width: 0;
+}
+
+.keyword-add-button {
+  padding-inline: 15px;
+}
+
+.game-main .pro-main-col[role='tabpanel']:focus-visible {
+  outline: 2px solid var(--ks-focus);
+  outline-offset: 4px;
+  border-radius: var(--ks-radius-sm);
+}
+
+@media (max-width: 900px) {
+  .directory-search {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .generate-game-button {
+    width: 100%;
+  }
+
+  .mobile-filter-toggle,
+  .mobile-filter-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .mobile-filter-close {
+    width: 100%;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+  }
+
+  .mobile-filter-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 2990;
+    border: 0;
+    min-height: 100dvh;
+    background: rgb(36 54 83 / 0.28);
+    cursor: default;
+  }
+
+  #root > aside.filter-sidebar-shell.mobile-open {
+    display: flex !important;
+    position: fixed;
+    inset: 0 auto 0 0;
+    z-index: 3000;
+    width: min(88vw, 360px);
+    max-width: 100%;
+    height: 100dvh;
+    overflow-y: auto;
+    border-right: 1px solid var(--ks-border);
+    border-bottom: 0;
+    box-shadow: 12px 0 32px rgb(36 54 83 / 0.18);
+  }
+
+  .control-panel {
+    align-items: flex-start;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .active-filters {
+    flex: 1 1 100%;
+    align-items: center;
+  }
+
+  .sort-select {
+    width: 100%;
+  }
+
+  .comparison-tray {
+    bottom: 0.75rem;
+    padding: 8px 12px;
+    gap: 8px;
+    overflow-x: auto;
+    justify-content: flex-start;
+  }
+
+  .comparison-page__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 560px) {
+  .keyword-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .keyword-remove-button,
+  .keyword-add-button {
+    justify-self: start;
+  }
+}

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -155,12 +155,12 @@ test('directory empty state and comparison tray use the same light palette', asy
   await page.goto('/')
   await expect(page.getByText('配色監査', { exact: true })).toBeVisible()
 
-  await page.getByRole('button', { name: 'COMPARE' }).first().click()
-  await page.getByRole('button', { name: 'COMPARE' }).first().click()
+  await page.getByRole('button', { name: '配色監査を比較に追加' }).click()
+  await page.getByRole('button', { name: '配色監査2を比較に追加' }).click()
   await expect(page.getByRole('button', { name: 'BATTLE START' })).toBeVisible()
   await expectLightSurface(page.locator('.comparison-tray'), 'comparison tray')
 
-  const search = page.getByPlaceholder('ゲームを検索、または未登録ゲームをAI生成...')
+  const search = page.getByLabel('ゲームを検索')
   await search.fill('no-match-palette-audit')
   await expect(page.getByText('条件に一致するゲームが見つかりません。')).toBeVisible()
   await expectLightSurface(page.locator('.app-empty-state'), 'directory empty state')

--- a/frontend/tests/rule_guide.spec.js
+++ b/frontend/tests/rule_guide.spec.js
@@ -89,7 +89,7 @@ test('new user can search IPSO and reach quick rules, scoring, diagram and sourc
 
   await page.goto('/')
   await expect(page.getByText('イプソ (IPSO)', { exact: true }).first()).toBeVisible()
-  await page.getByPlaceholder('ゲームを検索、または未登録ゲームをAI生成...').fill('IPSO')
+  await page.getByLabel('ゲームを検索').fill('IPSO')
   await expect(page.getByText('1 RESULTS')).toBeVisible()
   await page.screenshot({ path: testInfo.outputPath(`new-user-home-${testInfo.project.name}.png`), animations: 'disabled' })
 

--- a/frontend/tests/uiux_a11y_regression.spec.js
+++ b/frontend/tests/uiux_a11y_regression.spec.js
@@ -1,0 +1,132 @@
+import { test, expect } from '@playwright/test'
+
+const games = [
+  { id: '11111111-1111-4111-8111-111111111111', slug: 'game-one', title: 'Game One', title_ja: 'ゲーム1', summary: '宇宙のゲーム', min_players: 2, max_players: 4, play_time: 30, published_year: 2026, structured_data: {} },
+  { id: '22222222-2222-4222-8222-222222222222', slug: 'game-two', title: 'Game Two', title_ja: 'ゲーム2', summary: '森のゲーム', min_players: 3, max_players: 5, play_time: 45, published_year: 2025, structured_data: {} },
+  { id: '33333333-3333-4333-8333-333333333333', slug: 'game-three', title: 'Game Three', title_ja: 'ゲーム3', summary: '海のゲーム', min_players: 2, max_players: 6, play_time: 60, published_year: 2024, structured_data: {} },
+  { id: '44444444-4444-4444-8444-444444444444', slug: 'game-four', title: 'Game Four', title_ja: 'ゲーム4', summary: '山のゲーム', min_players: 4, max_players: 8, play_time: 90, published_year: 2023, structured_data: {} },
+]
+
+async function mockDirectory(page, counters = { generated: 0 }) {
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    if (url.pathname === '/api/games' && request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games, total: games.length }) })
+      return
+    }
+    if (url.pathname === '/api/search' && request.method() === 'POST') {
+      counters.generated += 1
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [games[0]] }) })
+      return
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'not mocked' }) })
+  })
+}
+
+async function mockGameDetail(page) {
+  const detail = {
+    ...games[0],
+    rules_content: '## 目的\n最初に勝利条件を満たします。',
+    setup_summary: 'カードを配ります。',
+    gameplay_summary: '順番に手番を行います。',
+    end_game_summary: '勝利条件を満たしたら終了します。',
+    source_url: 'https://example.com/rules',
+    structured_data: {},
+  }
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    if (url.pathname === '/api/games/game-one' && request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(detail) })
+      return
+    }
+    if (url.pathname === '/api/games' && request.method() === 'GET') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games, total: games.length }) })
+      return
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'not mocked' }) })
+  })
+}
+
+test('directory keeps search local, labels controls, exposes mobile filters, and explains compare limit', async ({ page }) => {
+  const counters = { generated: 0 }
+  await mockDirectory(page, counters)
+  await page.goto('/')
+  await expect(page.getByText('ゲーム1', { exact: true }).first()).toBeVisible()
+
+  const search = page.getByLabel('ゲームを検索')
+  const sort = page.getByLabel('ゲームの並び順')
+  await expect(search).toBeVisible()
+  await expect(sort).toBeVisible()
+
+  await search.fill('森')
+  await search.press('Enter')
+  await expect(page.getByText('ゲーム2', { exact: true }).first()).toBeVisible()
+  await expect(page.getByText('ゲーム1', { exact: true })).toHaveCount(0)
+  expect(counters.generated).toBe(0)
+
+  await search.fill('')
+  await expect(page.getByText('ゲーム1', { exact: true }).first()).toBeVisible()
+
+  if ((page.viewportSize()?.width || 0) <= 900) {
+    const filterToggle = page.getByRole('button', { name: 'フィルター', exact: true })
+    await expect(filterToggle).toBeVisible()
+    await filterToggle.click()
+    const filterPanel = page.getByRole('complementary', { name: 'ゲーム絞り込み' })
+    await expect(filterPanel).toBeVisible()
+    await filterPanel.getByRole('button', { name: '2人' }).click()
+    await filterPanel.getByRole('button', { name: 'フィルターを閉じる' }).click()
+    await expect(page.getByText('人数: 2')).toBeVisible()
+  }
+
+  for (const title of ['ゲーム1', 'ゲーム2', 'ゲーム3']) {
+    await page.getByRole('button', { name: `${title}を比較に追加` }).click()
+  }
+  await expect(page.getByRole('region', { name: '比較トレイ 3/3' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'ゲーム4を比較に追加' })).toBeDisabled()
+  await expect(page.getByText('BATTLE TRAY · 3/3')).toBeVisible()
+})
+
+test('AI generation only runs from its explicit CTA', async ({ page }) => {
+  const counters = { generated: 0 }
+  await mockDirectory(page, counters)
+  await page.goto('/')
+  const search = page.getByLabel('ゲームを検索')
+  await search.fill('未登録タイトル')
+  await search.press('Enter')
+  expect(counters.generated).toBe(0)
+
+  await page.getByRole('button', { name: '未登録ゲームをAIで追加' }).click()
+  await expect.poll(() => counters.generated).toBe(1)
+})
+
+test('game detail tabs implement the APG keyboard and tabpanel relationship', async ({ page }) => {
+  await mockGameDetail(page)
+  await page.goto('/games/game-one')
+
+  const rulesTab = page.getByRole('tab', { name: /詳しいルール/ })
+  const setupTab = page.getByRole('tab', { name: /セットアップ/ })
+  const relatedTab = page.getByRole('tab', { name: /関連ゲーム/ })
+  await expect(rulesTab).toHaveAttribute('aria-selected', 'true')
+  await expect(rulesTab).toHaveAttribute('tabindex', '0')
+  await expect(setupTab).toHaveAttribute('tabindex', '-1')
+
+  await rulesTab.focus()
+  await page.keyboard.press('ArrowRight')
+  await expect(setupTab).toBeFocused()
+  await expect(setupTab).toHaveAttribute('aria-selected', 'true')
+  await expect(rulesTab).toHaveAttribute('tabindex', '-1')
+
+  const panel = page.getByRole('tabpanel')
+  const setupId = await setupTab.getAttribute('id')
+  await expect(panel).toHaveAttribute('aria-labelledby', setupId)
+  await expect(setupTab).toHaveAttribute('aria-controls', 'game-detail-tabpanel')
+
+  await page.keyboard.press('End')
+  await expect(relatedTab).toBeFocused()
+  await expect(relatedTab).toHaveAttribute('aria-selected', 'true')
+  await page.keyboard.press('Home')
+  await expect(rulesTab).toBeFocused()
+})

--- a/frontend/tests/uiux_a11y_regression.spec.js
+++ b/frontend/tests/uiux_a11y_regression.spec.js
@@ -79,6 +79,8 @@ test('directory keeps search local, labels controls, exposes mobile filters, and
     await filterPanel.getByRole('button', { name: '2人' }).click()
     await filterPanel.getByRole('button', { name: 'フィルターを閉じる' }).click()
     await expect(page.getByText('人数: 2')).toBeVisible()
+    await page.getByRole('button', { name: '人数フィルターを解除' }).click()
+    await expect(page.getByText('ゲーム2', { exact: true }).first()).toBeVisible()
   }
 
   for (const title of ['ゲーム1', 'ゲーム2', 'ゲーム3']) {


### PR DESCRIPTION
## Summary

Fix the six UI/UX defects found in the 2026-08-14 production/code audit.

- restore player/time/tier filters on mobile/tablet with an accessible drawer, backdrop, close action, and Escape handling
- add explicit accessible labels for directory search, sorting, and EditGameModal controls
- complete the game-detail tabs as a WAI-ARIA tabs interaction: roving tabindex, tabpanel relationship, ArrowLeft/ArrowRight/Home/End keyboard activation
- make EditGameModal a modal dialog with initial focus, focus trapping, Escape close, and focus return
- make the 3-game compare limit explicit, expose per-game pressed state/names, and disable a fourth selection rather than silently ignoring it
- separate local existing-game search from the explicit "未登録ゲームをAIで追加" action so Enter no longer triggers AI generation

## Regression prevention

- add `uiux_a11y_regression.spec.js` for 375 / 768 / 1440 contracts
- add a static source contract gate for the accessibility/interaction invariants
- run the new checks in the canonical `UI UX regression` workflow

## Standards

Implementation follows the W3C WAI form-label guidance and WAI-ARIA APG Tabs / Modal Dialog patterns.

Closes #120
Closes #121
Closes #122
Closes #123
Closes #124
Closes #125