### PR TITLE
Protect canonical game mutations with server-side editor RBAC

### DIFF
--- a/.github/workflows/test-games-router.yml
+++ b/.github/workflows/test-games-router.yml
@@ -4,12 +4,16 @@ on:
   pull_request:
     paths:
       - "backend/app/main.py"
+      - "backend/app/routers/auth.py"
       - "backend/app/routers/games.py"
+      - "backend/app/services/catalog_authorization.py"
       - "backend/app/services/game_service.py"
       - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
+      - "backend/tests/test_auth.py"
       - "backend/tests/test_games_router.py"
       - "backend/tests/test_web_not_found.py"
+      - "supabase/migrations/**"
       - ".github/workflows/test-games-router.yml"
       - "vercel.json"
       - "pyproject.toml"
@@ -19,12 +23,16 @@ on:
       - main
     paths:
       - "backend/app/main.py"
+      - "backend/app/routers/auth.py"
       - "backend/app/routers/games.py"
+      - "backend/app/services/catalog_authorization.py"
       - "backend/app/services/game_service.py"
       - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
+      - "backend/tests/test_auth.py"
       - "backend/tests/test_games_router.py"
       - "backend/tests/test_web_not_found.py"
+      - "supabase/migrations/**"
       - ".github/workflows/test-games-router.yml"
       - "vercel.json"
       - "pyproject.toml"
@@ -42,7 +50,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uv sync --frozen --dev
-      - name: Run game route regression tests
-        run: uv run pytest -q backend/tests/test_games_router.py backend/tests/test_web_not_found.py
+      - name: Run auth and game route regression tests
+        run: uv run pytest -q backend/tests/test_auth.py backend/tests/test_games_router.py backend/tests/test_web_not_found.py
         env:
           PYTHONPATH: backend

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -1,11 +1,15 @@
+import logging
+
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.rate_limiter import RateLimiter
 from app.models import GameDetail, GameListResponse, GameUpdate, SearchRequest
 from app.routers.auth import get_current_user
+from app.services import catalog_authorization
 from app.services.game_service import GameService
 
 router = APIRouter()
+logger = logging.getLogger("security.catalog")
 
 # Shared limiters
 search_limiter = RateLimiter.get_limiter("search", max_requests=100, window_seconds=60)
