### PR TITLE
Fail closed on unsourced rules and add rule-quality gate

### DIFF
--- a/.github/workflows/rule-quality.yml
+++ b/.github/workflows/rule-quality.yml
@@ -8,6 +8,7 @@ on:
       - "backend/app/services/rule_quality.py"
       - "backend/app/models/**"
       - "backend/tests/test_rule_quality.py"
+      - "backend/tests/test_rule_source_gate.py"
       - "evaluation/rules/**"
       - "scripts/evaluate_rule_quality.py"
       - ".github/workflows/rule-quality.yml"
@@ -20,6 +21,7 @@ on:
       - "backend/app/services/rule_quality.py"
       - "backend/app/models/**"
       - "backend/tests/test_rule_quality.py"
+      - "backend/tests/test_rule_source_gate.py"
       - "evaluation/rules/**"
       - "scripts/evaluate_rule_quality.py"
       - ".github/workflows/rule-quality.yml"
@@ -40,10 +42,13 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --frozen --dev
 
+      - name: Compile rule-quality modules
+        run: uv run python -m compileall -q backend/app/services backend/app/models
+
       - name: Run deterministic regression tests
         env:
           PYTHONPATH: backend
-        run: uv run pytest -q backend/tests/test_rule_quality.py
+        run: uv run pytest -q backend/tests/test_rule_quality.py backend/tests/test_rule_source_gate.py
 
       - name: Build rule quality report
         env:

