### PR TITLE
Standardize implementation-ready issue contracts

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature.yml
+++ b/.github/ISSUE_TEMPLATE/01-feature.yml
@@ -1,0 +1,78 @@
+name: Feature / product change
+description: Define an implementation-ready feature with evidence, tests, production verification, and cleanup.
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe an outcome that an agent can implement, test, verify in production when needed, and close. Do not paste secrets, tokens, private credentials, or private user data.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / user value
+      description: What user or product problem must change, and why does it matter?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / current behavior
+      description: Add reproducible observations, screenshots, logs with secrets removed, code locations, or primary-source links.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is explicitly included?
+    validations:
+      required: true
+  - type: textarea
+    id: non_scope
+    attributes:
+      label: Non-scope
+      description: What is explicitly not part of this issue?
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies
+      description: Related issues, schemas, services, or contracts that must already exist.
+  - type: textarea
+    id: blockers
+    attributes:
+      label: Blockers
+      description: Separate external/admin/configuration blockers from code blockers. Write "None known" if there are none.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Use checkable outcomes. Avoid implementation-only statements such as "code is added" when user-visible or production behavior matters.
+      placeholder: "- [ ] Outcome 1\n- [ ] Outcome 2"
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Tests
+      description: List unit, integration, E2E, security, data-contract, or regression cases needed to prove the acceptance criteria.
+      placeholder: "- case A\n- case B"
+    validations:
+      required: true
+  - type: textarea
+    id: production_verification
+    attributes:
+      label: Production verification
+      description: State the production or production-equivalent proof required. If not applicable, explain why.
+    validations:
+      required: true
+  - type: textarea
+    id: cleanup_rollback
+    attributes:
+      label: Cleanup / rollback condition
+      description: Define branch/PR/artifact cleanup, obsolete paths to remove, and when to rollback or stop.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/02-ai-data-quality.yml
+++ b/.github/ISSUE_TEMPLATE/02-ai-data-quality.yml
@@ -1,0 +1,79 @@
+name: AI / data quality change
+description: Define source-grounded AI or data-quality work with evaluation, provenance, and release evidence.
+title: "[AI/Data] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use primary or canonical sources where possible. Unknown or unverified data must remain unknown; do not request secrets, tokens, private credentials, or copyrighted source dumps in the issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / user value
+      description: What quality failure or data problem is being solved?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / current behavior
+      description: Provide current measurements, failing examples, code/data locations, or reproducible observations.
+    validations:
+      required: true
+  - type: textarea
+    id: source_contract
+    attributes:
+      label: Source / provenance contract
+      description: Identify authoritative sources, edition/language/revision where relevant, and how source locators will be preserved.
+    validations:
+      required: true
+  - type: textarea
+    id: evaluation
+    attributes:
+      label: Evaluation / baseline
+      description: Define golden fixtures, metrics, thresholds, or before/after baseline. Separate unknown from failure.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope / non-scope
+      description: State what the change may modify and what it must not infer, overwrite, publish, or auto-connect.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies / blockers
+      description: List upstream schemas, services, permissions, external settings, or issues. Separate external blockers from code blockers.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Define machine-checkable quality and provenance outcomes.
+      placeholder: "- [ ] Metric or invariant 1\n- [ ] Metric or invariant 2"
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Tests
+      description: Include known-good, failure, unknown/unverified, malformed, and regression fixtures as applicable.
+    validations:
+      required: true
+  - type: textarea
+    id: production_verification
+    attributes:
+      label: Production verification
+      description: Define production-equivalent data, artifact/report, and deployment/runtime checks required before close.
+    validations:
+      required: true
+  - type: textarea
+    id: cleanup_rollback
+    attributes:
+      label: Cleanup / rollback condition
+      description: Define stale artifacts/overrides to remove and the condition that rejects or rolls back the change.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/03-ops-bug.yml
+++ b/.github/ISSUE_TEMPLATE/03-ops-bug.yml
@@ -1,0 +1,79 @@
+name: Ops / bug / production incident
+description: Report a reproducible defect or operational failure with expected behavior, verification, and rollback.
+title: "[Bug/Ops] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Remove secrets, tokens, cookies, credentials, and private user data from logs and screenshots before attaching evidence.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / impact
+      description: What is broken, who or what is affected, and what is the operational impact?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Give deterministic steps, request shape, environment, route, commit/deployment, or timing needed to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happens now? Include status/error text or sanitized logs when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What invariant or user-visible behavior should hold instead?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence / current production state
+      description: Add production URLs, Actions/Vercel run links, screenshots, sanitized logs, or code locations.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies / blockers
+      description: List external services, repository-admin settings, permissions, or code dependencies. Separate external blockers from code blockers.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: Define checkable recovery and regression-prevention outcomes.
+      placeholder: "- [ ] Recovery outcome\n- [ ] Regression-prevention outcome"
+    validations:
+      required: true
+  - type: textarea
+    id: tests
+    attributes:
+      label: Tests
+      description: Define reproduction, regression, failure-path, security, and smoke tests needed before close.
+    validations:
+      required: true
+  - type: textarea
+    id: production_verification
+    attributes:
+      label: Production verification
+      description: Define the exact deployment, HTTP/browser/API, data, or observability evidence required after the fix.
+    validations:
+      required: true
+  - type: textarea
+    id: cleanup_rollback
+    attributes:
+      label: Cleanup / rollback condition
+      description: Define temporary branches/artifacts/config to remove and the rollback trigger if production verification fails.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/workflows/issue-contract.yml
+++ b/.github/workflows/issue-contract.yml
@@ -1,0 +1,34 @@
+name: Issue contract
+
+on:
+  pull_request:
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - "docs/ISSUE_GUIDE.md"
+      - "README.md"
+      - "tests/test_issue_contract.py"
+      - ".github/workflows/issue-contract.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/ISSUE_TEMPLATE/**"
+      - "docs/ISSUE_GUIDE.md"
+      - "README.md"
+      - "tests/test_issue_contract.py"
+      - ".github/workflows/issue-contract.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+      - name: Validate issue forms and completion contract
+        run: uv run pytest -q tests/test_issue_contract.py

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ AIエージェントが自律的に実行可能な、4つの高度な自動化�
 - **[`scripts/`](./scripts/README.md)**: 運用を支える自動化の源泉。
 - **[`docs/`](./docs/README.md)**: [`SEO.md`](./docs/SEO.md), [`CONTENT_GUIDELINES.md`](./docs/CONTENT_GUIDELINES.md) 等の戦略ドキュメント。
 
