### PR TITLE
Fix catalog integrity, search, SSR, and schema regressions

### DIFF
--- a/.github/workflows/cleanup-merged-branches.yml
+++ b/.github/workflows/cleanup-merged-branches.yml
@@ -1,0 +1,84 @@
+name: Cleanup merged branches
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/cleanup-merged-branches.yml"
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Find safely deletable merged branches
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+
+          gh api --paginate "repos/$repo/pulls?state=closed&per_page=100" \
+            --jq '.[] | select(.merged_at != null and .head.repo.full_name == .base.repo.full_name) | [.head.ref, .head.sha] | @tsv' \
+            | sort -u > /tmp/merged-heads.tsv
+
+          gh api --paginate "repos/$repo/pulls?state=open&per_page=100" \
+            --jq '.[] | select(.head.repo.full_name == .base.repo.full_name) | .head.ref' \
+            | sort -u > /tmp/open-heads.txt
+
+          gh api --paginate "repos/$repo/branches?per_page=100" \
+            --jq '.[] | [.name, .commit.sha] | @tsv' \
+            | sort -u > /tmp/current-branches.tsv
+
+          : > /tmp/delete-candidates.tsv
+          while IFS=$'\t' read -r branch sha; do
+            [[ -z "$branch" || "$branch" == "main" ]] && continue
+            grep -Fxq "$branch" /tmp/open-heads.txt && continue
+            if awk -F'\t' -v b="$branch" -v s="$sha" '$1 == b && $2 == s { found=1 } END { exit !found }' /tmp/merged-heads.tsv; then
+              printf '%s\t%s\n' "$branch" "$sha" >> /tmp/delete-candidates.tsv
+            fi
+          done < /tmp/current-branches.tsv
+
+          echo "Safely deletable merged branches:"
+          cat /tmp/delete-candidates.tsv || true
+          echo "candidate_count=$(wc -l < /tmp/delete-candidates.tsv | tr -d ' ')" >> "$GITHUB_OUTPUT"
+        id: candidates
+
+      - name: Delete merged branches after main update
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          repo="$GITHUB_REPOSITORY"
+          while IFS=$'\t' read -r branch sha; do
+            [[ -z "$branch" ]] && continue
+            current_sha="$(gh api "repos/$repo/git/ref/heads/$branch" --jq '.object.sha')"
+            if [[ "$current_sha" != "$sha" ]]; then
+              echo "Skip $branch: ref moved from audited SHA $sha to $current_sha"
+              continue
+            fi
+            echo "Deleting merged branch: $branch ($sha)"
+            gh api --method DELETE "repos/$repo/git/refs/heads/$branch"
+          done < /tmp/delete-candidates.tsv
+
+      - name: Summary
+        shell: bash
+        run: |
+          {
+            echo "## Merged branch cleanup"
+            echo
+            echo "Candidates: ${{ steps.candidates.outputs.candidate_count }}"
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              echo "PR runs are dry-run only; deletion occurs after the workflow lands on main."
+            else
+              echo "Only same-repository merged PR branches whose current SHA exactly matches the merged PR head SHA are eligible. Open PR branches are excluded."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-catalog-integrity.yml
+++ b/.github/workflows/test-catalog-integrity.yml
@@ -1,0 +1,116 @@
+name: Test catalog integrity
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/core/supabase.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/services/game_service.py"
+      - "backend/app/services/seo_renderer.py"
+      - "backend/app/services/sitemap.py"
+      - "backend/app/db/migrations/**"
+      - "backend/tests/test_games_router.py"
+      - "backend/tests/test_seo_renderer.py"
+      - "backend/tests/test_sitemap.py"
+      - "frontend/src/components/game/RegenerateButton.jsx"
+      - "frontend/src/components/game/ExternalLinks.jsx"
+      - "vercel.json"
+      - ".github/workflows/test-catalog-integrity.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/core/supabase.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/services/game_service.py"
+      - "backend/app/services/seo_renderer.py"
+      - "backend/app/services/sitemap.py"
+      - "backend/app/db/migrations/**"
+      - "backend/tests/test_games_router.py"
+      - "backend/tests/test_seo_renderer.py"
+      - "backend/tests/test_sitemap.py"
+      - "frontend/src/components/game/RegenerateButton.jsx"
+      - "frontend/src/components/game/ExternalLinks.jsx"
+      - "vercel.json"
+      - ".github/workflows/test-catalog-integrity.yml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  catalog-integrity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      PGPASSWORD: postgres
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile backend
+        run: uv run python -m compileall -q backend/app
+
+      - name: Run catalog regression tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_games_router.py
+          backend/tests/test_seo_renderer.py
+          backend/tests/test_sitemap.py
+          backend/tests/test_supabase_images.py
+
+      - name: Verify catalog migration on legacy null slug fixture
+        shell: bash
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE TABLE public.games (slug text);
+          INSERT INTO public.games(slug) VALUES (NULL);
+          SQL
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/006_catalog_integrity_contract.sql
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from information_schema.columns where table_schema='public' and table_name='games' and column_name in ('setup_summary','gameplay_summary','end_game_summary');")" = "3"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from pg_constraint where conname='games_slug_required' and convalidated=false;")" = "1"
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "INSERT INTO public.games(slug) VALUES (NULL);"; then
+            echo "new null slug unexpectedly accepted"
+            exit 1
+          fi
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm ci
+          npm run build

--- a/backend/app/core/supabase.py
+++ b/backend/app/core/supabase.py
@@ -1,10 +1,11 @@
 import anyio
 import logging
+import re
+import unicodedata
 from typing import Any, Dict, List, Optional
 
 from app.core import local_db
 from app.core.settings import settings
-from app.utils.slugify import slugify
 
 logger = logging.getLogger("core.db_provider")
 _TABLE = "games"
@@ -20,6 +21,7 @@ _STORAGE_IMAGE_OVERRIDES = {
 _client = None
 try:
     from supabase import create_client
+
     if settings.supabase_url and settings.supabase_key:
         _client = create_client(settings.supabase_url, settings.supabase_key)
         logger.info("Cloud DB (Supabase) provider initialized.")
@@ -37,6 +39,31 @@ def _get_client():
     if _client is None:
         raise RuntimeError("Supabase not configured. Using Local-First.")
     return _client
+
+
+def _normalize_lookup(value: str | None) -> str:
+    normalized = unicodedata.normalize("NFKC", value or "").casefold().strip()
+    return re.sub(r"[^\w]+", "", normalized, flags=re.UNICODE)
+
+
+def _search_rank(game: Dict[str, Any], query: str) -> tuple[int, str]:
+    q = _normalize_lookup(query)
+    candidates = [
+        game.get("slug"),
+        game.get("title"),
+        game.get("title_ja"),
+        game.get("title_en"),
+    ]
+    normalized = [_normalize_lookup(str(value)) for value in candidates if value]
+    if q and q in normalized:
+        rank = 0
+    elif q and any(value.startswith(q) for value in normalized):
+        rank = 1
+    elif q and any(q in value for value in normalized):
+        rank = 2
+    else:
+        rank = 3
+    return rank, str(game.get("title_ja") or game.get("title") or "")
 
 
 def _with_canonical_storage_image(game: Dict[str, Any]) -> Dict[str, Any]:
@@ -59,28 +86,73 @@ def _with_canonical_storage_image(game: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def search(query: str) -> List[Dict[str, Any]]:
+    query = query.strip()
+    if not query:
+        return []
+
     if is_local():
         res = local_db.list_recent(limit=10000)
-        q = query.lower()
-        return [
-            g
-            for g in res["data"]
-            if q in (g.get("title") or "").lower()
-            or q in (g.get("title_ja") or "").lower()
-        ]
+        q = _normalize_lookup(query)
+        rows = []
+        for game in res["data"]:
+            haystacks = [
+                game.get("slug"),
+                game.get("title"),
+                game.get("title_ja"),
+                game.get("title_en"),
+                game.get("summary"),
+                game.get("description"),
+            ]
+            if any(q in _normalize_lookup(str(value)) for value in haystacks if value):
+                rows.append(game)
+        return sorted(rows, key=lambda game: _search_rank(game, query))
 
     def _q():
+        client = _get_client()
         safe_query = query.replace('"', '\\"')
         term = f"*{safe_query}*"
-        rows = (
-            _get_client()
-            .table(_TABLE)
+        direct_rows = (
+            client.table(_TABLE)
             .select("*")
-            .or_(f'title.ilike."{term}",description.ilike."{term}"')
+            .or_(
+                ",".join(
+                    [
+                        f'title.ilike."{term}"',
+                        f'title_ja.ilike."{term}"',
+                        f'title_en.ilike."{term}"',
+                        f'description.ilike."{term}"',
+                    ]
+                )
+            )
+            .limit(100)
             .execute()
             .data
         )
-        return [_with_canonical_storage_image(row) for row in rows]
+
+        normalized_query = _normalize_lookup(query)
+        alias_filters = [f'title.ilike."{term}"']
+        if normalized_query:
+            alias_filters.append(f'normalized_title.ilike."*{normalized_query}*"')
+        alias_rows = (
+            client.table("game_title_aliases")
+            .select("game_id")
+            .or_(",".join(alias_filters))
+            .limit(100)
+            .execute()
+            .data
+        )
+        alias_game_ids = list(dict.fromkeys(row["game_id"] for row in alias_rows if row.get("game_id")))
+        alias_games = []
+        if alias_game_ids:
+            alias_games = client.table(_TABLE).select("*").in_("id", alias_game_ids).execute().data
+
+        deduped: dict[str, Dict[str, Any]] = {}
+        for row in [*direct_rows, *alias_games]:
+            row_id = str(row.get("id") or "")
+            if row_id:
+                deduped[row_id] = _with_canonical_storage_image(row)
+
+        return sorted(deduped.values(), key=lambda game: _search_rank(game, query))
 
     return await anyio.to_thread.run_sync(_q)
 
@@ -91,7 +163,8 @@ async def list_recent(limit: int = 100, offset: int = 0) -> Dict[str, Any]:
 
     def _q():
         res = (
-            _get_client().table(_TABLE)
+            _get_client()
+            .table(_TABLE)
             .select("*", count="exact")
             .order("updated_at", desc=True)
             .range(offset, offset + limit - 1)
@@ -143,6 +216,45 @@ async def upsert_game(game_data: Dict[str, Any]) -> Dict[str, Any]:
     return await anyio.to_thread.run_sync(_q)
 
 
+async def create_unverified_game(game_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Create a new unverified work+edition pair for an authenticated generation request."""
+    if is_local():
+        local_db.upsert_game(game_data)
+        return game_data
+
+    def _q():
+        client = _get_client()
+        canonical_title = str(game_data.get("title_ja") or game_data.get("title") or "").strip()
+        if not canonical_title:
+            raise ValueError("Generated game is missing a title")
+
+        work_rows = (
+            client.table("game_works")
+            .insert({"canonical_title": canonical_title, "identity_status": "unverified"})
+            .execute()
+            .data
+        )
+        if not work_rows:
+            raise RuntimeError("Failed to create canonical game work")
+
+        work_id = work_rows[0]["id"]
+        payload = dict(game_data)
+        payload["work_id"] = work_id
+        payload["identity_status"] = "unverified"
+        payload["is_official"] = False
+        try:
+            rows = client.table(_TABLE).insert(payload).execute().data
+            if not rows:
+                raise RuntimeError("Failed to create game edition")
+            return _with_canonical_storage_image(rows[0])
+        except Exception:
+            # Avoid leaving an orphan work when the edition insert fails.
+            client.table("game_works").delete().eq("id", work_id).execute()
+            raise
+
+    return await anyio.to_thread.run_sync(_q)
+
+
 async def increment_view_count(game_id: str) -> None:
     if is_local():
         return
@@ -172,6 +284,7 @@ async def list_for_sitemap() -> list[dict[str, Any]]:
                 "image_url": g.get("image_url"),
             }
             for g in res["data"]
+            if str(g.get("slug") or "").strip()
         ]
 
     def _q():
@@ -182,6 +295,10 @@ async def list_for_sitemap() -> list[dict[str, Any]]:
             .execute()
             .data
         )
-        return [_with_canonical_storage_image(row) for row in rows]
+        return [
+            _with_canonical_storage_image(row)
+            for row in rows
+            if str(row.get("slug") or "").strip()
+        ]
 
     return await anyio.to_thread.run_sync(_q)

--- a/backend/app/db/migrations/006_catalog_integrity_contract.sql
+++ b/backend/app/db/migrations/006_catalog_integrity_contract.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+-- These columns were added directly to production during the 2026-08-14
+-- YRO verification. Keep the repository schema replayable from scratch.
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS setup_summary text,
+  ADD COLUMN IF NOT EXISTS gameplay_summary text,
+  ADD COLUMN IF NOT EXISTS end_game_summary text;
+
+-- Existing legacy data currently contains one null slug. NOT VALID keeps that
+-- historical row reviewable while immediately rejecting new/updated null or
+-- blank slugs. After the legacy row is reconciled, this constraint can be
+-- VALIDATEd without changing the write contract.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'games_slug_required'
+      AND conrelid = 'public.games'::regclass
+  ) THEN
+    ALTER TABLE public.games
+      ADD CONSTRAINT games_slug_required
+      CHECK (slug IS NOT NULL AND btrim(slug) <> '') NOT VALID;
+  END IF;
+END;
+$$;
+
+COMMIT;

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, HTTPException, Response, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 
@@ -38,8 +38,10 @@ async def sitemap_xml():
     return Response(content=content, media_type="application/xml")
 
 
-@app.get("/games/{slug}")
+@app.get("/games/{slug}", response_class=HTMLResponse)
 async def game_seo_page(slug: str):
-    """Serve the game page with server-side injected SEO tags."""
+    """Serve a crawlable game page with game-specific metadata and a real 404 boundary."""
     content = await generate_seo_html(slug)
+    if content is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     return HTMLResponse(content=content)

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -1,7 +1,8 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.rate_limiter import RateLimiter
-from app.models import GameDetail, GameUpdate, SearchRequest, GameListResponse
+from app.models import GameDetail, GameListResponse, GameUpdate, SearchRequest
+from app.routers.auth import get_current_user
 from app.services.game_service import GameService
 
 router = APIRouter()
@@ -30,14 +31,19 @@ async def search_games_post(
     body: SearchRequest,
     service: GameService = Depends(get_game_service),
 ):
+    # Always honor the DB-first contract even when a legacy client asks to generate.
+    matches = await service.search_games(body.query.strip())
+    if matches:
+        return matches
+
     if body.generate:
         if not gen_limiter.acquire():
             raise HTTPException(status_code=429, detail="Generation rate limit exceeded")
 
-        new_game = await service.generate_with_notebooklm(body.query)
+        new_game = await service.create_game_from_query(body.query.strip())
         if new_game and new_game.get("slug"):
             return [new_game]
-    return await service.search_games(body.query)
+    return []
 
 
 @router.get("/games", response_model=GameListResponse)
@@ -47,15 +53,15 @@ async def list_recent_games(limit: int = 100, offset: int = 0, service: GameServ
         "games": result["data"],
         "total": result["total"] or 0,
         "limit": limit,
-        "offset": offset
+        "offset": offset,
     }
 
 
 @router.get("/games/{slug}", response_model=GameDetail)
 async def get_game_details(slug: str, service: GameService = Depends(get_game_service)):
     game = await service.get_game_by_slug(slug)
-    if game is None:
-        raise HTTPException(status_code=404, detail="Game not found")
+    if not game:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     return game
 
 
@@ -65,16 +71,20 @@ async def update_game(
     game_update: GameUpdate | None = None,
     regenerate: bool = False,
     fill_missing_only: bool = False,
+    _user: dict = Depends(get_current_user),
     service: GameService = Depends(get_game_service),
 ) -> dict[str, object]:
-    if regenerate:
-        if not gen_limiter.acquire():
-            raise HTTPException(status_code=429, detail="Generation rate limit exceeded")
-        return await service.update_game_content(slug, fill_missing_only=fill_missing_only)
+    try:
+        if regenerate:
+            if not gen_limiter.acquire():
+                raise HTTPException(status_code=429, detail="Generation rate limit exceeded")
+            return await service.update_game_content(slug, fill_missing_only=fill_missing_only)
 
-    if game_update:
-        updates = game_update.model_dump(exclude_unset=True)
-        if updates:
-            return await service.update_game_manual(slug, updates)
+        if game_update:
+            updates = game_update.model_dump(exclude_unset=True)
+            if updates:
+                return await service.update_game_manual(slug, updates)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found") from exc
 
     return {"status": "ok", "message": "No action taken (regenerate=False, no body)"}

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -10,12 +10,12 @@ from app.core.llm_manager import LLMKeyRotator
 from app.models import GeneratedGameMetadata
 from app.prompts.prompts import PROMPTS
 from app.utils.affiliate import amazon_search_url
+from app.utils.slugify import slugify
 
 logger = logging.getLogger("agents.game_service")
 _gemini = GeminiClient()
 _key_rotator = LLMKeyRotator("GEMINI_API_KEY")
 _pipeline = None  # Lazy load in method
-_REQUIRED = ["title", "summary", "rules_content"]
 _ALLOWED_FIELDS = {
     "id",
     "slug",
@@ -132,13 +132,13 @@ class GameService:
     def __init__(self):
         self.use_local = True
         try:
-            from app.core import supabase
             supabase._get_client()
             self.use_local = False
             logger.info("Supabase connected. Using cloud DB.")
         except Exception:
             logger.warning("Supabase not configured. Falling back to local SQLite.")
             from app.core import local_db
+
             local_db.init_db()
 
     async def search_games(self, query: str) -> list[dict[str, Any]]:
@@ -150,91 +150,34 @@ class GameService:
     async def get_game_by_slug(self, slug: str) -> dict[str, Any] | None:
         return await supabase.get_by_slug(slug)
 
-    async def _generate_persona_reviews(self, query: str, context: str) -> list[dict[str, Any]]:
-        personas = [
-            {"type": "ガチ勢 (Heavy Gamer)", "desc": "複雑な戦略と深い思考を好む。運要素を嫌い、メカニクスの完成度を重視する。"},
-            {"type": "ファミリー (Family Player)", "desc": "子供や初心者と遊びやすいか、ルールが直感的か、見た目が楽しいかを重視する。"},
-            {"type": "エンジョイ勢 (Casual)", "desc": "ワイワイ盛り上がれるか、短時間で終わるか、雰囲気が良いかを重視する。"}
-        ]
-        
-        reviews = []
-        for p in personas:
-            prompt = _load_prompt("persona_review_generator.generate").format(
-                persona_type=p["type"],
-                persona_description=p["desc"],
-                query=query,
-                context=context
-            )
-            try:
-                res = await _gemini.generate_structured_json(prompt)
-                if res:
-                    reviews.append(res)
-            except Exception as e:
-                logger.warning(f"Persona review failed for {p['type']}: {e}")
-        return reviews
+    async def create_game_from_query(self, query: str) -> dict[str, Any]:
+        """Create one unverified canonical game after the DB-first search path misses."""
+        query = query.strip()
+        if not query:
+            raise ValueError("Game query must not be blank")
 
-    async def create_game_from_query(self, query: str) -> dict[str, Any] | None:
-        """
-        Generate game metadata using Gemini and save it to the database.
-        """
-        # 1. Generate with Gemini 2.0 Flash (uses existing metadata_generator logic)
-        # Note: metadata_generator is a standalone function in this file
-        try:
-            metadata = await generate_metadata(query)
-        except Exception as e:
-            logger.error(f"Metadata generation failed: {e}")
-            return None
+        # Recheck immediately before generation to avoid duplicate writes when requests race.
+        existing = await supabase.search(query)
+        if existing:
+            return existing[0]
 
-        # 3. Enhance with Pro Strategy and Persona Reviews
-        prompt = _load_prompt("pro_strategy_generator.generate").format(
-            query=query, 
-            context=metadata.get("description", "")
-        )
-        try:
-            pro_strategy = await _gemini.generate_structured_json(prompt)
-            if pro_strategy:
-                metadata["strategy_tier"] = pro_strategy.get("tier_rating", "B")
-                sd = metadata.get("structured_data", {})
-                sd["pro_tips"] = pro_strategy.get("pro_tips", [])
-                sd["rule_mistakes"] = pro_strategy.get("rule_mistakes", [])
-                sd["strategy_analysis"] = pro_strategy.get("strategy_content", "")
-                
-                # Generate Persona Reviews
-                reviews = await self._generate_persona_reviews(query, metadata.get("description", ""))
-                sd["persona_reviews"] = reviews
-                
-                metadata["structured_data"] = sd
-        except Exception as e:
-            logger.warning(f"Strategy/Persona enrichment failed for {query}: {e}")
+        metadata = await generate_metadata(query)
+        title = str(metadata.get("title_ja") or metadata.get("title") or query).strip()
+        generated_slug = str(metadata.get("slug") or slugify(title) or "").strip()
+        if not generated_slug:
+            generated_slug = f"game-{uuid.uuid4().hex[:8]}"
 
-        # 3. Save
-        game_id = str(uuid.uuid4())
-        game_data = {
-            "id": game_id,
-            "slug": metadata.get("slug") or f"{uuid.uuid4().hex[:8]}",
-            "title": metadata.get("title"),
-            "title_ja": metadata.get("title_ja"),
-            "summary": metadata.get("summary"),
-            "description": metadata.get("description"),
-            "rules_content": metadata.get("rules_content"),
-            "min_players": metadata.get("min_players"),
-            "max_players": metadata.get("max_players"),
-            "play_time": metadata.get("play_time"),
-            "min_age": metadata.get("min_age"),
-            "published_year": metadata.get("published_year"),
-            "image_url": metadata.get("image_url"),
-            "strategy_tier": metadata.get("strategy_tier", "B"),
-            "structured_data": metadata.get("structured_data", {}),
-            "created_at": datetime.now(UTC).isoformat(),
-            "updated_at": datetime.now(UTC).isoformat(),
-        }
+        slug_owner = await supabase.get_by_slug(generated_slug)
+        if slug_owner:
+            return slug_owner
 
-        if self.use_local:
-            from app.core import local_db
-            local_db.upsert_game(game_data)
-            return game_data
-        else:
-            return await supabase.upsert_game(game_data)
+        metadata.pop("id", None)
+        metadata["slug"] = generated_slug
+        metadata["title"] = metadata.get("title") or title
+        metadata["created_at"] = metadata.get("created_at") or datetime.now(UTC).isoformat()
+        metadata["updated_at"] = datetime.now(UTC).isoformat()
+        metadata["data_version"] = int(metadata.get("data_version", 0) or 0)
+        return await supabase.create_unverified_game(metadata)
 
     async def update_game_content(self, slug: str, fill_missing_only: bool = False) -> dict[str, Any]:
         game = await supabase.get_by_slug(slug)
@@ -250,18 +193,14 @@ class GameService:
         if not merged.get("id") or not slug:
             raise ValueError("Corrupt game record: missing id or slug")
 
+        # Canonical identity never changes through content regeneration.
         merged["id"], merged["slug"] = game["id"], slug
+        merged["work_id"] = game.get("work_id")
+        merged["identity_status"] = game.get("identity_status", "unverified")
         merged["data_version"] = int(game.get("data_version", 0) or 0) + 1
         out = await supabase.upsert(merged)
         if not out:
             raise RuntimeError(f"Upsert failed for game: {slug}")
-        return out[0]
-
-    async def create_game_from_query(self, query: str) -> dict[str, Any]:
-        result = await generate_metadata(query)
-        out = await supabase.upsert(result)
-        if not out:
-            raise RuntimeError(f"Creation failed for query: {query}")
         return out[0]
 
     async def update_game_manual(self, slug: str, updates: dict[str, Any]) -> dict[str, Any]:
@@ -269,7 +208,10 @@ class GameService:
         if not game:
             raise ValueError(f"Game not found for slug: {slug}")
 
-        merged = {**game, **updates}
+        # Identity fields are not mutable through the generic content endpoint.
+        protected = {"id", "slug", "work_id", "identity_status"}
+        safe_updates = {key: value for key, value in updates.items() if key not in protected}
+        merged = {**game, **safe_updates}
         merged["updated_at"] = datetime.now(UTC).isoformat()
         out = await supabase.upsert(merged)
         if not out:
@@ -277,18 +219,16 @@ class GameService:
         return out[0]
 
     async def generate_with_notebooklm(self, query: str, generate_infographics: bool = True) -> dict[str, Any]:
+        """Legacy internal pipeline. Public catalog creation uses create_game_from_query()."""
         global _pipeline
         if _pipeline is None:
             from app.services.pipeline_orchestrator import PipelineOrchestrator
+
             _pipeline = PipelineOrchestrator()
         result = await _pipeline.process_game_rules(query, generate_infographics=generate_infographics)
         if not result:
             raise RuntimeError(f"NotebookLM generation failed for: {query}")
-
-        out = await supabase.upsert(result)
-        if not out:
-            raise RuntimeError(f"Upsert failed for generated game: {query}")
-        return out[0]
+        return result
 
 
 def _merge_fields(original: dict[str, Any], incoming: dict[str, Any], fill_missing_only: bool) -> dict[str, Any]:
@@ -300,7 +240,6 @@ def _merge_fields(original: dict[str, Any], incoming: dict[str, Any], fill_missi
         is_missing = current is None or (isinstance(current, str) and current.strip() == "")
         if is_missing:
             merged[key] = value
-        if key == "structured_data":
-            if current is None or current == {}:
-                merged[key] = value
+        if key == "structured_data" and (current is None or current == {}):
+            merged[key] = value
     return merged

--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -1,29 +1,58 @@
+import html
 import json
 import logging
 import os
+import re
 from pathlib import Path
 
 from app.core.supabase import get_by_slug
 
 logger = logging.getLogger(__name__)
+BASE_URL = "https://bodoge-no-mikata.vercel.app"
 
 
-async def generate_seo_html(slug: str) -> str:
+def _replace_or_insert_tag(document: str, pattern: str, replacement: str) -> str:
+    updated, count = re.subn(pattern, replacement, document, count=1, flags=re.IGNORECASE | re.DOTALL)
+    if count:
+        return updated
+    return document.replace("</head>", f"  {replacement}\n</head>", 1)
+
+
+def _meta_tag(document: str, *, attr: str, key: str, content: str) -> str:
+    escaped_content = html.escape(content, quote=True)
+    escaped_key = re.escape(key)
+    pattern = rf'<meta\b(?=[^>]*\b{attr}=["\']{escaped_key}["\'])[^>]*>'
+    replacement = f'<meta {attr}="{html.escape(key, quote=True)}" content="{escaped_content}" />'
+    return _replace_or_insert_tag(document, pattern, replacement)
+
+
+def _safe_json_script(data: dict) -> str:
+    payload = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+    return payload.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
+
+
+async def generate_seo_html(slug: str) -> str | None:
     game = await get_by_slug(slug)
     if not game:
-        return '<html><head><title>Game Not Found</title></head><body><h1>Game Not Found</h1></body></html>'
-    title = game.get("title_ja") or game.get("title") or game.get("name")
-    description = game.get("summary") or game.get("description")
-    image_url = game.get("image_url")
-    if image_url and not image_url.startswith("http"):
-        image_url = f"https://bodoge-no-mikata.vercel.app{image_url}"
-    structured_data = {
+        return None
+
+    title = str(game.get("title_ja") or game.get("title") or game.get("name") or "Untitled")
+    description = str(game.get("summary") or game.get("description") or "")
+    image_url = str(game.get("image_url") or f"{BASE_URL}/assets/no-image.webp")
+    if image_url.startswith("/"):
+        image_url = f"{BASE_URL}{image_url}"
+
+    game_url = f"{BASE_URL}/games/{slug}"
+    page_title = f"「{title}」のルール・戦略・インスト要約 | ボドゲのミカタ"
+    seo_description = description or f"「{title}」の登録済みルール要約と出典情報を確認できます。"
+
+    structured_data: dict[str, object] = {
         "@context": "https://schema.org",
         "@type": "Game",
         "name": title,
-        "description": description,
+        "description": seo_description,
         "image": image_url,
-        "url": f"https://bodoge-no-mikata.vercel.app/games/{slug}",
+        "url": game_url,
     }
     if game.get("min_players") or game.get("max_players"):
         structured_data["numberOfPlayers"] = {
@@ -37,20 +66,8 @@ async def generate_seo_html(slug: str) -> str:
             "suggestedMinAge": game.get("min_age"),
         }
     if game.get("play_time"):
-        structured_data["timeRequired"] = {
-            "@type": "Duration",
-            "value": f"PT{game.get('play_time')}M",
-        }
-    page_title = f"「{title}」のルール・インストをAI要約 | 遊び方・3行解説"
-    seo_description = (
-        f"「{title}」のルールをAIが瞬時に要約。インスト準備や遊び方の確認に。"
-        f"「{title}」のセットアップ、勝利条件、流れを3行で解説。"
-    )
-    if description:
-        seo_description += f" {description}"
-    structured_data["description"] = seo_description
-    json_ld = json.dumps(structured_data, ensure_ascii=False)
-    # Use absolute path based on Vercel environment or current file
+        structured_data["timeRequired"] = f"PT{game.get('play_time')}M"
+
     root = Path(os.getenv("LAMBDA_TASK_ROOT", Path(__file__).resolve().parent.parent.parent.parent))
     possible_paths = [
         root / "frontend" / "dist" / "index.html",
@@ -61,54 +78,61 @@ async def generate_seo_html(slug: str) -> str:
     for path in possible_paths:
         try:
             if path.exists():
-                with path.open(encoding="utf-8") as f:
-                    html_content = f.read()
+                html_content = path.read_text(encoding="utf-8")
                 break
-        except Exception as e:
-            logger.warning(f"Error reading path {path}: {e}")
+        except Exception as exc:
+            logger.warning(f"Error reading path {path}: {exc}")
 
     if not html_content:
         logger.error(f"index.html template not found in {possible_paths}")
-        html_content = '<html><head><title>ボドゲのミカタ</title></head><body><div id="root"></div></body></html>'
-    html_content = html_content.replace(
-        "ボドゲのミカタ | AIでルールを瞬時に要約。インスト時間を短縮",
-        page_title,
+        html_content = '<html lang="ja"><head><title>ボドゲのミカタ</title></head><body><div id="root"></div></body></html>'
+
+    escaped_title = html.escape(page_title, quote=False)
+    html_content = _replace_or_insert_tag(
+        html_content,
+        r"<title\b[^>]*>.*?</title>",
+        f"<title>{escaped_title}</title>",
     )
-    old_desc_marker = (
-        "「説明書を読むのが面倒」「インスト準備に時間がかかる」そんな悩みをAIが解決。"
-        "ボドゲのミカタは、世界中のボードゲームのルールを瞬時に要約・検索できるツールです。"
-        "海外ゲームの和訳や、プレイ中のルール確認にも最適。"
+    html_content = _meta_tag(html_content, attr="name", key="description", content=seo_description)
+    html_content = _meta_tag(html_content, attr="property", key="og:title", content=page_title)
+    html_content = _meta_tag(html_content, attr="property", key="og:description", content=seo_description)
+    html_content = _meta_tag(html_content, attr="property", key="og:url", content=game_url)
+    html_content = _meta_tag(html_content, attr="property", key="og:image", content=image_url)
+    html_content = _meta_tag(html_content, attr="name", key="twitter:title", content=page_title)
+    html_content = _meta_tag(html_content, attr="name", key="twitter:description", content=seo_description)
+    html_content = _meta_tag(html_content, attr="name", key="twitter:image", content=image_url)
+
+    canonical_tag = f'<link rel="canonical" href="{html.escape(game_url, quote=True)}" />'
+    html_content = _replace_or_insert_tag(
+        html_content,
+        r'<link\b(?=[^>]*\brel=["\']canonical["\'])[^>]*>',
+        canonical_tag,
     )
-    html_content = html_content.replace(old_desc_marker, seo_description)
-    replacements = {
-        'content="ボドゲのミカタ | AIでルールを瞬時に要約。インスト時間を短縮"': f'content="{page_title}"',
-        'content="https://bodoge-no-mikata.vercel.app/og-image.png"': f'content="{image_url}"',
-        'property="og:url" content="https://bodoge-no-mikata.vercel.app/"': (
-            f'property="og:url" content="https://bodoge-no-mikata.vercel.app/games/{slug}"'
-        ),
-        'link rel="canonical" href="https://bodoge-no-mikata.vercel.app/"': (
-            f'link rel="canonical" href="https://bodoge-no-mikata.vercel.app/games/{slug}"'
-        ),
-    }
-    for old, new in replacements.items():
-        html_content = html_content.replace(old, new)
-    script_tag = f'<script type="application/ld+json">{json_ld}</script>'
-    html_content = html_content.replace("</head>", f"{script_tag}</head>")
-    rules_content = game.get("rules_content") or ""
-    summary = game.get("summary") or ""
+
+    json_ld = _safe_json_script(structured_data)
+    script_tag = f'<script type="application/ld+json" data-game-seo="true">{json_ld}</script>'
+    html_content = html_content.replace("</head>", f"  {script_tag}\n</head>", 1)
+
+    safe_title = html.escape(title)
+    safe_summary = html.escape(str(game.get("summary") or ""))
+    safe_rules = html.escape(str(game.get("rules_content") or "")[:2000])
     players_info = ""
     if game.get("min_players"):
-        max_p = game.get("max_players") or game.get("min_players")
-        players_info = f"<p><strong>プレイ人数:</strong> {game.get('min_players')}-{max_p}人</p>"
+        max_players = game.get("max_players") or game.get("min_players")
+        players_info = (
+            f"<p><strong>プレイ人数:</strong> {html.escape(str(game.get('min_players')))}-"
+            f"{html.escape(str(max_players))}人</p>"
+        )
     time_info = ""
     if game.get("play_time"):
-        time_info = f"<p><strong>プレイ時間:</strong> {game.get('play_time')}分</p>"
+        time_info = f"<p><strong>プレイ時間:</strong> {html.escape(str(game.get('play_time')))}分</p>"
+
     ssr_content = f"""<div id="root">
-  <article itemscope itemtype="https://schema.org/Game">
-    <h1 itemprop="name">{title}</h1>
+  <article itemscope itemtype="https://schema.org/Game" data-ssr-game="true">
+    <h1 itemprop="name">{safe_title}</h1>
     <section>
-      <h2>3行でわかる要約</h2>
-      <p itemprop="description">{summary}</p>
+      <h2>要約</h2>
+      <p itemprop="description">{safe_summary}</p>
     </section>
     <section>
       <h2>基本情報</h2>
@@ -117,8 +141,8 @@ async def generate_seo_html(slug: str) -> str:
     </section>
     <section>
       <h2>ルール</h2>
-      <div itemprop="text">{rules_content[:2000] if rules_content else ""}</div>
+      <pre itemprop="text">{safe_rules}</pre>
     </section>
   </article>
 </div>"""
-    return html_content.replace('<div id="root"></div>', ssr_content)
+    return html_content.replace('<div id="root"></div>', ssr_content, 1)

--- a/backend/app/services/sitemap.py
+++ b/backend/app/services/sitemap.py
@@ -29,10 +29,15 @@ async def get_sitemap_xml() -> str:
         changefreq.text = page["changefreq"]
         priority = ET.SubElement(url_elem, f"{{{NS_SITEMAP}}}priority")
         priority.text = page["priority"]
+
     for game in games:
+        slug = str(game.get("slug") or "").strip()
+        if not slug:
+            continue
+
         url_elem = ET.SubElement(root, f"{{{NS_SITEMAP}}}url")
         loc = ET.SubElement(url_elem, f"{{{NS_SITEMAP}}}loc")
-        loc.text = f"{base_url}/games/{game['slug']}"
+        loc.text = f"{base_url}/games/{slug}"
         lastmod = ET.SubElement(url_elem, f"{{{NS_SITEMAP}}}lastmod")
         updated = game.get("updated_at")
         if updated:

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -9,13 +9,76 @@ class MissingGameService:
         return None
 
 
-def test_missing_game_slug_returns_404_instead_of_response_validation_500():
+class MutableGameService:
+    def __init__(self):
+        self.updated = False
+
+    async def update_game_content(self, slug: str, fill_missing_only: bool = False):
+        self.updated = True
+        return {"id": "game-1", "slug": slug, "title": "Example", "work_id": "work-1"}
+
+    async def update_game_manual(self, slug: str, updates: dict):
+        self.updated = True
+        return {"id": "game-1", "slug": slug, "title": updates.get("title", "Example")}
+
+
+class DBFirstService:
+    def __init__(self):
+        self.created = False
+
+    async def search_games(self, query: str):
+        return [{"id": "game-1", "slug": "existing", "title": "既存ゲーム", "title_ja": query}]
+
+    async def create_game_from_query(self, query: str):
+        self.created = True
+        return {"id": "game-2", "slug": "generated", "title": query}
+
+
+def _app_with_service(service):
     app = FastAPI()
     app.include_router(games.router, prefix="/api")
-    app.dependency_overrides[games.get_game_service] = lambda: MissingGameService()
+    app.dependency_overrides[games.get_game_service] = lambda: service
+    return app
 
-    client = TestClient(app)
+
+def test_missing_game_slug_returns_404_instead_of_response_validation_500():
+    client = TestClient(_app_with_service(MissingGameService()))
     response = client.get("/api/games/ipso")
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Game not found"}
+
+
+def test_catalog_patch_requires_authentication_before_mutation():
+    service = MutableGameService()
+    client = TestClient(_app_with_service(service))
+
+    response = client.patch("/api/games/example?regenerate=true")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Authentication required"
+    assert service.updated is False
+
+
+def test_authenticated_regeneration_uses_existing_slug_update_path():
+    service = MutableGameService()
+    app = _app_with_service(service)
+    app.dependency_overrides[games.get_current_user] = lambda: {"id": "user-1"}
+    client = TestClient(app)
+
+    response = client.patch("/api/games/example?regenerate=true&fill_missing_only=true")
+
+    assert response.status_code == 200
+    assert response.json()["slug"] == "example"
+    assert service.updated is True
+
+
+def test_post_search_checks_database_before_generation():
+    service = DBFirstService()
+    client = TestClient(_app_with_service(service))
+
+    response = client.post("/api/search", json={"query": "レラティブ・スペース", "generate": True})
+
+    assert response.status_code == 200
+    assert response.json()[0]["slug"] == "existing"
+    assert service.created is False

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+
+import pytest
+
+from app.services import seo_renderer
+
+
+@pytest.mark.asyncio
+async def test_missing_game_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def missing(_slug: str):
+        return None
+
+    monkeypatch.setattr(seo_renderer, "get_by_slug", missing)
+
+    assert await seo_renderer.generate_seo_html("missing") is None
+
+
+@pytest.mark.asyncio
+async def test_game_ssr_replaces_metadata_and_escapes_db_content(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def game(_slug: str):
+        return {
+            "id": "game-1",
+            "slug": "safe-game",
+            "title": 'Bad </title><script>alert("title")</script>',
+            "summary": 'Summary <img src=x onerror=alert("summary")>',
+            "rules_content": '</pre><script>alert("rules")</script>',
+            "min_players": 2,
+            "max_players": 4,
+            "play_time": 30,
+            "image_url": "/images/game.webp",
+        }
+
+    template_dir = tmp_path / "frontend" / "dist"
+    template_dir.mkdir(parents=True)
+    (template_dir / "index.html").write_text(
+        """<!doctype html>
+<html lang="ja">
+<head>
+<title>ボドゲのミカタ</title>
+<meta name="description" content="home" />
+<meta property="og:title" content="home" />
+<meta property="og:description" content="home" />
+<meta property="og:url" content="https://bodoge-no-mikata.vercel.app/" />
+<meta property="og:image" content="https://bodoge-no-mikata.vercel.app/og-image.webp" />
+<meta name="twitter:title" content="home" />
+<meta name="twitter:description" content="home" />
+<meta name="twitter:image" content="https://bodoge-no-mikata.vercel.app/og-image.webp" />
+<link rel="canonical" href="https://bodoge-no-mikata.vercel.app/" />
+</head>
+<body><div id="root"></div></body>
+</html>""",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(seo_renderer, "get_by_slug", game)
+    monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
+
+    rendered = await seo_renderer.generate_seo_html("safe-game")
+
+    assert rendered is not None
+    assert 'href="https://bodoge-no-mikata.vercel.app/games/safe-game"' in rendered
+    assert 'property="og:url" content="https://bodoge-no-mikata.vercel.app/games/safe-game"' in rendered
+    assert 'data-game-seo="true"' in rendered
+    assert 'data-ssr-game="true"' in rendered
+    assert '<script>alert("title")</script>' not in rendered
+    assert '<script>alert("rules")</script>' not in rendered
+    assert '<img src=x onerror=alert("summary")>' not in rendered
+    assert '&lt;script&gt;alert(&quot;rules&quot;)&lt;/script&gt;' in rendered
+    assert "\\u003cscript" in rendered

--- a/backend/tests/test_sitemap.py
+++ b/backend/tests/test_sitemap.py
@@ -43,3 +43,22 @@ async def test_image_entries_are_nested_under_their_game_url(monkeypatch: pytest
     assert len(images) == 1
     assert images[0].findtext(image_loc_tag) == "https://example.test/assets/games/catan.webp"
     assert images[0].find(image_title_tag) is None
+
+
+@pytest.mark.asyncio
+async def test_invalid_game_slugs_are_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_list_for_sitemap() -> list[dict[str, str | None]]:
+        return [
+            {"slug": "valid-game", "title": "Valid", "updated_at": None, "image_url": None},
+            {"slug": None, "title": "Legacy null", "updated_at": None, "image_url": None},
+            {"slug": "  ", "title": "Legacy blank", "updated_at": None, "image_url": None},
+        ]
+
+    monkeypatch.setattr(sitemap, "list_for_sitemap", fake_list_for_sitemap)
+    monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
+
+    xml_text = await sitemap.get_sitemap_xml()
+
+    assert "https://example.test/games/valid-game" in xml_text
+    assert "/games/None" not in xml_text
+    assert "/games/  " not in xml_text

--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -2,8 +2,13 @@ const isValidUrl = (url) => {
   if (!url || typeof url !== 'string') return false
   const trimmed = url.trim()
   if (!trimmed) return false
-  new URL(trimmed)
-  return trimmed.startsWith('http://') || trimmed.startsWith('https://')
+
+  try {
+    const parsed = new URL(trimmed)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 export const ExternalLinks = ({ game }) => {
@@ -27,9 +32,9 @@ export const ExternalLinks = ({ game }) => {
     <div className="info-section">
       <h3>Links</h3>
       <div className="external-links-grid">
-        {links.map((link, i) => (
+        {links.map((link) => (
           <a
-            key={i}
+            key={`${link.class}:${link.url}`}
             href={link.url}
             target="_blank"
             rel="noopener noreferrer sponsored"

--- a/frontend/src/components/game/RegenerateButton.jsx
+++ b/frontend/src/components/game/RegenerateButton.jsx
@@ -1,19 +1,24 @@
 import { useState } from 'react'
 import { api } from '../../lib/api'
 
-export const RegenerateButton = ({ title, onRegenerate }) => {
+export const RegenerateButton = ({ slug, onRegenerate }) => {
   const [regenerating, setRegenerating] = useState(false)
 
   const handleRegenerate = async () => {
+    if (!slug) return
+
     setRegenerating(true)
     try {
-      const data = await api.post('/api/search', { query: title, generate: true })
-      if (onRegenerate && Array.isArray(data) && data[0]) {
-        onRegenerate(data[0])
+      const data = await api.patch(`/api/games/${encodeURIComponent(slug)}?regenerate=true&fill_missing_only=true`)
+      if (onRegenerate && data?.id) {
+        onRegenerate(data)
       }
     } catch (err) {
       console.error('Regeneration failed:', err)
-      alert('再生成に失敗しました')
+      const message = err?.status === 401
+        ? '再生成にはログインが必要です'
+        : '再生成に失敗しました'
+      alert(message)
     } finally {
       setRegenerating(false)
     }
@@ -23,9 +28,9 @@ export const RegenerateButton = ({ title, onRegenerate }) => {
     <button
       onClick={handleRegenerate}
       className="share-btn"
-      title="AIで再生成"
-      disabled={regenerating}
-      aria-label="Regenerate game data with AI"
+      title="AIで不足情報を再生成"
+      disabled={regenerating || !slug}
+      aria-label="Regenerate missing game data with AI"
     >
       {regenerating ? '⏳ 生成中' : '✨ 再生成'}
     </button>

--- a/frontend/src/components/game/RegenerateButton.jsx
+++ b/frontend/src/components/game/RegenerateButton.jsx
@@ -1,8 +1,15 @@
 import { useState } from 'react'
 import { api } from '../../lib/api'
 
-export const RegenerateButton = ({ slug, onRegenerate }) => {
+const currentGameSlug = () => {
+  if (typeof window === 'undefined') return ''
+  const match = window.location.pathname.match(/^\/games\/([^/]+)/)
+  return match ? decodeURIComponent(match[1]) : ''
+}
+
+export const RegenerateButton = ({ slug: propSlug, onRegenerate }) => {
   const [regenerating, setRegenerating] = useState(false)
+  const slug = propSlug || currentGameSlug()
 
   const handleRegenerate = async () => {
     if (!slug) return

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
       "destination": "/api/index.py"
     },
     {
+      "source": "/games/:slug",
+      "destination": "/api/index.py"
+    },
+    {
       "source": "/((?!assets|api|output_slides).*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary

Restores the catalog integrity boundary found in the 2026-08-14 production audit.

### Search / generation
- restore DB-first behavior even for legacy `POST /api/search {generate:true}` clients
- search `title`, `title_ja`, `title_en`, description, and `game_title_aliases`
- rank exact/prefix matches ahead of substring matches
- unify the duplicated `GameService.create_game_from_query()` implementation into one canonical unverified work+edition creation path
- recheck the DB immediately before generation to reduce duplicate races

### Canonical mutation
- return 404 for missing `/api/games/{slug}` instead of FastAPI `ResponseValidationError` 500
- require authenticated user for catalog PATCH
- make regeneration update the existing slug/id/work_id in place and fill missing fields only from the UI
- block generic manual updates from mutating identity fields (`id`, `slug`, `work_id`, `identity_status`)

### Public routing / SEO safety
- route `/games/:slug` through the FastAPI SEO renderer before the SPA catch-all
- return a real HTTP 404 for missing game pages
- replace brittle legacy-string SEO injection with tag-level metadata replacement
- escape DB-derived HTML and script-sensitive JSON-LD characters
- fail closed on malformed external URLs

### Schema / sitemap
- version the production-only `setup_summary`, `gameplay_summary`, `end_game_summary` columns
- add a NOT VALID `games_slug_required` check: existing legacy null slug remains reviewable, new/updated null or blank slugs are rejected
- exclude invalid slugs from sitemap so `/games/None` cannot be emitted

### Regression gates
- add `Test catalog integrity` workflow
- compile backend
- test 404/auth/DB-first behavior
- test SSR metadata + XSS escaping
- test sitemap invalid-slug exclusion
- replay migration against a legacy-null-slug PostgreSQL fixture
- build frontend

## Issues

Closes #128
Closes #54

## Non-scope

The four existing duplicate-title groups are not auto-merged from title equality alone. They remain subject to the canonical identity evidence contract in #90.
