### PR TITLE
Separate identity, source trust, and content review semantics

### DIFF
--- a/.github/workflows/trust-semantics.yml
+++ b/.github/workflows/trust-semantics.yml
@@ -1,0 +1,60 @@
+name: Trust semantics
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/**"
+      - "backend/app/services/game_service.py"
+      - "backend/tests/test_rule_source_gate.py"
+      - "backend/tests/test_trust_semantics.py"
+      - "frontend/src/components/game/ExternalLinks.jsx"
+      - "supabase/migrations/**"
+      - "docs/TRUST_MODEL.md"
+      - ".github/workflows/trust-semantics.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/models/**"
+      - "backend/app/services/game_service.py"
+      - "backend/tests/test_rule_source_gate.py"
+      - "backend/tests/test_trust_semantics.py"
+      - "frontend/src/components/game/ExternalLinks.jsx"
+      - "supabase/migrations/**"
+      - "docs/TRUST_MODEL.md"
+      - ".github/workflows/trust-semantics.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  trust-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Test trust and source contracts
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_rule_source_gate.py backend/tests/test_trust_semantics.py
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Assert UI ignores legacy is_official trust flag
+        run: |
+          ! grep -q 'game\.is_official' frontend/src/components/game/ExternalLinks.jsx
+          grep -q 'source_trust_status' frontend/src/components/game/ExternalLinks.jsx
+          grep -q 'content_review_status' frontend/src/components/game/ExternalLinks.jsx

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,8 +1,12 @@
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+IdentityStatus = Literal["unverified", "verified"]
+SourceTrustStatus = Literal["unknown", "publisher_primary", "platform_primary", "secondary", "tertiary"]
+ContentReviewStatus = Literal["ai_draft", "human_reviewed", "publisher_reviewed"]
 
 
 def validate_bga_url(value: str | None) -> str | None:
@@ -50,7 +54,7 @@ class GenerationProvenance(BaseSchema):
     prompt_version: str
     golden_version: str
     source_bound: bool
-    content_review_status: str = "ai_draft"
+    content_review_status: ContentReviewStatus = "ai_draft"
 
 
 class StructuredData(BaseSchema):
@@ -89,6 +93,9 @@ class GameDetail(BaseSchema):
     search_count: int | None = 0
     data_version: int = 1
     last_regenerated_at: datetime | None = None
+    identity_status: IdentityStatus = "unverified"
+    source_trust_status: SourceTrustStatus = "unknown"
+    content_review_status: ContentReviewStatus = "ai_draft"
     is_official: bool | None = False
     min_players: int | None = None
     max_players: int | None = None
@@ -131,6 +138,8 @@ class GameUpdate(BaseSchema):
     official_url: str | None = None
     bgg_url: str | None = None
     bga_url: str | None = None
+    source_trust_status: SourceTrustStatus | None = None
+    content_review_status: ContentReviewStatus | None = None
     structured_data: StructuredData | None = None
     rules_content: str | None = None
     infographics: dict[str, str] | None = None

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -32,6 +32,9 @@ _ALLOWED_FIELDS = {
     "view_count",
     "search_count",
     "data_version",
+    "identity_status",
+    "source_trust_status",
+    "content_review_status",
     "is_official",
     "min_players",
     "max_players",
@@ -140,6 +143,10 @@ async def generate_metadata(query: str, context: str | None = None, source_bound
         "content_review_status": "ai_draft",
     }
     data["structured_data"] = structured_data
+    data["identity_status"] = "unverified"
+    data["source_trust_status"] = "unknown"
+    data["content_review_status"] = "ai_draft"
+    data["is_official"] = False
     data["updated_at"] = datetime.now(UTC).isoformat()
     data["amazon_url"] = amazon_search_url(str(data.get("title_ja") or query))
 
@@ -223,6 +230,9 @@ class GameService:
         merged["id"], merged["slug"] = game["id"], slug
         merged["work_id"] = game.get("work_id")
         merged["identity_status"] = game.get("identity_status", "unverified")
+        merged["source_trust_status"] = game.get("source_trust_status", "unknown")
+        merged["content_review_status"] = game.get("content_review_status", "ai_draft")
+        merged["is_official"] = bool(game.get("is_official")) and merged["identity_status"] == "verified"
         merged["data_version"] = int(game.get("data_version", 0) or 0) + 1
         out = await supabase.upsert(merged)
         if not out:
@@ -234,7 +244,7 @@ class GameService:
         if not game:
             raise ValueError(f"Game not found for slug: {slug}")
 
-        protected = {"id", "slug", "work_id", "identity_status"}
+        protected = {"id", "slug", "work_id", "identity_status", "is_official"}
         safe_updates = {key: value for key, value in updates.items() if key not in protected}
         merged = {**game, **safe_updates}
         merged["updated_at"] = datetime.now(UTC).isoformat()

--- a/backend/tests/test_rule_source_gate.py
+++ b/backend/tests/test_rule_source_gate.py
@@ -43,6 +43,10 @@ async def test_unsourced_generation_discards_rule_derived_fields(monkeypatch, ge
     assert result["min_age"] is None
     assert result["bga_url"] is None
     assert result["structured_data"]["keywords"] == []
+    assert result["identity_status"] == "unverified"
+    assert result["source_trust_status"] == "unknown"
+    assert result["content_review_status"] == "ai_draft"
+    assert result["is_official"] is False
     provenance = result["structured_data"]["generation_provenance"]
     assert provenance["source_bound"] is False
     assert provenance["content_review_status"] == "ai_draft"
@@ -50,7 +54,7 @@ async def test_unsourced_generation_discards_rule_derived_fields(monkeypatch, ge
 
 
 @pytest.mark.asyncio
-async def test_source_bound_generation_preserves_supported_rule_fields(monkeypatch, generated_payload):
+async def test_source_bound_generation_preserves_supported_rule_fields_without_promoting_trust(monkeypatch, generated_payload):
     async def fake_generate(*_args, **_kwargs):
         return generated_payload
 
@@ -67,6 +71,9 @@ async def test_source_bound_generation_preserves_supported_rule_fields(monkeypat
     assert result["rules_content"] == "invented rule text"
     assert result["min_players"] == 2
     assert result["bga_url"] == "https://boardgamearena.com/gamepanel?game=example"
+    assert result["source_trust_status"] == "unknown"
+    assert result["content_review_status"] == "ai_draft"
+    assert result["is_official"] is False
     assert result["structured_data"]["generation_provenance"]["source_bound"] is True
 
 

--- a/backend/tests/test_trust_semantics.py
+++ b/backend/tests/test_trust_semantics.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from app.models import GameDetail, GameUpdate
+
+ROOT = Path(__file__).resolve().parents[2]
+MIGRATION = ROOT / "supabase" / "migrations" / "20260814071000_trust_semantics_139.sql"
+
+
+def test_game_detail_defaults_are_conservative():
+    game = GameDetail(id="1", title="Example")
+    assert game.identity_status == "unverified"
+    assert game.source_trust_status == "unknown"
+    assert game.content_review_status == "ai_draft"
+    assert game.is_official is False
+
+
+def test_invalid_source_trust_is_rejected():
+    with pytest.raises(ValidationError):
+        GameDetail(id="1", title="Example", source_trust_status="official")
+
+
+def test_manual_update_does_not_expose_identity_or_legacy_official_flags():
+    fields = GameUpdate.model_fields
+    assert "identity_status" not in fields
+    assert "is_official" not in fields
+    assert "source_trust_status" in fields
+    assert "content_review_status" in fields
+
+
+def test_migration_backfills_only_from_explicit_source_documents():
+    sql = MIGRATION.read_text(encoding="utf-8")
+    assert "structured_data->'source_documents'" in sql
+    assert "publisher_official" in sql
+    assert "platform_official_rules" in sql
+    assert "official_url is not null" not in sql.lower()
+    assert "bga_url is not null" not in sql.lower()
+
+
+def test_migration_blocks_unverified_legacy_official_state():
+    sql = MIGRATION.read_text(encoding="utf-8")
+    assert "set is_official = false" in sql.lower()
+    assert "not coalesce(is_official, false) or identity_status = 'verified'" in sql.lower()

--- a/docs/TRUST_MODEL.md
+++ b/docs/TRUST_MODEL.md
@@ -1,0 +1,40 @@
+# Catalog trust model
+
+`games` records expose three independent trust axes. None may be inferred from another.
+
+## `identity_status`
+
+- `unverified`: title/edition identity has not been resolved against canonical evidence.
+- `verified`: the game/edition identity has been resolved.
+
+Identity verification does not imply that rule content was reviewed.
+
+## `source_trust_status`
+
+- `unknown`: no explicit classified source provenance is recorded.
+- `publisher_primary`: explicit publisher/designer primary source is recorded.
+- `platform_primary`: explicit first-party platform rules/game page is recorded.
+- `secondary`: explicit secondary source classification.
+- `tertiary`: explicit tertiary source classification.
+
+A URL existing in `official_url`, `bga_url`, or `source_url` is not sufficient by itself to promote source trust. Promotion requires explicit provenance classification in `structured_data.source_documents` or an authenticated manual update.
+
+`official_url` is reserved for publisher/product official URLs. Board Game Arena URLs belong in `bga_url`.
+
+## `content_review_status`
+
+- `ai_draft`: AI-generated or otherwise not independently reviewed content.
+- `human_reviewed`: content reviewed against cited evidence by a human/editorial process.
+- `publisher_reviewed`: content confirmed by the publisher/rightsholder.
+
+A primary source does not automatically make generated content human-reviewed.
+
+## Legacy `is_official`
+
+`is_official` remains only for backward compatibility. It is not a UI trust signal. The database rejects `is_official=true` unless `identity_status='verified'`, and new generated records always use `false`.
+
+## Conservative migration policy
+
+Existing records are never promoted from a URL/domain heuristic. The migration promotes `source_trust_status` only when `structured_data.source_documents[*].type` explicitly identifies a publisher or platform primary source. Everything else remains `unknown`. Existing content defaults to `ai_draft` unless an explicit generation provenance review status already exists.
+
+Schema changes are tracked under `supabase/migrations/` and should be applied through the Supabase migration workflow rather than ad-hoc remote edits.

--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -11,6 +11,25 @@ const isValidUrl = (url) => {
   }
 }
 
+const identityLabels = {
+  verified: '確認済み',
+  unverified: '未検証',
+}
+
+const sourceTrustLabels = {
+  publisher_primary: '出版社一次資料',
+  platform_primary: 'プラットフォーム一次資料',
+  secondary: '二次資料',
+  tertiary: '三次資料',
+  unknown: '未確認',
+}
+
+const contentReviewLabels = {
+  publisher_reviewed: '出版社確認済み',
+  human_reviewed: '人手確認済み',
+  ai_draft: 'AI下書き / 未確認',
+}
+
 export const ExternalLinks = ({ game }) => {
   const { affiliate_urls, official_url, bgg_url, amazon_url } = game
   const amazon = affiliate_urls?.amazon || amazon_url
@@ -21,29 +40,44 @@ export const ExternalLinks = ({ game }) => {
     { url: amazon, label: 'Amazon', class: 'amazon' },
     { url: rakuten, label: '楽天で見る', class: 'rakuten' },
     { url: yahoo, label: 'Yahoo!で見る', class: 'yahoo' },
-    { url: official_url, label: '公式サイト', class: 'official' },
+    { url: official_url, label: '出版社・製品公式', class: 'official' },
     { url: bgg_url, label: 'BoardGameGeek', class: 'bgg' },
     { url: game.bga_url, label: 'Board Game Arena', class: 'bga' },
   ].filter((link) => isValidUrl(link.url))
 
-  if (links.length === 0) return null
+  const identity = identityLabels[game.identity_status] || '未検証'
+  const sourceTrust = sourceTrustLabels[game.source_trust_status] || '未確認'
+  const contentReview = contentReviewLabels[game.content_review_status] || 'AI下書き / 未確認'
 
   return (
     <div className="info-section">
-      <h3>Links</h3>
-      <div className="external-links-grid">
-        {links.map((link) => (
-          <a
-            key={`${link.class}:${link.url}`}
-            href={link.url}
-            target="_blank"
-            rel="noopener noreferrer sponsored"
-            className={`link-button ${link.class}`}
-          >
-            {link.label}
-          </a>
-        ))}
+      <div aria-label="情報の信頼状態" style={{ display: 'grid', gap: '8px', marginBottom: links.length ? '14px' : 0 }}>
+        <div><strong>ゲーム同定:</strong> {identity}</div>
+        <div><strong>ルール出典:</strong> {sourceTrust}</div>
+        <div><strong>内容レビュー:</strong> {contentReview}</div>
+        <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)', lineHeight: 1.5 }}>
+          3項目は独立した判定です。URLの存在や旧 is_official 値だけで「公式確認済み」にはしません。
+        </div>
       </div>
+
+      {links.length > 0 && (
+        <>
+          <h3>Links</h3>
+          <div className="external-links-grid">
+            {links.map((link) => (
+              <a
+                key={`${link.class}:${link.url}`}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer sponsored"
+                className={`link-button ${link.class}`}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/supabase/migrations/20260814071000_trust_semantics_139.sql
+++ b/supabase/migrations/20260814071000_trust_semantics_139.sql
@@ -1,0 +1,55 @@
+alter table public.games
+  add column if not exists source_trust_status text not null default 'unknown',
+  add column if not exists content_review_status text not null default 'ai_draft';
+
+update public.games
+set source_trust_status = case
+  when exists (
+    select 1
+    from jsonb_array_elements(coalesce(structured_data->'source_documents', '[]'::jsonb)) as doc
+    where doc->>'type' in ('publisher_official', 'publisher_official_faq')
+  ) then 'publisher_primary'
+  when exists (
+    select 1
+    from jsonb_array_elements(coalesce(structured_data->'source_documents', '[]'::jsonb)) as doc
+    where doc->>'type' in (
+      'platform_official_rules',
+      'platform_official_game',
+      'platform_official_game_page',
+      'platform_rules_summary'
+    )
+  ) then 'platform_primary'
+  else 'unknown'
+end;
+
+update public.games
+set content_review_status = case
+  when structured_data->'generation_provenance'->>'content_review_status' in (
+    'ai_draft',
+    'human_reviewed',
+    'publisher_reviewed'
+  ) then structured_data->'generation_provenance'->>'content_review_status'
+  else 'ai_draft'
+end;
+
+update public.games
+set is_official = false
+where is_official is true
+  and identity_status <> 'verified';
+
+alter table public.games
+  drop constraint if exists games_source_trust_status_check,
+  add constraint games_source_trust_status_check
+    check (source_trust_status in ('unknown', 'publisher_primary', 'platform_primary', 'secondary', 'tertiary')),
+  drop constraint if exists games_content_review_status_check,
+  add constraint games_content_review_status_check
+    check (content_review_status in ('ai_draft', 'human_reviewed', 'publisher_reviewed')),
+  drop constraint if exists games_legacy_official_requires_verified_identity_check,
+  add constraint games_legacy_official_requires_verified_identity_check
+    check (not coalesce(is_official, false) or identity_status = 'verified');
+
+comment on column public.games.source_trust_status is
+  'Trust level of explicit source provenance. Independent from identity_status and legacy is_official.';
+
+comment on column public.games.content_review_status is
+  'Review state of game content. Independent from source_trust_status and identity_status.';


### PR DESCRIPTION
Superseded by canonical PR #146, which already covers #134/#138/#139 and contains the broader compatible rollout/cleanup sequence. This duplicate PR will not be merged.