+## 🧭 Issue workflow
+
+新規Issueは、実装だけでなくAcceptance Criteria・Tests・必要なproduction verification・cleanup/rollbackまで完遂できる契約として作成します。Feature、AI/Data Quality、Ops/BugのIssue Formsと運用規約は **[`docs/ISSUE_GUIDE.md`](./docs/ISSUE_GUIDE.md)** を参照してください。
+
 ---
 
 **Built with Precision by RuleScribe Games Team**

--- a/docs/ISSUE_GUIDE.md
+++ b/docs/ISSUE_GUIDE.md
@@ -1,0 +1,65 @@
+# Issue contract
+
+RuleScribe GamesのIssueは、**実装 → テスト → 必要な本番検証 → cleanup → close**まで1本の証拠線で完遂できることを基準にする。
+
+## Template selection
+
+- **Feature / product change**: ユーザー価値や製品挙動を追加・変更する。
+- **AI / data quality change**: source、provenance、evaluation、data-quality gateが主題になる。
+- **Ops / bug / production incident**: 再現可能な障害、回帰、deploy/runtime問題を扱う。
+- 既存のAPI connection専用templateは、その障害種別に限定して利用する。
+
+GitHub Issue Formsは `.github/ISSUE_TEMPLATE/*.yml` を正準とする。blank issueは通常のcontributor経路では無効化し、既存Issueの編集やmaintainer作業を妨げない。
+
+## Required completion contract
+
+Issueは最低限、次を分離して記載する。
+
+1. **Problem / user value or impact** — 何を見極め、何を変えるか。
+2. **Evidence / current behavior** — 再現、code/data location、sanitized log、一次source URLなど。
+3. **Scope / non-scope** — 今回変える範囲と変えない範囲。
+4. **Dependencies / blockers** — code blockerと外部設定・権限blockerを分ける。
+5. **Acceptance Criteria** — close判定できる結果。実装手段そのものだけを完了条件にしない。
+6. **Tests** — unit / integration / E2E / security / data contract / regressionの必要範囲。
+7. **Production verification** — 本番確認が必要ならURL、deployment、HTTP/browser/API/data evidenceまで指定する。不要なら理由を書く。
+8. **Cleanup / rollback condition** — branch、superseded PR、一時artifact、暫定override、失敗時rollback条件を明示する。
+
+## AI / data-quality additions
+
+AI・データ品質Issueでは、さらに以下を固定する。
+
+- authoritative / canonical sourceとsource locator
+- edition / language / revisionなど、意味を変えるversion情報
+- golden fixture、baseline、metric、thresholdまたは判定可能なinvariant
+- `FAIL` と `UNKNOWN / NOT_RUN` の区別
+- sourceで確認できない値を推測で補完しない契約
+- provenance/schema validationに失敗した結果を正準データへ昇格させない条件
+
+## Ops / bug additions
+
+障害Issueでは、少なくとも以下を分ける。
+
+- reproduction
+- actual behavior
+- expected behavior
+- production/deployment evidence
+- retry/fallback/rollbackを含むfailure-path test
+
+CIがgreenでも本番Acceptance Criteriaが未達ならIssueはcloseしない。
+
+## Blockers
+
+外部設定やrepository administrationが必要で、現在のagent権限では実行できない場合は、コード側を偽装してcloseしない。Issueへ次を残す。
+
+- 実施済み内容
+- 実行できない操作と必要権限
+- 現在のproduction state
+- unblock後の具体的な次手
+
+## Superseded work
+
+同じAcceptance Criteriaを別PRが先に満たした場合、古いPRをmergeして新しい実装を巻き戻さない。最新mainを検証し、満たしていれば古いPRを`superseded`としてcloseし、不要branch/artifactを削除可能な範囲で整理する。
+
+## Secrets and private data
+
+Issue本文、ログ、fixture、screenshot、repository sourceへtoken、API key、cookie、private credential、private user dataを貼らない。必要なsecretはproviderのsecret/environment機構へ保存し、存在だけを検証する。