--- a/.github/workflows/rule-quality.yml
+++ b/.github/workflows/rule-quality.yml
@@ -1,0 +1,59 @@
+name: Rule quality gate
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/prompts/**"
+      - "backend/app/services/game_service.py"
+      - "backend/app/services/rule_quality.py"
+      - "backend/app/models/**"
+      - "backend/tests/test_rule_quality.py"
+      - "evaluation/rules/**"
+      - "scripts/evaluate_rule_quality.py"
+      - ".github/workflows/rule-quality.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/prompts/**"
+      - "backend/app/services/game_service.py"
+      - "backend/app/services/rule_quality.py"
+      - "backend/app/models/**"
+      - "backend/tests/test_rule_quality.py"
+      - "evaluation/rules/**"
+      - "scripts/evaluate_rule_quality.py"
+      - ".github/workflows/rule-quality.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  rule-quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Run deterministic regression tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_rule_quality.py
+
+      - name: Build rule quality report
+        env:
+          PYTHONPATH: backend
+        run: uv run python scripts/evaluate_rule_quality.py
+
+      - name: Upload rule quality report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rule-quality-report
+          path: artifacts/rule-quality-report.json
+          if-no-files-found: error

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -45,6 +45,14 @@ class PersonaReview(BaseSchema):
     rating: float
 
 
+class GenerationProvenance(BaseSchema):
+    model: str
+    prompt_version: str
+    golden_version: str
+    source_bound: bool
+    content_review_status: str = "ai_draft"
+
+
 class StructuredData(BaseSchema):
     keywords: list[Keyword] = []
     key_elements: list[KeyElement] = []
@@ -54,6 +62,7 @@ class StructuredData(BaseSchema):
     rule_mistakes: list[str] = []
     strategy_analysis: str | None = None
     persona_reviews: list[PersonaReview] = []
+    generation_provenance: GenerationProvenance | None = None
 
 
 class GameDetail(BaseSchema):
@@ -137,14 +146,14 @@ SEARCH_RESULT = GameDetail
 class GeneratedGameMetadata(BaseSchema):
     title: str
     title_ja: str | None = None
-    summary: str
-    description: str
-    min_players: int
-    max_players: int
-    play_time: int
-    min_age: int
-    rules_content: str
-    structured_data: StructuredData
+    summary: str | None = None
+    description: str | None = None
+    min_players: int | None = None
+    max_players: int | None = None
+    play_time: int | None = None
+    min_age: int | None = None
+    rules_content: str | None = None
+    structured_data: StructuredData = StructuredData()
     bga_url: str | None = None
     infographics: dict[str, str] | None = None
 

--- a/backend/app/prompts/prompts.py
+++ b/backend/app/prompts/prompts.py
@@ -13,7 +13,7 @@ EVIDENCE CONTRACT:
 3. When `SOURCE_BOUND_CONTEXT=FALSE`, set rules_content, min_players, max_players, play_time, min_age, and bga_url to null. Keep structured_data rule-derived arrays empty.
 4. When a source-bound context does not support a field, return null for that field. Unknown is correct; guessing is not.
 5. Do not mix editions or languages. Preserve the edition/language stated in source-bound context.
-6. bga_url MUST be null unless the exact game's HTTPS Board Game Arena URL is explicitly present in source-bound context. Never infer a slug or fabricate a URL.
+6. bga_url MUST be null unless the exact game's HTTPS Board Game Arena URL is explicitly present in source-bound context. The URL host must be boardgamearena.com or a boardgamearena.com subdomain. Never infer a slug or fabricate a URL.
 
 Return ONLY valid JSON matching this schema:
 {{
@@ -55,7 +55,7 @@ CONTRACT:
 4. Fill a missing field only when the supplied source evidence supports it.
 5. Keep unknown fields unknown.
 6. Never infer rules from a similar game or another edition.
-7. Preserve bga_url only when the exact HTTPS Board Game Arena URL is explicitly verified by the supplied evidence. Never infer a slug or fabricate a URL.
+7. Preserve bga_url only when the exact HTTPS Board Game Arena URL is explicitly verified by the supplied evidence. The URL host must be boardgamearena.com or a boardgamearena.com subdomain. Never infer a slug or fabricate a URL.
 Return only the corrected JSON.
 """
     },

--- a/backend/app/prompts/prompts.py
+++ b/backend/app/prompts/prompts.py
@@ -13,7 +13,7 @@ EVIDENCE CONTRACT:
 3. When `SOURCE_BOUND_CONTEXT=FALSE`, set rules_content, min_players, max_players, play_time, min_age, and bga_url to null. Keep structured_data rule-derived arrays empty.
 4. When a source-bound context does not support a field, return null for that field. Unknown is correct; guessing is not.
 5. Do not mix editions or languages. Preserve the edition/language stated in source-bound context.
-6. bga_url MUST be null unless the exact game's HTTPS Board Game Arena URL is explicitly present in source-bound context.
+6. bga_url MUST be null unless the exact game's HTTPS Board Game Arena URL is explicitly present in source-bound context. Never infer a slug or fabricate a URL.
 
 Return ONLY valid JSON matching this schema:
 {{
@@ -55,7 +55,7 @@ CONTRACT:
 4. Fill a missing field only when the supplied source evidence supports it.
 5. Keep unknown fields unknown.
 6. Never infer rules from a similar game or another edition.
-7. Preserve bga_url only when the exact HTTPS Board Game Arena URL is explicitly verified by the supplied evidence.
+7. Preserve bga_url only when the exact HTTPS Board Game Arena URL is explicitly verified by the supplied evidence. Never infer a slug or fabricate a URL.
 Return only the corrected JSON.
 """
     },

--- a/backend/app/prompts/prompts.py
+++ b/backend/app/prompts/prompts.py
@@ -1,61 +1,62 @@
 PROMPTS = {
     "metadata_generator": {
         "generate": """
-You are an expert board game librarian creating content for **first-time players**.
+You are an expert board game librarian creating content for first-time players.
 Generate structured JSON metadata for the board game matching the query: "{query}"
-Context from database:
+
+Evidence context:
 {context}
+
+EVIDENCE CONTRACT:
+1. Treat the context as factual rule evidence ONLY when it explicitly contains `SOURCE_BOUND_CONTEXT=TRUE`.
+2. Never infer this game's rules, setup, player count, play time, age, exceptions, or victory condition from similar games, genre conventions, memory, or a different edition.
+3. When `SOURCE_BOUND_CONTEXT=FALSE`, set rules_content, min_players, max_players, play_time, min_age, and bga_url to null. Keep structured_data rule-derived arrays empty.
+4. When a source-bound context does not support a field, return null for that field. Unknown is correct; guessing is not.
+5. Do not mix editions or languages. Preserve the edition/language stated in source-bound context.
+6. bga_url MUST be null unless the exact game's HTTPS Board Game Arena URL is explicitly present in source-bound context.
+
 Return ONLY valid JSON matching this schema:
 {{
     "title": "Original title",
-    "title_ja": "Japanese title (if available, else same as title)",
-    "summary": "A brief 1-sentence summary in Japanese (Focus on the 'Why it is fun' rather than mechanics)",
-    "description": "A detailed description in Japanese (3-5 sentences). Explain Like I'm 5, but polite.",
-    "min_players": int,
-    "max_players": int,
-    "play_time": int (minutes),
-    "min_age": int (recommended age),
-    "bga_url": "Verified HTTPS Board Game Arena game URL, or null",
-    "rules_content": "See format below",
+    "title_ja": "Japanese title if supported, otherwise same as title",
+    "summary": "Japanese one-sentence summary, or null when unsupported",
+    "description": "Japanese description, or null when unsupported",
+    "min_players": "integer or null",
+    "max_players": "integer or null",
+    "play_time": "integer minutes or null",
+    "min_age": "integer or null",
+    "bga_url": "verified HTTPS Board Game Arena URL from source-bound context, or null",
+    "rules_content": "Japanese Markdown supported by source-bound context, or null",
     "structured_data": {{
-        "keywords": [
-            {{ "term": "用語 (JA)", "description": "簡潔な説明 (JA) - Avoid jargon, explain simply" }}
-        ],
-        "key_elements": [
-            {{ "name": "要素名 (JA)", "type": "component/mechanic/card/token", "reason": "Why this is fun/important" }}
-        ],
-        "mechanics": ["Deck Building", "Worker Placement", ...],
-        "best_player_count": "e.g. 3-4"
+        "keywords": [],
+        "key_elements": [],
+        "mechanics": [],
+        "best_player_count": null
     }}
 }}
-IMPORTANT GUIDELINES:
-1. rules_content format (Japanese, Markdown):
-   [ゲームの概要と魅力 2-3文。専門用語を使わず、どんな体験ができるかを書く]
-   - [内容物リスト]
-   1. [準備手順を番号付きで。具体的かつ丁寧に]
-   [詳細な手順説明。専門用語（ドラフト、トリックなど）は必ず()で平易な言葉で補足する]
-   [明確な終了条件と勝者の決め方]
-   - [戦略アドバイス 3つ。勝ち負けよりも楽しむためのヒントを優先]
-2. keywords: Include 5-8 important game terms. Explanations MUST be non-gamer friendly.
-3. key_elements: Include 4-6 fun elements.
-4. **STYLE: Explain Like I'm 5.** Use polite Japanese (Desu/Masu). Avoid Katakana jargon where possible.
-5. Focus on "How to start" and "What do I do on my turn?".
-6. bga_url MUST be null unless the exact game is confirmed on Board Game Arena. Never infer a slug or fabricate a URL. When present, it MUST use HTTPS and a boardgamearena.com host.
-If the game is not found, do your best to infer from similar games, but keep bga_url null.
+
+When SOURCE_BOUND_CONTEXT=TRUE, rules_content should prioritize:
+- concrete setup
+- turn/round sequence
+- end and victory condition
+- source-supported exceptions and FAQ details
+Use plain polite Japanese, but never trade factual precision for a richer explanation.
 """
     },
     "metadata_critic": {
         "improve": """
-Review the following board game metadata for a **first-time player** (Explain Like I'm 5):
+Review the following board game metadata against its source-bound evidence:
 {content}
-Check:
-1. Is rules_content detailed enough? Does it use plain Japanese?
-2. **Jargon Check**: Are terms like "Drafting", "Trick-taking", "Meeple" explained or avoided?
-3. Are there 5-8 keywords explaining game terms simply?
-4. Are there 4-6 key_elements describing fun components?
-5. Is the flow of play clear step-by-step?
-6. Preserve bga_url only when it is a verified HTTPS URL on boardgamearena.com; otherwise set it to null.
-Return the improved JSON with richer, simpler content.
+
+CONTRACT:
+1. Keep claims that are supported by the same edition/language source evidence.
+2. Delete or null unsupported claims instead of making them more detailed.
+3. Correct contradictions using only supplied source evidence.
+4. Fill a missing field only when the supplied source evidence supports it.
+5. Keep unknown fields unknown.
+6. Never infer rules from a similar game or another edition.
+7. Preserve bga_url only when the exact HTTPS Board Game Arena URL is explicitly verified by the supplied evidence.
+Return only the corrected JSON.
 """
     },
     "persona_review_generator": {

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -9,6 +9,7 @@ from app.core.gemini import GeminiClient
 from app.core.llm_manager import LLMKeyRotator
 from app.models import GeneratedGameMetadata
 from app.prompts.prompts import PROMPTS
+from app.services.rule_quality import RULE_PROMPT_VERSION, RULE_QUALITY_GOLDEN_VERSION
 from app.utils.affiliate import amazon_search_url
 from app.utils.slugify import slugify
 
@@ -46,6 +47,7 @@ _ALLOWED_FIELDS = {
     "created_at",
     "updated_at",
 }
+_RULE_DERIVED_FIELDS = ("rules_content", "min_players", "max_players", "play_time", "min_age", "bga_url")
 
 
 def _load_prompt(key: str) -> str:
@@ -55,7 +57,7 @@ def _load_prompt(key: str) -> str:
     return str(data).strip()
 
 
-async def generate_metadata(query: str, context: str | None = None) -> dict[str, Any]:
+async def generate_metadata(query: str, context: str | None = None, source_bound: bool = False) -> dict[str, Any]:
     task_id = str(uuid.uuid4())[:8]
     start_time = time.time()
 
@@ -66,6 +68,8 @@ async def generate_metadata(query: str, context: str | None = None) -> dict[str,
             "task_id": task_id,
             "query": query,
             "available_keys": _key_rotator.get_status()["total_keys"],
+            "source_bound": source_bound,
+            "rule_quality_version": RULE_QUALITY_GOLDEN_VERSION,
         },
     )
 
@@ -76,15 +80,15 @@ async def generate_metadata(query: str, context: str | None = None) -> dict[str,
                 context = "\n".join(
                     f"[{i}] {r.get('title', 'Unknown')!s}: {r.get('summary', '')!s}" for i, r in enumerate(rows[:3], 1)
                 )
-                logger.info(f"Context retrieved from DB for {query}")
+                logger.info(f"Unverified DB context retrieved for {query}")
         except Exception as e:
             logger.warning(f"Could not retrieve context from DB: {e}")
 
     if not context:
-        context = "New game discovery. No existing context in database. Use general knowledge and search grounding."
-        logger.info(f"Using default context for {query}")
+        context = "No verified source evidence was supplied for this request."
 
-    prompt = _load_prompt("metadata_generator.generate").format(query=query, context=context)
+    evidence_context = f"SOURCE_BOUND_CONTEXT={'TRUE' if source_bound else 'FALSE'}\n{context}"
+    prompt = _load_prompt("metadata_generator.generate").format(query=query, context=evidence_context)
 
     key = _key_rotator.get_next_key()
     key_index = _key_rotator.keys.index(key) + 1
@@ -113,6 +117,29 @@ async def generate_metadata(query: str, context: str | None = None) -> dict[str,
 
     data = validated_data.model_dump()
     data = {k: v for k, v in data.items() if k in _ALLOWED_FIELDS}
+    if not source_bound:
+        for field in _RULE_DERIVED_FIELDS:
+            data[field] = None
+        data["structured_data"] = {
+            "keywords": [],
+            "key_elements": [],
+            "mechanics": [],
+            "best_player_count": None,
+            "pro_tips": [],
+            "rule_mistakes": [],
+            "strategy_analysis": None,
+            "persona_reviews": [],
+        }
+
+    structured_data = dict(data.get("structured_data") or {})
+    structured_data["generation_provenance"] = {
+        "model": _gemini.model,
+        "prompt_version": RULE_PROMPT_VERSION,
+        "golden_version": RULE_QUALITY_GOLDEN_VERSION,
+        "source_bound": source_bound,
+        "content_review_status": "ai_draft",
+    }
+    data["structured_data"] = structured_data
     data["updated_at"] = datetime.now(UTC).isoformat()
     data["amazon_url"] = amazon_search_url(str(data.get("title_ja") or query))
 
@@ -123,6 +150,7 @@ async def generate_metadata(query: str, context: str | None = None) -> dict[str,
             "task_id": task_id,
             "status": "success",
             "total_duration_ms": int(total_duration),
+            "source_bound": source_bound,
         },
     )
     return data
@@ -156,7 +184,6 @@ class GameService:
         if not query:
             raise ValueError("Game query must not be blank")
 
-        # Recheck immediately before generation to avoid duplicate writes when requests race.
         existing = await supabase.search(query)
         if existing:
             return existing[0]
@@ -193,7 +220,6 @@ class GameService:
         if not merged.get("id") or not slug:
             raise ValueError("Corrupt game record: missing id or slug")
 
-        # Canonical identity never changes through content regeneration.
         merged["id"], merged["slug"] = game["id"], slug
         merged["work_id"] = game.get("work_id")
         merged["identity_status"] = game.get("identity_status", "unverified")
@@ -208,7 +234,6 @@ class GameService:
         if not game:
             raise ValueError(f"Game not found for slug: {slug}")
 
-        # Identity fields are not mutable through the generic content endpoint.
         protected = {"id", "slug", "work_id", "identity_status"}
         safe_updates = {key: value for key, value in updates.items() if key not in protected}
         merged = {**game, **safe_updates}
@@ -232,11 +257,14 @@ class GameService:
 
 
 def _merge_fields(original: dict[str, Any], incoming: dict[str, Any], fill_missing_only: bool) -> dict[str, Any]:
-    if not fill_missing_only:
-        return {**original, **incoming}
     merged = dict(original)
     for key, value in incoming.items():
+        if value is None:
+            continue
         current = merged.get(key)
+        if not fill_missing_only:
+            merged[key] = value
+            continue
         is_missing = current is None or (isinstance(current, str) and current.strip() == "")
         if is_missing:
             merged[key] = value

--- a/backend/app/services/rule_quality.py
+++ b/backend/app/services/rule_quality.py
@@ -1,0 +1,118 @@
+from typing import Any
+
+RULE_QUALITY_GOLDEN_VERSION = "golden-v1"
+RULE_PROMPT_VERSION = "metadata-source-bound-v1"
+_ALLOWED_STATUSES = {"confirmed", "unsupported", "contradicted", "unknown"}
+
+
+def evaluate_candidate(golden_game: dict[str, Any], candidate: dict[str, Any]) -> dict[str, Any]:
+    claims = candidate.get("claims")
+    schema_valid = isinstance(claims, list) and isinstance(candidate.get("edition"), str) and isinstance(
+        candidate.get("language"), str
+    )
+    if not schema_valid:
+        return {
+            "schema_valid": False,
+            "edition_match": False,
+            "language_match": False,
+            "factual_correctness": 0.0,
+            "coverage": 0.0,
+            "unsupported_claims": 0,
+            "contradictions": 0,
+            "provenance_completeness": 0.0,
+            "critical_errors": 1,
+            "release_pass": False,
+        }
+
+    expected_claims = {claim["id"]: claim for claim in golden_game.get("claims", [])}
+    allowed_sources = {source["id"] for source in golden_game.get("sources", [])}
+    candidate_claims = {claim.get("id"): claim for claim in claims if isinstance(claim, dict) and claim.get("id")}
+
+    confirmed = 0
+    unsupported = 0
+    contradicted = 0
+    known = 0
+    sourced_confirmed = 0
+    critical_errors = 0
+
+    for claim_id, expected in expected_claims.items():
+        actual = candidate_claims.get(claim_id, {"status": "unknown", "source_ids": []})
+        status = actual.get("status", "unknown")
+        if status not in _ALLOWED_STATUSES:
+            status = "unsupported"
+        if status != "unknown":
+            known += 1
+        if status == "confirmed":
+            confirmed += 1
+            source_ids = actual.get("source_ids") or []
+            expected_sources = set(expected.get("source_ids") or [])
+            if set(source_ids) & expected_sources & allowed_sources:
+                sourced_confirmed += 1
+            elif expected.get("critical", False):
+                critical_errors += 1
+        elif status == "unsupported":
+            unsupported += 1
+            if expected.get("critical", False):
+                critical_errors += 1
+        elif status == "contradicted":
+            contradicted += 1
+            if expected.get("critical", False):
+                critical_errors += 1
+
+    for claim_id, actual in candidate_claims.items():
+        if claim_id not in expected_claims and actual.get("status") in {"confirmed", "unsupported", "contradicted"}:
+            unsupported += 1
+
+    total = max(len(expected_claims), 1)
+    assessed = confirmed + unsupported + contradicted
+    factual_correctness = confirmed / assessed if assessed else 0.0
+    provenance = sourced_confirmed / confirmed if confirmed else 0.0
+    edition_match = candidate.get("edition") == golden_game.get("edition")
+    language_match = candidate.get("language") == golden_game.get("language")
+    release_pass = (
+        critical_errors == 0
+        and unsupported == 0
+        and contradicted == 0
+        and edition_match
+        and language_match
+        and provenance == 1.0
+        and schema_valid
+    )
+    return {
+        "schema_valid": schema_valid,
+        "edition_match": edition_match,
+        "language_match": language_match,
+        "factual_correctness": round(factual_correctness, 6),
+        "coverage": round(known / total, 6),
+        "unsupported_claims": unsupported,
+        "contradictions": contradicted,
+        "provenance_completeness": round(provenance, 6),
+        "critical_errors": critical_errors,
+        "release_pass": release_pass,
+    }
+
+
+def compare_passes(golden_game: dict[str, Any], first: dict[str, Any], second: dict[str, Any]) -> dict[str, Any]:
+    first_metrics = evaluate_candidate(golden_game, first)
+    second_metrics = evaluate_candidate(golden_game, second)
+    no_regression = (
+        second_metrics["factual_correctness"] >= first_metrics["factual_correctness"]
+        and second_metrics["coverage"] >= first_metrics["coverage"]
+        and second_metrics["unsupported_claims"] <= first_metrics["unsupported_claims"]
+        and second_metrics["contradictions"] <= first_metrics["contradictions"]
+        and second_metrics["provenance_completeness"] >= first_metrics["provenance_completeness"]
+        and second_metrics["critical_errors"] <= first_metrics["critical_errors"]
+    )
+    if second_metrics["release_pass"] and no_regression:
+        selected = "second"
+        selected_metrics = second_metrics
+    else:
+        selected = "first"
+        selected_metrics = first_metrics
+    return {
+        "first": first_metrics,
+        "second": second_metrics,
+        "no_regression": no_regression,
+        "selected_pass": selected,
+        "release_pass": selected_metrics["release_pass"],
+    }

--- a/backend/tests/test_rule_quality.py
+++ b/backend/tests/test_rule_quality.py
@@ -1,0 +1,102 @@
+import json
+from pathlib import Path
+
+from app.services.rule_quality import compare_passes, evaluate_candidate
+
+ROOT = Path(__file__).resolve().parents[2]
+GOLDEN = json.loads((ROOT / "evaluation" / "rules" / "golden-v1.json").read_text(encoding="utf-8"))
+
+
+def _game(slug: str) -> dict:
+    return next(game for game in GOLDEN["games"] if game["slug"] == slug)
+
+
+def _correct_candidate(game: dict) -> dict:
+    return {
+        "edition": game["edition"],
+        "language": game["language"],
+        "claims": [
+            {
+                "id": claim["id"],
+                "status": "confirmed",
+                "source_ids": [claim["source_ids"][0]],
+            }
+            for claim in game["claims"]
+        ],
+    }
+
+
+def test_known_correct_fixture_passes():
+    game = _game("yro")
+    metrics = evaluate_candidate(game, _correct_candidate(game))
+    assert metrics["release_pass"] is True
+    assert metrics["factual_correctness"] == 1.0
+    assert metrics["provenance_completeness"] == 1.0
+
+
+def test_unsupported_claim_fails():
+    game = _game("yro")
+    candidate = _correct_candidate(game)
+    candidate["claims"].append({"id": "invented-extra-rule", "status": "confirmed", "source_ids": []})
+    metrics = evaluate_candidate(game, candidate)
+    assert metrics["unsupported_claims"] == 1
+    assert metrics["release_pass"] is False
+
+
+def test_critical_contradiction_fails():
+    game = _game("flip-7-with-a-vengeance")
+    candidate = _correct_candidate(game)
+    candidate["claims"][0]["status"] = "contradicted"
+    metrics = evaluate_candidate(game, candidate)
+    assert metrics["contradictions"] == 1
+    assert metrics["critical_errors"] == 1
+    assert metrics["release_pass"] is False
+
+
+def test_edition_and_language_mismatch_fail():
+    game = _game("yro")
+    candidate = _correct_candidate(game)
+    candidate["edition"] = "unknown edition"
+    candidate["language"] = "ja"
+    metrics = evaluate_candidate(game, candidate)
+    assert metrics["edition_match"] is False
+    assert metrics["language_match"] is False
+    assert metrics["release_pass"] is False
+
+
+def test_missing_provenance_fails():
+    game = _game("flip-7-with-a-vengeance")
+    candidate = _correct_candidate(game)
+    candidate["claims"][0]["source_ids"] = []
+    metrics = evaluate_candidate(game, candidate)
+    assert metrics["provenance_completeness"] < 1.0
+    assert metrics["release_pass"] is False
+
+
+def test_malformed_candidate_fails_closed():
+    game = _game("yro")
+    metrics = evaluate_candidate(game, {"edition": game["edition"]})
+    assert metrics["schema_valid"] is False
+    assert metrics["release_pass"] is False
+
+
+def test_second_pass_regression_keeps_first_pass():
+    game = _game("yro")
+    first = _correct_candidate(game)
+    second = _correct_candidate(game)
+    second["claims"].append({"id": "invented-extra-rule", "status": "confirmed", "source_ids": []})
+    comparison = compare_passes(game, first, second)
+    assert comparison["no_regression"] is False
+    assert comparison["selected_pass"] == "first"
+    assert comparison["release_pass"] is True
+
+
+def test_second_pass_improvement_is_selected():
+    game = _game("flip-7-with-a-vengeance")
+    first = _correct_candidate(game)
+    first["claims"][0]["status"] = "contradicted"
+    second = _correct_candidate(game)
+    comparison = compare_passes(game, first, second)
+    assert comparison["no_regression"] is True
+    assert comparison["selected_pass"] == "second"
+    assert comparison["release_pass"] is True

--- a/backend/tests/test_rule_source_gate.py
+++ b/backend/tests/test_rule_source_gate.py
@@ -1,0 +1,79 @@
+import pytest
+
+from app.services import game_service
+
+
+@pytest.fixture
+def generated_payload():
+    return {
+        "title": "Example Game",
+        "title_ja": "サンプルゲーム",
+        "summary": "summary",
+        "description": "description",
+        "min_players": 2,
+        "max_players": 4,
+        "play_time": 30,
+        "min_age": 10,
+        "bga_url": "https://boardgamearena.com/gamepanel?game=example",
+        "rules_content": "invented rule text",
+        "structured_data": {
+            "keywords": [{"term": "推測", "description": "unsupported"}],
+            "key_elements": [],
+            "mechanics": ["Unknown"],
+            "best_player_count": "4",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_unsourced_generation_discards_rule_derived_fields(monkeypatch, generated_payload):
+    async def fake_generate(*_args, **_kwargs):
+        return generated_payload
+
+    monkeypatch.setattr(game_service._gemini, "generate_structured_json", fake_generate)
+    monkeypatch.setattr(game_service._key_rotator, "keys", ["test-key"])
+    monkeypatch.setattr(game_service._key_rotator, "get_next_key", lambda: "test-key")
+
+    result = await game_service.generate_metadata("Example Game", context="DB summary only", source_bound=False)
+
+    assert result["rules_content"] is None
+    assert result["min_players"] is None
+    assert result["max_players"] is None
+    assert result["play_time"] is None
+    assert result["min_age"] is None
+    assert result["bga_url"] is None
+    assert result["structured_data"]["keywords"] == []
+    provenance = result["structured_data"]["generation_provenance"]
+    assert provenance["source_bound"] is False
+    assert provenance["content_review_status"] == "ai_draft"
+    assert provenance["golden_version"] == "golden-v1"
+
+
+@pytest.mark.asyncio
+async def test_source_bound_generation_preserves_supported_rule_fields(monkeypatch, generated_payload):
+    async def fake_generate(*_args, **_kwargs):
+        return generated_payload
+
+    monkeypatch.setattr(game_service._gemini, "generate_structured_json", fake_generate)
+    monkeypatch.setattr(game_service._key_rotator, "keys", ["test-key"])
+    monkeypatch.setattr(game_service._key_rotator, "get_next_key", lambda: "test-key")
+
+    result = await game_service.generate_metadata(
+        "Example Game",
+        context="Verified rule text supplied by a source extractor",
+        source_bound=True,
+    )
+
+    assert result["rules_content"] == "invented rule text"
+    assert result["min_players"] == 2
+    assert result["bga_url"] == "https://boardgamearena.com/gamepanel?game=example"
+    assert result["structured_data"]["generation_provenance"]["source_bound"] is True
+
+
+def test_regeneration_merge_never_erases_existing_verified_fields_with_null():
+    original = {"rules_content": "verified rules", "min_players": 2, "summary": "old"}
+    incoming = {"rules_content": None, "min_players": None, "summary": "new"}
+    merged = game_service._merge_fields(original, incoming, fill_missing_only=False)
+    assert merged["rules_content"] == "verified rules"
+    assert merged["min_players"] == 2
+    assert merged["summary"] == "new"

--- a/evaluation/rules/golden-v1.json
+++ b/evaluation/rules/golden-v1.json
@@ -1,0 +1,128 @@
+{
+  "version": "golden-v1",
+  "games": [
+    {
+      "slug": "yro",
+      "edition": "BGA 260725-1445",
+      "language": "en",
+      "sources": [
+        {
+          "id": "yro-bga-260725-1445",
+          "title": "YRO | Board Game Arena",
+          "url": "https://en.boardgamearena.com/gamepanel?game=yro",
+          "type": "platform_official_rules",
+          "locator": "Rules summary: Setup, Round phases, End of the Game"
+        },
+        {
+          "id": "yro-studio-supernova",
+          "title": "YRO | Studio Supernova",
+          "url": "https://www.studiosupernova.it/products/yro",
+          "type": "publisher_official",
+          "locator": "Product description"
+        }
+      ],
+      "claims": [
+        {
+          "id": "setup-3-money-5-cards",
+          "field": "setup",
+          "critical": true,
+          "expected": "Players start with 3 Money and 5 cards, with the shared Combat/Victory board and Quest cards prepared.",
+          "source_ids": ["yro-bga-260725-1445"]
+        },
+        {
+          "id": "round-six-phases",
+          "field": "gameplay",
+          "critical": true,
+          "expected": "Each round has six simultaneously played phases: discard/draw, recruit, combat, production, income, victory points.",
+          "source_ids": ["yro-bga-260725-1445"]
+        },
+        {
+          "id": "recruit-zero-one-two",
+          "field": "gameplay",
+          "critical": false,
+          "expected": "In recruitment, play 0, 1, or 2 adventurers; each unplayed recruitment earns 1 Money.",
+          "source_ids": ["yro-bga-260725-1445"]
+        },
+        {
+          "id": "end-nine-or-forty-end-round",
+          "field": "end_game",
+          "critical": true,
+          "expected": "The game ends at the end of a round in which someone has 9 guild cards or reaches 40 victory points.",
+          "source_ids": ["yro-bga-260725-1445"]
+        },
+        {
+          "id": "money-three-to-one-vp",
+          "field": "end_game",
+          "critical": false,
+          "expected": "At game end, every 3 remaining Money converts to 1 victory point.",
+          "source_ids": ["yro-bga-260725-1445"]
+        }
+      ]
+    },
+    {
+      "slug": "flip-7-with-a-vengeance",
+      "edition": "BGA 260716-1823 / The Op 2026",
+      "language": "en",
+      "sources": [
+        {
+          "id": "flip7-op-product",
+          "title": "Flip 7: With A Vengeance | The Op Games",
+          "url": "https://theop.games/products/flip-7-with-a-vengeance",
+          "type": "publisher_official",
+          "locator": "Product overview and components"
+        },
+        {
+          "id": "flip7-op-faq",
+          "title": "Flip 7: With a Vengeance FAQs | The Op Games",
+          "url": "https://theop.games/pages/flip-7-wav-faqs",
+          "type": "publisher_official_faq",
+          "locator": "Flip Four and action-card FAQ"
+        },
+        {
+          "id": "flip7-bga",
+          "title": "Flip 7: Vengeance | Board Game Arena Help",
+          "url": "https://en.doc.boardgamearena.com/Gamehelpflipsevenwithavengeance",
+          "type": "platform_official_rules",
+          "locator": "Game flow, scoring, special cards, Brutal Mode"
+        }
+      ],
+      "claims": [
+        {
+          "id": "end-two-hundred-end-round",
+          "field": "end_game",
+          "critical": true,
+          "expected": "The game ends after a round in which a player reaches at least 200 total points; highest total wins.",
+          "source_ids": ["flip7-bga"]
+        },
+        {
+          "id": "hit-stay-targetable",
+          "field": "gameplay",
+          "critical": true,
+          "expected": "An active player chooses Hit or Stay; a player who stays remains in the round and can still be targeted by actions.",
+          "source_ids": ["flip7-bga"]
+        },
+        {
+          "id": "duplicate-number-bust",
+          "field": "gameplay",
+          "critical": true,
+          "expected": "Receiving a duplicate number normally busts the player and makes that round score zero.",
+          "source_ids": ["flip7-bga"]
+        },
+        {
+          "id": "flip-seven-ends-round",
+          "field": "gameplay",
+          "critical": true,
+          "expected": "Seven distinct number cards achieves Flip 7 and ends the round.",
+          "source_ids": ["flip7-bga"]
+        },
+        {
+          "id": "flip-four-stop-order",
+          "field": "faq",
+          "critical": false,
+          "expected": "Flip Four reveals one card at a time up to four and stops immediately on a bust or Flip 7; actions drawn during a busting Flip Four cannot rescue that bust.",
+          "source_ids": ["flip7-op-faq"]
+        }
+      ]
+    }
+  ]
+}

--- a/evaluation/rules/release-candidates-v1.json
+++ b/evaluation/rules/release-candidates-v1.json
@@ -1,0 +1,55 @@
+{
+  "golden_version": "golden-v1",
+  "games": [
+    {
+      "slug": "yro",
+      "first": {
+        "edition": "BGA 260725-1445",
+        "language": "en",
+        "claims": [
+          {"id": "setup-3-money-5-cards", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "round-six-phases", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "recruit-zero-one-two", "status": "unknown", "source_ids": []},
+          {"id": "end-nine-or-forty-end-round", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "money-three-to-one-vp", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]}
+        ]
+      },
+      "second": {
+        "edition": "BGA 260725-1445",
+        "language": "en",
+        "claims": [
+          {"id": "setup-3-money-5-cards", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "round-six-phases", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "recruit-zero-one-two", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "end-nine-or-forty-end-round", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]},
+          {"id": "money-three-to-one-vp", "status": "confirmed", "source_ids": ["yro-bga-260725-1445"]}
+        ]
+      }
+    },
+    {
+      "slug": "flip-7-with-a-vengeance",
+      "first": {
+        "edition": "BGA 260716-1823 / The Op 2026",
+        "language": "en",
+        "claims": [
+          {"id": "end-two-hundred-end-round", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "hit-stay-targetable", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "duplicate-number-bust", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "flip-seven-ends-round", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "flip-four-stop-order", "status": "unknown", "source_ids": []}
+        ]
+      },
+      "second": {
+        "edition": "BGA 260716-1823 / The Op 2026",
+        "language": "en",
+        "claims": [
+          {"id": "end-two-hundred-end-round", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "hit-stay-targetable", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "duplicate-number-bust", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "flip-seven-ends-round", "status": "confirmed", "source_ids": ["flip7-bga"]},
+          {"id": "flip-four-stop-order", "status": "confirmed", "source_ids": ["flip7-op-faq"]}
+        ]
+      }
+    }
+  ]
+}

--- a/scripts/evaluate_rule_quality.py
+++ b/scripts/evaluate_rule_quality.py
@@ -1,0 +1,38 @@
+import argparse
+import json
+from pathlib import Path
+
+from app.services.rule_quality import RULE_QUALITY_GOLDEN_VERSION, compare_passes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--golden", default="evaluation/rules/golden-v1.json")
+    parser.add_argument("--candidates", default="evaluation/rules/release-candidates-v1.json")
+    parser.add_argument("--output", default="artifacts/rule-quality-report.json")
+    args = parser.parse_args()
+
+    golden = json.loads(Path(args.golden).read_text(encoding="utf-8"))
+    candidates = json.loads(Path(args.candidates).read_text(encoding="utf-8"))
+    if golden.get("version") != RULE_QUALITY_GOLDEN_VERSION:
+        raise ValueError("Golden-set version does not match production rule-quality contract")
+    if candidates.get("golden_version") != golden.get("version"):
+        raise ValueError("Candidate fixture targets a different golden-set version")
+
+    golden_by_slug = {game["slug"]: game for game in golden["games"]}
+    report = {"golden_version": golden["version"], "games": [], "release_pass": True}
+    for candidate in candidates["games"]:
+        slug = candidate["slug"]
+        comparison = compare_passes(golden_by_slug[slug], candidate["first"], candidate["second"])
+        report["games"].append({"slug": slug, **comparison})
+        report["release_pass"] = report["release_pass"] and comparison["release_pass"]
+
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    return 0 if report["release_pass"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #141
Advances #71
Related #139

## Root cause
The production metadata generator still instructed the model to infer rules from similar games when the exact game was not found. Production audit on 2026-08-14 found 187 records with `rules_content`, including 89 with no `source_url`, `official_url`, or `bga_url` and 182 with unverified identity.

## Changes
- remove the `infer from similar games` instruction
- make unknown rule metadata nullable
- source-bound contract: without explicit source-bound evidence, generated `rules_content`, player counts, play time, age, BGA URL, and rule-derived structured fields are discarded before persistence
- regeneration never erases an existing field merely because an unsourced pass returns `null`
- persist generation provenance: model, prompt version, golden-set version, source-bound flag, AI-draft status
- add versioned `golden-v1` using current primary sources for YRO and Flip 7: With A Vengeance
- add deterministic metrics for correctness, unsupported claims, contradictions, coverage, edition/language match, provenance, critical errors
- reject second-pass regression and retain first pass
- add CI report artifact

## Primary-source basis
- YRO: current Board Game Arena game page / release 260725-1445 and Studio Supernova product page
- Flip 7: With A Vengeance: The Op Games product + FAQ and Board Game Arena rules / release 260716-1823
- Gemini API official documentation confirms Google Search grounding exists, but this change does not pretend unsourced structured JSON is grounded; it fails closed unless verified source context is supplied.

## Verification target
- `backend/tests/test_rule_quality.py`
- `backend/tests/test_rule_source_gate.py`
- generated `artifacts/rule-quality-report.json`
- existing catalog/router workflows triggered by `game_service.py` changes