@@ -14,6 +18,40 @@ gen_limiter = RateLimiter.get_limiter("generation", max_requests=10, window_seco
 
 def get_game_service():
     return GameService()
+
+
+async def require_catalog_editor(
+    slug: str,
+    regenerate: bool = False,
+    user: dict = Depends(get_current_user),
+) -> dict:
+    """Authorize global catalog mutation from a verified Auth identity."""
+    actor_user_id = str(user.get("id") or "")
+    action = "regenerate" if regenerate else "manual_update"
+    role = await catalog_authorization.get_catalog_editor_role(actor_user_id)
+
+    if role not in {"owner", "editor"}:
+        await catalog_authorization.record_catalog_mutation_audit(
+            actor_user_id=actor_user_id,
+            game_slug=slug,
+            action=action,
+            changed_fields=[],
+            outcome="denied",
+        )
+        logger.warning(
+            "catalog_authorization_denied",
+            extra={"actor_user_id": actor_user_id, "game_slug": slug, "action": action},
+        )
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Catalog editor permission required")
+
+    await catalog_authorization.record_catalog_mutation_audit(
+        actor_user_id=actor_user_id,
+        game_slug=slug,
+        action=action,
+        changed_fields=[],
+        outcome="allowed",
+    )
+    return {**user, "catalog_role": role}
 
 
 @router.get("/search", response_model=list[GameDetail])
@@ -71,20 +109,49 @@ async def update_game(
     game_update: GameUpdate | None = None,
     regenerate: bool = False,
     fill_missing_only: bool = False,
-    _user: dict = Depends(get_current_user),
+    editor: dict = Depends(require_catalog_editor),
     service: GameService = Depends(get_game_service),
 ) -> dict[str, object]:
+    actor_user_id = str(editor["id"])
+    action = "regenerate" if regenerate else "manual_update"
+    changed_fields: list[str] = []
+
     try:
         if regenerate:
             if not gen_limiter.acquire():
                 raise HTTPException(status_code=429, detail="Generation rate limit exceeded")
-            return await service.update_game_content(slug, fill_missing_only=fill_missing_only)
+            changed_fields = ["regenerated_content"]
+            result = await service.update_game_content(slug, fill_missing_only=fill_missing_only)
+            await catalog_authorization.record_catalog_mutation_audit(
+                actor_user_id=actor_user_id,
+                game_slug=slug,
+                action=action,
+                changed_fields=changed_fields,
+                outcome="succeeded",
+            )
+            return result
 
         if game_update:
             updates = game_update.model_dump(exclude_unset=True)
             if updates:
-                return await service.update_game_manual(slug, updates)
+                changed_fields = sorted(updates)
+                result = await service.update_game_manual(slug, updates)
+                await catalog_authorization.record_catalog_mutation_audit(
+                    actor_user_id=actor_user_id,
+                    game_slug=slug,
+                    action=action,
+                    changed_fields=changed_fields,
+                    outcome="succeeded",
+                )
+                return result
     except ValueError as exc:
+        await catalog_authorization.record_catalog_mutation_audit(
+            actor_user_id=actor_user_id,
+            game_slug=slug,
+            action=action,
+            changed_fields=changed_fields,
+            outcome="not_found",
+        )
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found") from exc
 
     return {"status": "ok", "message": "No action taken (regenerate=False, no body)"}

--- a/backend/app/services/catalog_authorization.py
+++ b/backend/app/services/catalog_authorization.py
@@ -1,0 +1,70 @@
+import logging
+from typing import Literal
+
+import anyio
+
+from app.core import supabase
+
+logger = logging.getLogger("security.catalog")
+CatalogAction = Literal["manual_update", "regenerate"]
+AuditOutcome = Literal["allowed", "denied", "succeeded", "not_found", "failed"]
+
+
+async def get_catalog_editor_role(user_id: str) -> str | None:
+    """Resolve a verified Auth user against the server-only catalog editor allowlist."""
+    if not user_id or supabase.is_local():
+        return None
+
+    def _q():
+        rows = (
+            supabase._get_client()
+            .table("catalog_editors")
+            .select("role")
+            .eq("user_id", user_id)
+            .eq("active", True)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rows:
+            return None
+        role = str(rows[0].get("role") or "")
+        return role if role in {"owner", "editor"} else None
+
+    return await anyio.to_thread.run_sync(_q)
+
+
+async def record_catalog_mutation_audit(
+    *,
+    actor_user_id: str,
+    game_slug: str,
+    action: CatalogAction,
+    changed_fields: list[str],
+    outcome: AuditOutcome,
+) -> None:
+    """Persist secret-free catalog authorization/mutation evidence before returning."""
+    if not actor_user_id or supabase.is_local():
+        raise RuntimeError("Catalog mutation audit requires configured server-side Supabase access")
+
+    payload = {
+        "actor_user_id": actor_user_id,
+        "game_slug": game_slug,
+        "action": action,
+        "changed_fields": sorted(set(changed_fields)),
+        "outcome": outcome,
+    }
+
+    def _q():
+        supabase._get_client().table("catalog_mutation_audit").insert(payload).execute()
+
+    await anyio.to_thread.run_sync(_q)
+    logger.info(
+        "catalog_mutation_audit",
+        extra={
+            "actor_user_id": actor_user_id,
+            "game_slug": game_slug,
+            "action": action,
+            "changed_fields": payload["changed_fields"],
+            "outcome": outcome,
+        },
+    )

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -12,6 +12,7 @@ class MissingGameService:
 class MutableGameService:
     def __init__(self):
         self.updated = False
+        self.last_updates = None
 
     async def update_game_content(self, slug: str, fill_missing_only: bool = False):
         self.updated = True
@@ -19,7 +20,13 @@ class MutableGameService:
 
     async def update_game_manual(self, slug: str, updates: dict):
         self.updated = True
+        self.last_updates = updates
         return {"id": "game-1", "slug": slug, "title": updates.get("title", "Example")}
+
+
+class NotFoundMutableGameService(MutableGameService):
+    async def update_game_manual(self, slug: str, updates: dict):
+        raise ValueError("missing")
 
 
 class DBFirstService:
@@ -41,6 +48,19 @@ def _app_with_service(service):
     return app
 
 
+def _install_editor_authorization(app, monkeypatch, role="editor"):
+    app.dependency_overrides[games.get_current_user] = lambda: {"id": "user-1"}
+
+    async def get_role(_user_id: str):
+        return role
+
+    async def audit(**_kwargs):
+        return None
+
+    monkeypatch.setattr(games.catalog_authorization, "get_catalog_editor_role", get_role)
+    monkeypatch.setattr(games.catalog_authorization, "record_catalog_mutation_audit", audit)
+
+
 def test_missing_game_slug_returns_404_instead_of_response_validation_500():
     client = TestClient(_app_with_service(MissingGameService()))
     response = client.get("/api/games/ipso")
@@ -60,10 +80,23 @@ def test_catalog_patch_requires_authentication_before_mutation():
     assert service.updated is False
 
 
-def test_authenticated_regeneration_uses_existing_slug_update_path():
+def test_regular_authenticated_user_cannot_mutate_global_catalog(monkeypatch):
     service = MutableGameService()
     app = _app_with_service(service)
-    app.dependency_overrides[games.get_current_user] = lambda: {"id": "user-1"}
+    _install_editor_authorization(app, monkeypatch, role=None)
+    client = TestClient(app)
+
+    response = client.patch("/api/games/example", json={"title": "Should not write"})
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Catalog editor permission required"
+    assert service.updated is False
+
+
+def test_authorized_editor_regeneration_uses_existing_slug_update_path(monkeypatch):
+    service = MutableGameService()
+    app = _app_with_service(service)
+    _install_editor_authorization(app, monkeypatch, role="editor")
     client = TestClient(app)
 
     response = client.patch("/api/games/example?regenerate=true&fill_missing_only=true")
@@ -71,6 +104,34 @@ def test_authenticated_regeneration_uses_existing_slug_update_path():
     assert response.status_code == 200
     assert response.json()["slug"] == "example"
     assert service.updated is True
+
+
+def test_identity_fields_are_not_forwarded_to_manual_update(monkeypatch):
+    service = MutableGameService()
+    app = _app_with_service(service)
+    _install_editor_authorization(app, monkeypatch, role="editor")
+    client = TestClient(app)
+
+    response = client.patch(
+        "/api/games/example",
+        json={"slug": "hijacked", "id": "other-id", "work_id": "other-work", "identity_status": "official", "title": "Safe title"},
+    )
+
+    assert response.status_code == 200
+    assert service.updated is True
+    assert service.last_updates == {"title": "Safe title"}
+
+
+def test_authorized_editor_missing_slug_returns_404(monkeypatch):
+    service = NotFoundMutableGameService()
+    app = _app_with_service(service)
+    _install_editor_authorization(app, monkeypatch, role="editor")
+    client = TestClient(app)
+
+    response = client.patch("/api/games/missing", json={"title": "No target"})
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Game not found"}
 
 
 def test_post_search_checks_database_before_generation():

--- a/supabase/migrations/202608140655_catalog_editor_authorization.sql
+++ b/supabase/migrations/202608140655_catalog_editor_authorization.sql
@@ -1,0 +1,37 @@
+create table if not exists public.catalog_editors (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  role text not null check (role in ('owner', 'editor')),
+  active boolean not null default true,
+  created_at timestamptz not null default now()
+);
+
+alter table public.catalog_editors enable row level security;
+
+create table if not exists public.catalog_mutation_audit (
+  id bigint generated always as identity primary key,
+  actor_user_id uuid not null references auth.users(id) on delete restrict,
+  game_slug text not null,
+  action text not null check (action in ('manual_update', 'regenerate')),
+  changed_fields text[] not null default '{}',
+  outcome text not null check (outcome in ('allowed', 'denied', 'succeeded', 'not_found', 'failed')),
+  created_at timestamptz not null default now()
+);
+
+alter table public.catalog_mutation_audit enable row level security;
+
+create index if not exists catalog_mutation_audit_actor_created_idx
+  on public.catalog_mutation_audit(actor_user_id, created_at desc);
+create index if not exists catalog_mutation_audit_game_created_idx
+  on public.catalog_mutation_audit(game_slug, created_at desc);
+
+alter table public.games enable row level security;
+
+drop policy if exists games_public_read on public.games;
+create policy games_public_read
+  on public.games
+  for select
+  to anon, authenticated
+  using (true);
+
+revoke insert, update, delete, truncate, references, trigger on table public.games from anon, authenticated;
+grant select on table public.games to anon, authenticated;


### PR DESCRIPTION
Closes #134

## Security boundary
- verified Supabase Auth identity remains the authentication source
- global catalog PATCH additionally requires an active server-side `catalog_editors` allowlist row
- ordinary authenticated users receive 403 before `GameService` mutation
- authorization and mutation outcomes are written to a server-only audit table without token bodies
- canonical identity fields remain excluded from `GameUpdate` and are not forwarded to manual updates

## Database defense in depth
Production was audited before this PR and `public.games` had RLS disabled while `anon`/`authenticated` held INSERT/UPDATE/DELETE/TRUNCATE grants. Production has already been migrated to:
- enable RLS on `games`
- allow public/authenticated SELECT only
- revoke client write/truncate/reference/trigger privileges
- add RLS-protected `catalog_editors` and `catalog_mutation_audit`
- seed the single existing Auth account as an active `editor` (no user identifier is committed)

The idempotent schema contract is committed under `supabase/migrations/` without generated user IDs.

## Tests
Canonical route gate now covers auth, catalog RBAC, 404 and Web route regressions, including anonymous, malformed token, regular user, editor, nonexistent slug and identity-field filtering.

## Primary-source basis
Supabase documents authentication and authorization as separate responsibilities and supports application authorization through custom claims/RBAC. This implementation uses the already-verified Supabase user ID plus a server-only allowlist so role changes take effect without waiting for token refresh.