--- a/tests/test_issue_contract.py
+++ b/tests/test_issue_contract.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_DIR = ROOT / ".github" / "ISSUE_TEMPLATE"
+FORMS = [
+    TEMPLATE_DIR / "01-feature.yml",
+    TEMPLATE_DIR / "02-ai-data-quality.yml",
+    TEMPLATE_DIR / "03-ops-bug.yml",
+]
+COMMON_IDS = {"problem", "evidence", "acceptance", "tests", "production_verification", "cleanup_rollback"}
+
+
+def load_yaml(path: Path):
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_issue_forms_are_valid_structured_contracts():
+    for path in FORMS:
+        form = load_yaml(path)
+        assert isinstance(form.get("name"), str) and len(form["name"]) > 3
+        assert isinstance(form.get("description"), str) and form["description"].strip()
+        assert isinstance(form.get("body"), list) and form["body"]
+
+        fields = [item for item in form["body"] if item.get("type") != "markdown"]
+        ids = [item.get("id") for item in fields]
+        labels = [item.get("attributes", {}).get("label") for item in fields]
+
+        assert None not in ids
+        assert None not in labels
+        assert len(ids) == len(set(ids)), f"duplicate ids in {path}"
+        assert len(labels) == len(set(labels)), f"duplicate labels in {path}"
+        assert COMMON_IDS <= set(ids), f"missing common completion fields in {path}"
+        assert all(item.get("validations", {}).get("required") is True for item in fields if item["id"] in COMMON_IDS)
+
+
+def test_specialized_forms_capture_domain_specific_evidence():
+    ai_form = load_yaml(TEMPLATE_DIR / "02-ai-data-quality.yml")
+    ai_ids = {item.get("id") for item in ai_form["body"]}
+    assert {"source_contract", "evaluation", "dependencies"} <= ai_ids
+
+    ops_form = load_yaml(TEMPLATE_DIR / "03-ops-bug.yml")
+    ops_ids = {item.get("id") for item in ops_form["body"]}
+    assert {"reproduction", "actual", "expected", "dependencies"} <= ops_ids
+
+    feature_form = load_yaml(TEMPLATE_DIR / "01-feature.yml")
+    feature_ids = {item.get("id") for item in feature_form["body"]}
+    assert {"scope", "non_scope", "dependencies", "blockers"} <= feature_ids
+
+
+def test_template_chooser_and_documentation_enforce_the_contract():
+    config = load_yaml(TEMPLATE_DIR / "config.yml")
+    assert config["blank_issues_enabled"] is False
+
+    guide = (ROOT / "docs" / "ISSUE_GUIDE.md").read_text(encoding="utf-8")
+    for heading in (
+        "Acceptance Criteria",
+        "Tests",
+        "Production verification",
+        "Cleanup / rollback condition",
+        "Dependencies / blockers",
+    ):
+        assert heading in guide
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "docs/ISSUE_GUIDE.md" in readme


### PR DESCRIPTION
Closes #92

## Changes
- add structured Feature / AI-Data / Ops-Bug GitHub Issue Forms
- require separate Acceptance Criteria, Tests, Production verification, and Cleanup / rollback fields
- make source/provenance/evaluation explicit for AI/data-quality work
- make reproduction/actual/expected behavior explicit for ops/bug work
- separate dependencies from external/admin blockers in the documented contract
- disable contributor blank issues through the template chooser
- add `docs/ISSUE_GUIDE.md` and link it from README
- add a focused pytest contract plus GitHub Actions gate for template structure and documentation reachability

## Source contract
The forms follow GitHub's current Issue Forms / form schema documentation. No secret or private-data fields are requested.
