### PR TITLE
Fix directory query race in SPA history

### DIFF
--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { Outlet, useLocation, useNavigationType } from 'react-router-dom'
+import { Outlet, useLocation, useNavigate, useNavigationType } from 'react-router-dom'
 
 import AuthControlPortal from './AuthControlPortal.jsx'
 import GameListSavePortal from './GameListSavePortal.jsx'
@@ -61,9 +61,32 @@ function handleGameTabKeyDown(event) {
 
 export default function AppShell() {
   const location = useLocation()
+  const navigate = useNavigate()
   const navigationType = useNavigationType()
   const scrollPositions = useRef(new Map())
   const [navigating, setNavigating] = useState(false)
+
+  useEffect(() => {
+    if (!location.pathname.startsWith('/games/') || !location.search) return
+
+    const params = new URLSearchParams(location.search)
+    if (!params.has('q')) return
+
+    // `q` belongs to the directory route. A pending directory debounce can race
+    // with SPA navigation and replace the game history entry with `?q=...`.
+    // Strip only that directory-owned parameter while preserving any future
+    // game-detail parameters and the directory entry already in browser history.
+    params.delete('q')
+    const search = params.toString()
+    navigate(
+      {
+        pathname: location.pathname,
+        search: search ? `?${search}` : '',
+        hash: location.hash,
+      },
+      { replace: true },
+    )
+  }, [location.hash, location.pathname, location.search, navigate])
 
   useEffect(() => {
     const previous = window.history.scrollRestoration


### PR DESCRIPTION
## Problem
The navigation regression suite exposed a race where the directory's debounced `q` search-param update can land after SPA navigation and replace a game-detail history entry with `/games/<slug>?q=...`. That makes history unstable: the initial game URL is canonical, but returning from `/lists` can surface a mutated game URL.

## Fix
Enforce route ownership at the app shell: on `/games/*`, strip only the directory-owned `q` parameter with a history replace, while preserving any future game-detail query parameters and the directory's own history entry.

## Verification
The existing navigation E2E already asserts:
- directory → game is SPA navigation
- game URL stays canonical
- game → lists → back returns to canonical game URL
- a second back restores the directory query context

This PR is intentionally separate from the dependency/Vite migration so the routing regression is fixed independently on `main`.