### PR TITLE
Fix compare limit feedback and accessibility

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -89,7 +89,7 @@ jobs:
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
-      - name: Gate existing list navigation loading and auth contracts
+      - name: Gate existing list navigation loading auth and compare contracts
         working-directory: frontend
         run: >-
           npx playwright test
@@ -98,6 +98,7 @@ jobs:
           tests/performance.spec.js
           tests/game_layout.spec.js
           tests/auth.spec.js
+          tests/compare.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState, useMemo } from 'react'
 import { useSearchParams, Link, useNavigate } from 'react-router-dom'
 import { api } from './lib/api'
 
+const COMPARE_LIMIT = 3
+
 function App() {
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -172,13 +174,16 @@ function App() {
   }
 
   const toggleCompare = (game) => {
-    if (compareList.find(g => g.id === game.id)) {
-      setCompareList(compareList.filter(g => g.id !== game.id))
-    } else {
-      if (compareList.length >= 3) return
-      setCompareList([...compareList, game])
-    }
+    setCompareList((current) => {
+      if (current.some(g => g.id === game.id)) {
+        return current.filter(g => g.id !== game.id)
+      }
+      if (current.length >= COMPARE_LIMIT) return current
+      return [...current, game]
+    })
   }
+
+  const compareLimitReached = compareList.length >= COMPARE_LIMIT
 
   if (isBattleMode) {
     return (
@@ -322,6 +327,15 @@ function App() {
             <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)', fontWeight: '700' }}>
               {filteredGames.length} RESULTS
             </span>
+            <span
+              id="compare-limit-status"
+              role="status"
+              aria-live="polite"
+              style={{ fontSize: '0.75rem', color: compareLimitReached ? 'var(--ks-rejected)' : 'var(--text-muted)', fontWeight: 700 }}
+            >
+              比較 {compareList.length}/{COMPARE_LIMIT}
+              {compareLimitReached ? ' · 上限です。選択済みを外すと追加できます。' : ' · 最大3件'}
+            </span>
             {activePlayers && <div className="filter-chip">人数: {activePlayers} <button onClick={() => setActivePlayers(null)}>×</button></div>}
             {activeTime && <div className="filter-chip">時間: {activeTime} <button onClick={() => setActiveTime(null)}>×</button></div>}
             {activeTier && <div className="filter-chip">Tier: {activeTier} <button onClick={() => setActiveTier(null)}>×</button></div>}
@@ -346,37 +360,57 @@ function App() {
           <div className="app-loading-state" role="status">ARCHIVE INITIALIZING...</div>
         ) : (
           <div className="asset-grid">
-            {filteredGames.map(game => (
-              <div key={game.id} style={{ position: 'relative' }}>
-                <Link to={`/games/${game.slug}`} className="asset-card" style={{ height: '100%' }}>
-                  <div className="asset-thumb-container">
-                    {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
-                    <img
-                      src={game.image_url || '/assets/no-image.webp'}
-                      alt={game.title_ja || game.title}
-                      className="asset-thumb"
-                      loading="lazy"
-                    />
-                  </div>
-                  <div className="asset-info">
-                    <div className="asset-title">{game.title_ja || game.title}</div>
-                    <div className="asset-meta">
-                      {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
-                      {game.play_time && <span className="meta-item">⏳ {game.play_time}m</span>}
-                      {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}
+            {filteredGames.map(game => {
+              const gameName = game.title_ja || game.title || '名称未設定のゲーム'
+              const isCompared = compareList.some(g => g.id === game.id)
+              const compareDisabled = compareLimitReached && !isCompared
+
+              return (
+                <div key={game.id} style={{ position: 'relative' }}>
+                  <Link to={`/games/${game.slug}`} className="asset-card" style={{ height: '100%' }}>
+                    <div className="asset-thumb-container">
+                      {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
+                      <img
+                        src={game.image_url || '/assets/no-image.webp'}
+                        alt={gameName}
+                        className="asset-thumb"
+                        loading="lazy"
+                      />
                     </div>
-                    <div className="asset-summary">{game.summary || game.description}</div>
-                  </div>
-                </Link>
-                <button
-                  onClick={(e) => { e.preventDefault(); toggleCompare(game); }}
-                  className={`filter-btn ${compareList.find(g => g.id === game.id) ? 'active' : ''}`}
-                  style={{ position: 'absolute', top: '8px', right: '8px', zIndex: 10, padding: '4px 8px', fontSize: '0.65rem' }}
-                >
-                  {compareList.find(g => g.id === game.id) ? 'READY' : 'COMPARE'}
-                </button>
-              </div>
-            ))}
+                    <div className="asset-info">
+                      <div className="asset-title">{gameName}</div>
+                      <div className="asset-meta">
+                        {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
+                        {game.play_time && <span className="meta-item">⏳ {game.play_time}m</span>}
+                        {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}
+                      </div>
+                      <div className="asset-summary">{game.summary || game.description}</div>
+                    </div>
+                  </Link>
+                  <button
+                    onClick={(e) => { e.preventDefault(); toggleCompare(game); }}
+                    className={`filter-btn ${isCompared ? 'active' : ''}`}
+                    disabled={compareDisabled}
+                    aria-pressed={isCompared}
+                    aria-label={`${gameName}を比較${isCompared ? 'から外す' : 'に追加する'}`}
+                    aria-describedby="compare-limit-status"
+                    title={compareDisabled ? `比較は${COMPARE_LIMIT}件までです。選択済みのゲームを外してから追加してください。` : undefined}
+                    style={{
+                      position: 'absolute',
+                      top: '8px',
+                      right: '8px',
+                      zIndex: 10,
+                      padding: '4px 8px',
+                      fontSize: '0.65rem',
+                      opacity: compareDisabled ? 0.55 : 1,
+                      cursor: compareDisabled ? 'not-allowed' : 'pointer',
+                    }}
+                  >
+                    {isCompared ? 'READY' : compareDisabled ? 'LIMIT 3' : 'COMPARE'}
+                  </button>
+                </div>
+              )
+            })}
             {filteredGames.length === 0 && !loading && (
               <div className="app-empty-state">
                 条件に一致するゲームが見つかりません。
@@ -399,14 +433,25 @@ function App() {
       </main>
 
       {compareList.length > 0 && (
-        <div className="comparison-tray">
-          <div className="comparison-tray__label" style={{ fontSize: '0.75rem', fontWeight: 700 }}>BATTLE TRAY</div>
-          {compareList.map(g => (
-            <div key={g.id} className="compare-item">
-              <img src={g.image_url || '/assets/no-image.webp'} style={{ width: '100%', height: '100%', objectFit: 'cover' }} alt="Compare Item" />
-              <button onClick={() => toggleCompare(g)}>×</button>
-            </div>
-          ))}
+        <div className="comparison-tray" aria-label={`比較トレイ ${compareList.length}/${COMPARE_LIMIT}`}>
+          <div className="comparison-tray__label" style={{ fontSize: '0.75rem', fontWeight: 700 }}>
+            BATTLE TRAY · {compareList.length}/{COMPARE_LIMIT}
+          </div>
+          {compareList.map(g => {
+            const gameName = g.title_ja || g.title || '名称未設定のゲーム'
+            return (
+              <div key={g.id} className="compare-item">
+                <img src={g.image_url || '/assets/no-image.webp'} style={{ width: '100%', height: '100%', objectFit: 'cover' }} alt={`${gameName}の比較サムネイル`} />
+                <button
+                  onClick={() => toggleCompare(g)}
+                  aria-label={`${gameName}を比較から外す`}
+                  title={`${gameName}を比較から外す`}
+                >
+                  ×
+                </button>
+              </div>
+            )
+          })}
           {compareList.length >= 2 && (
             <button
               className="filter-btn active"

--- a/frontend/tests/compare.spec.js
+++ b/frontend/tests/compare.spec.js
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+
+const games = [
+  { id: '11111111-1111-4111-8111-111111111111', slug: 'game-one', title: 'Game One', title_ja: 'ゲーム1', summary: '1番目', min_players: 2, max_players: 4, play_time: 45, published_year: 2026, structured_data: {} },
+  { id: '22222222-2222-4222-8222-222222222222', slug: 'game-two', title: 'Game Two', title_ja: 'ゲーム2', summary: '2番目', min_players: 2, max_players: 4, play_time: 60, published_year: 2026, structured_data: {} },
+  { id: '33333333-3333-4333-8333-333333333333', slug: 'game-three', title: 'Game Three', title_ja: 'ゲーム3', summary: '3番目', min_players: 2, max_players: 4, play_time: 75, published_year: 2026, structured_data: {} },
+  { id: '44444444-4444-4444-8444-444444444444', slug: 'game-four', title: 'Game Four', title_ja: 'ゲーム4', summary: '4番目', min_players: 2, max_players: 4, play_time: 90, published_year: 2026, structured_data: {} },
+]
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/api/games?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+})
+
+test('compare limit is explicit, accessible, and blocks a fourth game until one is removed', async ({ page }) => {
+  await page.goto('/')
+  await expect(page.getByText('ゲーム1', { exact: true }).first()).toBeVisible()
+
+  const first = page.getByRole('button', { name: 'ゲーム1を比較に追加する' })
+  const second = page.getByRole('button', { name: 'ゲーム2を比較に追加する' })
+  const third = page.getByRole('button', { name: 'ゲーム3を比較に追加する' })
+  const fourth = page.getByRole('button', { name: 'ゲーム4を比較に追加する' })
+
+  await expect(page.getByRole('status')).toContainText('比較 0/3')
+  await expect(first).toHaveAttribute('aria-pressed', 'false')
+
+  await first.click()
+  await second.click()
+  await third.click()
+
+  await expect(page.getByRole('status')).toContainText('比較 3/3 · 上限です')
+  await expect(page.getByRole('button', { name: 'ゲーム1を比較から外す' }).first()).toHaveAttribute('aria-pressed', 'true')
+  await expect(fourth).toBeDisabled()
+  await expect(fourth).toHaveText('LIMIT 3')
+  await expect(page.locator('.compare-item')).toHaveCount(3)
+
+  await fourth.evaluate((button) => button.click())
+  await expect(page.locator('.compare-item')).toHaveCount(3)
+  await expect(fourth).toHaveAttribute('aria-pressed', 'false')
+
+  const trayRemoveFirst = page.locator('.compare-item').getByRole('button', { name: 'ゲーム1を比較から外す' })
+  await expect(trayRemoveFirst).toBeVisible()
+  await trayRemoveFirst.click()
+
+  await expect(page.getByRole('status')).toContainText('比較 2/3 · 最大3件')
+  await expect(fourth).toBeEnabled()
+  await fourth.click()
+
+  await expect(page.getByRole('button', { name: 'ゲーム4を比較から外す' }).first()).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.locator('.compare-item')).toHaveCount(3)
+})

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -155,8 +155,8 @@ test('directory empty state and comparison tray use the same light palette', asy
   await page.goto('/')
   await expect(page.getByText('配色監査', { exact: true })).toBeVisible()
 
-  await page.getByRole('button', { name: 'COMPARE' }).first().click()
-  await page.getByRole('button', { name: 'COMPARE' }).first().click()
+  await page.getByRole('button', { name: '配色監査を比較に追加する' }).click()
+  await page.getByRole('button', { name: '配色監査2を比較に追加する' }).click()
   await expect(page.getByRole('button', { name: 'BATTLE START' })).toBeVisible()
   await expectLightSurface(page.locator('.comparison-tray'), 'comparison tray')
 


### PR DESCRIPTION
Fixes #124

## Changes
- show the compare capacity as `0/3` through `3/3`, including an explicit limit message
- disable unselected compare buttons once three games are selected while keeping selected games removable
- give each compare toggle a game-specific accessible name, `aria-pressed`, and shared limit description
- give tray thumbnails/removal buttons game-specific accessible text
- use a functional state update so rapid toggles cannot bypass the three-game limit
- add Playwright coverage for selecting three games, blocking the fourth, removing one, and then selecting the fourth

## Verification target
- frontend lint/build
- Playwright `compare.spec.js`
- repository CI / Vercel preview