### PR TITLE
Finish real HTML 404 handling for game routes

### DIFF
--- a/.github/workflows/test-games-router.yml
+++ b/.github/workflows/test-games-router.yml
@@ -1,24 +1,32 @@
-name: Test games router
+name: Test game routes
 
 on:
   pull_request:
     paths:
+      - "backend/app/main.py"
       - "backend/app/routers/games.py"
       - "backend/app/services/game_service.py"
+      - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
       - "backend/tests/test_games_router.py"
+      - "backend/tests/test_web_not_found.py"
       - ".github/workflows/test-games-router.yml"
+      - "vercel.json"
       - "pyproject.toml"
       - "uv.lock"
   push:
     branches:
       - main
     paths:
+      - "backend/app/main.py"
       - "backend/app/routers/games.py"
       - "backend/app/services/game_service.py"
+      - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
       - "backend/tests/test_games_router.py"
+      - "backend/tests/test_web_not_found.py"
       - ".github/workflows/test-games-router.yml"
+      - "vercel.json"
       - "pyproject.toml"
       - "uv.lock"
 
@@ -34,7 +42,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uv sync --frozen --dev
-      - name: Run games router regression tests
-        run: uv run pytest -q backend/tests/test_games_router.py
+      - name: Run game route regression tests
+        run: uv run pytest -q backend/tests/test_games_router.py backend/tests/test_web_not_found.py
         env:
           PYTHONPATH: backend

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Response, status
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 
@@ -38,10 +38,31 @@ async def sitemap_xml():
     return Response(content=content, media_type="application/xml")
 
 
+def game_not_found_html() -> str:
+    return """<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>ゲームが見つかりません | ボドゲのミカタ</title>
+    <meta name="description" content="指定されたゲームは登録されていないか、URLが変更されています。" />
+  </head>
+  <body>
+    <main style="max-width:42rem;margin:10vh auto;padding:2rem;font-family:system-ui,sans-serif;line-height:1.7">
+      <p style="font-weight:700;letter-spacing:.08em">404 · GAME NOT FOUND</p>
+      <h1>ゲームが見つかりません</h1>
+      <p>指定されたゲームは登録されていないか、URLが変更されています。</p>
+      <p><a href="/">ゲーム一覧へ戻る</a></p>
+    </main>
+  </body>
+</html>"""
+
+
 @app.get("/games/{slug}", response_class=HTMLResponse)
 async def game_seo_page(slug: str):
     """Serve a crawlable game page with game-specific metadata and a real 404 boundary."""
     content = await generate_seo_html(slug)
     if content is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+        return HTMLResponse(content=game_not_found_html(), status_code=404)
     return HTMLResponse(content=content)

--- a/backend/tests/test_web_not_found.py
+++ b/backend/tests/test_web_not_found.py
@@ -1,0 +1,35 @@
+from fastapi.testclient import TestClient
+
+from app import main
+
+
+def test_missing_web_game_returns_user_facing_html_404(monkeypatch):
+    async def missing(_slug: str):
+        return None
+
+    monkeypatch.setattr(main, "generate_seo_html", missing)
+    client = TestClient(main.app)
+
+    response = client.get("/games/not-a-real-game")
+
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("text/html")
+    assert "ゲームが見つかりません" in response.text
+    assert "ゲーム一覧へ戻る" in response.text
+    assert 'name="robots" content="noindex, nofollow"' in response.text
+    assert 'rel="canonical"' not in response.text
+    assert 'application/json' not in response.headers["content-type"]
+
+
+def test_valid_web_game_keeps_rendered_html_200(monkeypatch):
+    async def rendered(_slug: str):
+        return "<!doctype html><html><head><title>Known Game</title></head><body><h1>Known Game</h1></body></html>"
+
+    monkeypatch.setattr(main, "generate_seo_html", rendered)
+    client = TestClient(main.app)
+
+    response = client.get("/games/known-game")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "Known Game" in response.text


### PR DESCRIPTION
Closes #135

## Current production evidence before this PR
- missing `/api/games/:slug` already returns 404 JSON
- missing `/games/:slug` already returns HTTP 404, but the response body is FastAPI JSON rather than a user-facing page
- known API and Web slugs return 200

## Changes
- preserve the real 404 status for missing Web game routes
- return a user-facing HTML not-found page instead of a JSON error body
- mark the missing page `noindex, nofollow` and omit canonical metadata
- preserve valid game SSR responses as 200 HTML
- expand the canonical game-route CI gate so `backend/app/main.py`, `seo_renderer.py`, `vercel.json`, and Web 404 tests cannot bypass regression coverage

## Verification
- API 404 behavior remains covered by `test_games_router.py`
- Web 404/valid response behavior is covered by `test_web_not_found.py`
- production smoke will re-check known and unknown API/Web slugs after merge

Primary behavior follows FastAPI's explicit 404 error semantics and Vercel's documented rewrite routing contract.