### PR TITLE
Add canonical Rule Graph v1

### DIFF
--- a/.github/workflows/test-rule-graph.yml
+++ b/.github/workflows/test-rule-graph.yml
@@ -1,0 +1,49 @@
+name: Rule graph contract
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/rule_graph.py"
+      - "backend/app/services/rule_graph.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/010_rule_graph.sql"
+      - "backend/tests/test_rule_graph.py"
+      - "evaluation/rules/rule-graph-v1-fixtures.json"
+      - "docs/RULE_GRAPH_V1.md"
+      - ".github/workflows/test-rule-graph.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/models/rule_graph.py"
+      - "backend/app/services/rule_graph.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/010_rule_graph.sql"
+      - "backend/tests/test_rule_graph.py"
+      - "evaluation/rules/rule-graph-v1-fixtures.json"
+      - "docs/RULE_GRAPH_V1.md"
+      - ".github/workflows/test-rule-graph.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  rule-graph:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile rule graph modules
+        run: uv run python -m compileall -q backend/app/models/rule_graph.py backend/app/services/rule_graph.py backend/app/routers/games.py
+
+      - name: Run rule graph contract tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_rule_graph.py

--- a/backend/app/db/migrations/010_rule_graph.sql
+++ b/backend/app/db/migrations/010_rule_graph.sql
@@ -1,0 +1,96 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.rule_sets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  game_id uuid NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  work_id uuid REFERENCES public.game_works(id) ON DELETE RESTRICT,
+  version integer NOT NULL DEFAULT 1 CHECK (version > 0),
+  schema_version text NOT NULL DEFAULT '1.0',
+  language_code text,
+  edition_label text,
+  source_revision text,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (game_id, version)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS rule_sets_one_active_per_game
+  ON public.rule_sets (game_id)
+  WHERE is_active;
+
+CREATE TABLE IF NOT EXISTS public.rule_nodes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  rule_id text NOT NULL,
+  node_type text NOT NULL CHECK (
+    node_type IN (
+      'phase', 'turn', 'action', 'condition', 'effect', 'setup', 'scoring',
+      'round_end', 'game_end', 'victory', 'exception', 'targeting',
+      'conflict_resolution', 'variant'
+    )
+  ),
+  normalized_statement text NOT NULL CHECK (trim(normalized_statement) <> ''),
+  sequence integer CHECK (sequence IS NULL OR sequence >= 0),
+  phase_rule_id text,
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (
+    verification_status IN ('unknown', 'unverified', 'source_bound', 'verified', 'rejected')
+  ),
+  source_claim_ref text,
+  evidence_ref text,
+  source_url text,
+  source_locator text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_set_id, rule_id)
+);
+
+CREATE TABLE IF NOT EXISTS public.rule_edges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  from_rule_id text NOT NULL,
+  to_rule_id text NOT NULL,
+  relation_type text NOT NULL CHECK (
+    relation_type IN (
+      'contains', 'next', 'condition_effect', 'results_in', 'overrides',
+      'targets', 'variant_of', 'requires'
+    )
+  ),
+  sequence integer CHECK (sequence IS NULL OR sequence >= 0),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT rule_edges_from_rule_fkey
+    FOREIGN KEY (rule_set_id, from_rule_id)
+    REFERENCES public.rule_nodes(rule_set_id, rule_id)
+    ON DELETE CASCADE,
+  CONSTRAINT rule_edges_to_rule_fkey
+    FOREIGN KEY (rule_set_id, to_rule_id)
+    REFERENCES public.rule_nodes(rule_set_id, rule_id)
+    ON DELETE CASCADE,
+  CHECK (from_rule_id <> to_rule_id)
+);
+
+ALTER TABLE public.rule_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_edges ENABLE ROW LEVEL SECURITY;
+
+CREATE INDEX IF NOT EXISTS rule_nodes_type_idx
+  ON public.rule_nodes (rule_set_id, node_type);
+CREATE INDEX IF NOT EXISTS rule_edges_relation_idx
+  ON public.rule_edges (rule_set_id, relation_type);
+
+CREATE OR REPLACE VIEW public.rule_graph_audit_summary AS
+SELECT
+  count(DISTINCT rs.id) AS rule_sets,
+  count(DISTINCT rn.id) AS rule_nodes,
+  count(DISTINCT re.id) AS rule_edges,
+  count(DISTINCT rs.game_id) AS games_with_rule_graph,
+  count(DISTINCT rn.id) FILTER (WHERE rn.verification_status = 'verified') AS verified_nodes,
+  count(DISTINCT rn.id) FILTER (WHERE rn.verification_status IN ('unknown', 'unverified')) AS unresolved_nodes
+FROM public.rule_sets rs
+LEFT JOIN public.rule_nodes rn ON rn.rule_set_id = rs.id
+LEFT JOIN public.rule_edges re ON re.rule_set_id = rs.id
+WHERE rs.is_active;
+
+COMMIT;

--- a/backend/app/models/rule_graph.py
+++ b/backend/app/models/rule_graph.py
@@ -1,0 +1,121 @@
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+RULE_GRAPH_SCHEMA_VERSION = "1.0"
+
+
+class RuleNodeType(StrEnum):
+    PHASE = "phase"
+    TURN = "turn"
+    ACTION = "action"
+    CONDITION = "condition"
+    EFFECT = "effect"
+    SETUP = "setup"
+    SCORING = "scoring"
+    ROUND_END = "round_end"
+    GAME_END = "game_end"
+    VICTORY = "victory"
+    EXCEPTION = "exception"
+    TARGETING = "targeting"
+    CONFLICT_RESOLUTION = "conflict_resolution"
+    VARIANT = "variant"
+
+
+class RuleRelationType(StrEnum):
+    CONTAINS = "contains"
+    NEXT = "next"
+    CONDITION_EFFECT = "condition_effect"
+    RESULTS_IN = "results_in"
+    OVERRIDES = "overrides"
+    TARGETS = "targets"
+    VARIANT_OF = "variant_of"
+    REQUIRES = "requires"
+
+
+class RuleVerificationStatus(StrEnum):
+    UNKNOWN = "unknown"
+    UNVERIFIED = "unverified"
+    SOURCE_BOUND = "source_bound"
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+
+
+class RuleGraphSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class RuleNode(RuleGraphSchema):
+    rule_id: str = Field(pattern=r"^[a-z0-9][a-z0-9._:-]{2,127}$")
+    node_type: RuleNodeType
+    normalized_statement: str = Field(min_length=1)
+    sequence: int | None = Field(default=None, ge=0)
+    phase_rule_id: str | None = None
+    verification_status: RuleVerificationStatus = RuleVerificationStatus.UNKNOWN
+    source_claim_ref: str | None = None
+    evidence_ref: str | None = None
+    source_url: str | None = None
+    source_locator: str | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RuleEdge(RuleGraphSchema):
+    from_rule_id: str
+    to_rule_id: str
+    relation_type: RuleRelationType
+    sequence: int | None = Field(default=None, ge=0)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class RuleGraphReadResponse(RuleGraphSchema):
+    schema_version: Literal["1.0"] = RULE_GRAPH_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    work_id: str | None = None
+    edition_label: str | None = None
+    language_code: str | None = None
+    source_revision: str | None = None
+    rule_set_id: str | None = None
+    nodes: list[RuleNode] = Field(default_factory=list)
+    edges: list[RuleEdge] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_graph(self):
+        if self.status == "not_available":
+            if self.rule_set_id is not None or self.nodes or self.edges:
+                raise ValueError("not_available rule graphs must not contain canonical rules")
+            return self
+
+        if self.rule_set_id is None:
+            raise ValueError("available rule graphs require rule_set_id")
+
+        node_by_id: dict[str, RuleNode] = {}
+        for node in self.nodes:
+            if node.rule_id in node_by_id:
+                raise ValueError(f"duplicate rule_id: {node.rule_id}")
+            node_by_id[node.rule_id] = node
+
+        for edge in self.edges:
+            if edge.from_rule_id not in node_by_id or edge.to_rule_id not in node_by_id:
+                raise ValueError("rule edge references an unknown node")
+            if edge.relation_type == RuleRelationType.CONDITION_EFFECT:
+                if node_by_id[edge.from_rule_id].node_type != RuleNodeType.CONDITION:
+                    raise ValueError("condition_effect must originate from a condition node")
+                if node_by_id[edge.to_rule_id].node_type != RuleNodeType.EFFECT:
+                    raise ValueError("condition_effect must point to an effect node")
+
+        return self
+
+    def select_types(self, rule_types: set[RuleNodeType]) -> "RuleGraphReadResponse":
+        if not rule_types or self.status == "not_available":
+            return self
+
+        selected = [node for node in self.nodes if node.node_type in rule_types]
+        selected_ids = {node.rule_id for node in selected}
+        selected_edges = [
+            edge for edge in self.edges
+            if edge.from_rule_id in selected_ids and edge.to_rule_id in selected_ids
+        ]
+        return self.model_copy(update={"nodes": selected, "edges": selected_edges})

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.rate_limiter import RateLimiter
 from app.models import GameDetail, GameListResponse, GameUpdate, SearchRequest
+from app.models.rule_graph import RuleGraphReadResponse, RuleNodeType
 from app.routers.auth import require_catalog_editor
 from app.services import catalog_access
 from app.services.game_service import GameService
+from app.services.rule_graph import RuleGraphService
 
 router = APIRouter()
 
@@ -15,6 +17,10 @@ gen_limiter = RateLimiter.get_limiter("generation", max_requests=10, window_seco
 
 def get_game_service():
     return GameService()
+
+
+def get_rule_graph_service():
+    return RuleGraphService()
 
 
 @router.get("/search", response_model=list[GameDetail])
@@ -56,6 +62,18 @@ async def list_recent_games(limit: int = 100, offset: int = 0, service: GameServ
         "limit": limit,
         "offset": offset,
     }
+
+
+@router.get("/games/{slug}/rule-graph", response_model=RuleGraphReadResponse)
+async def get_game_rule_graph(
+    slug: str,
+    types: list[RuleNodeType] | None = Query(default=None),
+    service: RuleGraphService = Depends(get_rule_graph_service),
+):
+    graph = await service.get_by_slug(slug, rule_types=types)
+    if graph is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return graph
 
 
 @router.get("/games/{slug}", response_model=GameDetail)

--- a/backend/app/services/rule_graph.py
+++ b/backend/app/services/rule_graph.py
@@ -1,0 +1,118 @@
+import logging
+from collections.abc import Iterable
+
+import anyio
+
+from app.core import supabase
+from app.models.rule_graph import (
+    RuleEdge,
+    RuleGraphReadResponse,
+    RuleNode,
+    RuleNodeType,
+)
+
+logger = logging.getLogger("services.rule_graph")
+
+
+class RuleGraphService:
+    async def get_by_slug(
+        self,
+        slug: str,
+        rule_types: Iterable[RuleNodeType] | None = None,
+    ) -> RuleGraphReadResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+
+        base = {
+            "game_id": str(game["id"]),
+            "slug": str(game["slug"]),
+            "work_id": str(game["work_id"]) if game.get("work_id") else None,
+            "edition_label": game.get("edition_label"),
+            "language_code": game.get("language_code"),
+            "source_revision": game.get("source_revision"),
+        }
+
+        if supabase.is_local():
+            return RuleGraphReadResponse(status="not_available", **base)
+
+        try:
+            graph = await anyio.to_thread.run_sync(self._load_graph, game, base)
+        except Exception as exc:
+            # Deploying application code before the database migration must fail closed.
+            logger.warning("Rule graph unavailable for %s: %s", slug, exc)
+            graph = RuleGraphReadResponse(status="not_available", **base)
+
+        if rule_types:
+            return graph.select_types(set(rule_types))
+        return graph
+
+    @staticmethod
+    def _load_graph(game: dict, base: dict) -> RuleGraphReadResponse:
+        client = supabase._get_client()
+        rule_sets = (
+            client.table("rule_sets")
+            .select("*")
+            .eq("game_id", game["id"])
+            .eq("is_active", True)
+            .order("version", desc=True)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rule_sets:
+            return RuleGraphReadResponse(status="not_available", **base)
+
+        rule_set = rule_sets[0]
+        node_rows = (
+            client.table("rule_nodes")
+            .select("*")
+            .eq("rule_set_id", rule_set["id"])
+            .order("sequence")
+            .execute()
+            .data
+        )
+        edge_rows = (
+            client.table("rule_edges")
+            .select("*")
+            .eq("rule_set_id", rule_set["id"])
+            .order("sequence")
+            .execute()
+            .data
+        )
+
+        nodes = [
+            RuleNode(
+                rule_id=row["rule_id"],
+                node_type=row["node_type"],
+                normalized_statement=row["normalized_statement"],
+                sequence=row.get("sequence"),
+                phase_rule_id=row.get("phase_rule_id"),
+                verification_status=row.get("verification_status", "unknown"),
+                source_claim_ref=row.get("source_claim_ref"),
+                evidence_ref=row.get("evidence_ref"),
+                source_url=row.get("source_url"),
+                source_locator=row.get("source_locator"),
+                metadata=row.get("metadata") or {},
+            )
+            for row in node_rows
+        ]
+        edges = [
+            RuleEdge(
+                from_rule_id=row["from_rule_id"],
+                to_rule_id=row["to_rule_id"],
+                relation_type=row["relation_type"],
+                sequence=row.get("sequence"),
+                metadata=row.get("metadata") or {},
+            )
+            for row in edge_rows
+        ]
+
+        return RuleGraphReadResponse(
+            status="available",
+            rule_set_id=str(rule_set["id"]),
+            source_revision=rule_set.get("source_revision") or base.get("source_revision"),
+            nodes=nodes,
+            edges=edges,
+            **{key: value for key, value in base.items() if key != "source_revision"},
+        )

--- a/backend/tests/test_rule_graph.py
+++ b/backend/tests/test_rule_graph.py
@@ -1,0 +1,170 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.models.rule_graph import (
+    RuleEdge,
+    RuleGraphReadResponse,
+    RuleNode,
+    RuleNodeType,
+)
+from app.routers import games
+
+
+def _node(rule_id: str, node_type: RuleNodeType, statement: str) -> RuleNode:
+    return RuleNode(
+        rule_id=rule_id,
+        node_type=node_type,
+        normalized_statement=statement,
+        verification_status="unverified",
+    )
+
+
+def test_condition_effect_relation_is_explicit_and_validated():
+    graph = RuleGraphReadResponse(
+        status="available",
+        game_id="game-1",
+        slug="example",
+        rule_set_id="set-1",
+        nodes=[
+            _node("condition.duplicate", RuleNodeType.CONDITION, "A duplicate value is present."),
+            _node("effect.bust", RuleNodeType.EFFECT, "Resolve the bust effect."),
+        ],
+        edges=[
+            RuleEdge(
+                from_rule_id="condition.duplicate",
+                to_rule_id="effect.bust",
+                relation_type="condition_effect",
+            )
+        ],
+    )
+    assert graph.edges[0].relation_type == "condition_effect"
+
+    with pytest.raises(ValidationError):
+        RuleGraphReadResponse(
+            status="available",
+            game_id="game-1",
+            slug="example",
+            rule_set_id="set-1",
+            nodes=[
+                _node("action.draw", RuleNodeType.ACTION, "Draw."),
+                _node("effect.bust", RuleNodeType.EFFECT, "Bust."),
+            ],
+            edges=[
+                RuleEdge(
+                    from_rule_id="action.draw",
+                    to_rule_id="effect.bust",
+                    relation_type="condition_effect",
+                )
+            ],
+        )
+
+
+def test_unknown_graph_fails_closed_without_invented_nodes():
+    graph = RuleGraphReadResponse(
+        status="not_available",
+        game_id="game-1",
+        slug="unknown",
+    )
+    assert graph.rule_set_id is None
+    assert graph.nodes == []
+    assert graph.edges == []
+
+
+def test_rule_type_projection_returns_only_requested_canonical_nodes():
+    graph = RuleGraphReadResponse(
+        status="available",
+        game_id="game-1",
+        slug="example",
+        rule_set_id="set-1",
+        nodes=[
+            _node("setup.start", RuleNodeType.SETUP, "Prepare the game."),
+            _node("score.points", RuleNodeType.SCORING, "Score points."),
+            _node("end.game", RuleNodeType.GAME_END, "End the game."),
+            _node("exception.tie", RuleNodeType.EXCEPTION, "Resolve a tie."),
+        ],
+    )
+
+    projected = graph.select_types({RuleNodeType.SCORING, RuleNodeType.EXCEPTION})
+    assert [node.rule_id for node in projected.nodes] == ["score.points", "exception.tie"]
+
+
+class FakeRuleGraphService:
+    async def get_by_slug(self, slug: str, rule_types=None):
+        if slug == "missing":
+            return None
+        graph = RuleGraphReadResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            rule_set_id="set-1",
+            nodes=[
+                _node("score.points", RuleNodeType.SCORING, "Score points."),
+                _node("end.game", RuleNodeType.GAME_END, "End the game."),
+                _node("exception.tie", RuleNodeType.EXCEPTION, "Resolve a tie."),
+            ],
+        )
+        return graph.select_types(set(rule_types or []))
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(games.router, prefix="/api")
+    app.dependency_overrides[games.get_rule_graph_service] = lambda: FakeRuleGraphService()
+    return app
+
+
+def test_rule_graph_api_can_query_end_scoring_and_exception_types():
+    client = TestClient(_app())
+    response = client.get(
+        "/api/games/example/rule-graph",
+        params=[
+            ("types", "game_end"),
+            ("types", "scoring"),
+            ("types", "exception"),
+        ],
+    )
+
+    assert response.status_code == 200
+    assert {node["node_type"] for node in response.json()["nodes"]} == {
+        "game_end",
+        "scoring",
+        "exception",
+    }
+
+
+def test_rule_graph_api_returns_404_for_unknown_game():
+    client = TestClient(_app())
+    response = client.get("/api/games/missing/rule-graph")
+    assert response.status_code == 404
+
+
+def test_versioned_rule_graph_fixtures_validate_all_required_structures():
+    fixture_path = Path(__file__).parents[2] / "evaluation" / "rules" / "rule-graph-v1-fixtures.json"
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    assert payload["version"] == "rule-graph-fixtures-v1"
+    assert len(payload["cases"]) >= 5
+
+    names = set()
+    for case in payload["cases"]:
+        graph = RuleGraphReadResponse.model_validate(case["graph"])
+        names.add(case["name"])
+        actual_types = {node.node_type.value for node in graph.nodes}
+        for expected in case.get("expected_node_types", []):
+            assert expected in actual_types
+        actual_relations = {edge.relation_type.value for edge in graph.edges}
+        for expected in case.get("expected_relations", []):
+            assert expected in actual_relations
+
+    assert {
+        "ordered-turn-flow",
+        "round-end-vs-game-end",
+        "flip7-threshold-continues-round-structural",
+        "exception-overrides-base",
+        "variant-delta",
+    }.issubset(names)

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@
 - **[`PROJECT_MASTER_GUIDE.md`](./PROJECT_MASTER_GUIDE.md)**
     - プロジェクトの「Single Source of Truth（信頼できる唯一の情報源）」です。要件、アーキテクチャ、データモデル、開発フロー、コーディング規約などが網羅されています。開発者が最初に読むべきドキュメントです。
 
+- **[`RULE_GRAPH_V1.md`](./RULE_GRAPH_V1.md)**
+    - Ontology v2 の canonical Rule Graph v1。RuleSet / RuleNode / RuleEdge、provenance境界、API、legacy migration mappingを定義します。
+
 - **[`diagrams.md`](./diagrams.md)**
     - システムアーキテクチャ、シーケンス図、ER図などの視覚的な資料が含まれています。
 
@@ -17,4 +20,4 @@
     - 画像生成に関する調査や設計メモです。
 
 ## ドキュメントの更新について
-コードやアーキテクチャに変更があった場合、必ず `PROJECT_MASTER_GUIDE.md` を更新し、実態との乖離を防いでください。
+コードやアーキテクチャに変更があった場合、必ず `PROJECT_MASTER_GUIDE.md` を更新し、実態との乖離を防いでください。Ontology v2 の詳細契約は専用versioned documentを正準として参照し、Master Guideからリンクします。

--- a/docs/RULE_GRAPH_V1.md
+++ b/docs/RULE_GRAPH_V1.md
@@ -1,0 +1,102 @@
+# Rule Graph v1
+
+Status: canonical contract for Issue #149  
+Schema version: `1.0`
+
+## Purpose
+
+`rules_content`, `setup_summary`, `gameplay_summary`, and `end_game_summary` remain presentation/legacy fields. Canonical rules are represented as nodes and typed relations so the same verified rule can power detailed rules, Quick Rules, UGUG, diagrams, and rule-specific API queries.
+
+The graph is fail-closed: missing evidence does not create a rule node. `unknown` and `unverified` are valid states and must not be promoted by inference.
+
+## Identity and provenance boundary
+
+A rule graph belongs to exactly one game edition (`games.id`) and may link to its canonical work (`game_works.id`). `language_code`, `edition_label`, and `source_revision` are copied into the active `rule_set` so edition/language provenance cannot be lost during projection.
+
+Rule nodes may carry `source_claim_ref`, `evidence_ref`, `source_url`, and `source_locator`. These references do not replace the provenance/trust contracts in #71 and #139; they are foreign identifiers that allow those systems to be joined later.
+
+## Node types
+
+| Type | Meaning |
+| --- | --- |
+| `setup` | Initial preparation rule |
+| `phase` | Named structural phase |
+| `turn` | Turn/activation structure when the game has one |
+| `action` | Player-permitted action |
+| `condition` | Predicate that gates a rule |
+| `effect` | State transition/result |
+| `scoring` | Score/progress rule |
+| `round_end` | Round/hand/chapter end |
+| `game_end` | Game termination |
+| `victory` | Winner/success determination |
+| `exception` | Rule that overrides or narrows a base rule |
+| `targeting` | Who/what may be selected |
+| `conflict_resolution` | Tie/priority/simultaneous conflict resolution |
+| `variant` | Optional/alternate rule set delta |
+
+## Edge types
+
+- `contains`: structural membership such as phase -> action.
+- `next`: canonical order.
+- `condition_effect`: condition -> effect. API validation requires the source node to be `condition` and destination to be `effect`.
+- `results_in`: generic causal/state transition relation.
+- `overrides`: exception -> base rule.
+- `targets`: targeting rule -> target/action/effect.
+- `variant_of`: variant -> base rule changed by the variant.
+- `requires`: dependency/precondition relation.
+
+## PostgreSQL layout
+
+```mermaid
+erDiagram
+    GAMES ||--o{ RULE_SETS : edition
+    GAME_WORKS ||--o{ RULE_SETS : work
+    RULE_SETS ||--o{ RULE_NODES : contains
+    RULE_SETS ||--o{ RULE_EDGES : contains
+    RULE_NODES ||--o{ RULE_EDGES : from
+    RULE_NODES ||--o{ RULE_EDGES : to
+```
+
+## API
+
+`GET /api/games/{slug}/rule-graph`
+
+Optional repeated query parameter:
+
+`?types=game_end&types=scoring&types=exception`
+
+Response status is:
+
+- `available`: an active canonical rule set exists.
+- `not_available`: the game exists but no canonical rule graph is available, the DB migration is not yet present, or the local fallback DB is in use.
+
+`not_available` MUST contain no rule nodes or edges. It is not an invitation to synthesize them.
+
+## Legacy migration map
+
+| Legacy field | Rule Graph destination |
+| --- | --- |
+| `setup_summary` | one or more `setup` nodes |
+| `gameplay_summary` | `phase` / `turn` / `action` / `condition` / `effect` nodes and ordering edges |
+| `end_game_summary` | `game_end` and, when separately evidenced, `victory` nodes |
+| scoring paragraphs in `rules_content` | `scoring` nodes |
+| FAQ/known exceptions | `exception` + `overrides` |
+| player/card target restrictions | `targeting` + `targets` |
+| optional modes | `variant` + `variant_of` |
+
+Migration is evidence-gated. Legacy prose without edition/language/source support stays unresolved and is not converted into a verified node.
+
+## Projection rules
+
+Quick Rules and later UGUG/diagram projections consume only graph nodes. Projection code may shorten wording, but it must preserve `rule_id` traceability and may not add factual rules absent from the graph.
+
+## Validation
+
+The Pydantic contract rejects duplicate `rule_id` values, edges referencing missing nodes, malformed `condition_effect` edges, `not_available` responses containing canonical nodes, and unknown node/relation enum values.
+
+The SQL migration adds type checks, endpoint foreign keys, one active rule set per game, and an audit view.
+
+## Primary references
+
+- W3C PROV-O: https://www.w3.org/TR/prov-o/
+- W3C SHACL Recommendation: https://www.w3.org/TR/shacl/

--- a/evaluation/rules/rule-graph-v1-fixtures.json
+++ b/evaluation/rules/rule-graph-v1-fixtures.json
@@ -1,0 +1,95 @@
+{
+  "version": "rule-graph-fixtures-v1",
+  "note": "Structural fixtures only. Statements are test data, not production rule evidence.",
+  "cases": [
+    {
+      "name": "ordered-turn-flow",
+      "graph": {
+        "status": "available",
+        "game_id": "fixture-turn",
+        "slug": "fixture-turn",
+        "rule_set_id": "set-turn",
+        "nodes": [
+          {"rule_id": "turn.start", "node_type": "turn", "normalized_statement": "A turn begins.", "verification_status": "unverified", "sequence": 0},
+          {"rule_id": "action.choose", "node_type": "action", "normalized_statement": "Choose one permitted action.", "verification_status": "unverified", "sequence": 1},
+          {"rule_id": "effect.resolve", "node_type": "effect", "normalized_statement": "Resolve the chosen action.", "verification_status": "unverified", "sequence": 2}
+        ],
+        "edges": [
+          {"from_rule_id": "turn.start", "to_rule_id": "action.choose", "relation_type": "next", "sequence": 0},
+          {"from_rule_id": "action.choose", "to_rule_id": "effect.resolve", "relation_type": "results_in", "sequence": 1}
+        ]
+      },
+      "expected_node_types": ["turn", "action", "effect"]
+    },
+    {
+      "name": "round-end-vs-game-end",
+      "graph": {
+        "status": "available",
+        "game_id": "fixture-end",
+        "slug": "fixture-end",
+        "rule_set_id": "set-end",
+        "nodes": [
+          {"rule_id": "end.round", "node_type": "round_end", "normalized_statement": "The current round ends.", "verification_status": "unverified"},
+          {"rule_id": "end.game", "node_type": "game_end", "normalized_statement": "The game ends.", "verification_status": "unverified"},
+          {"rule_id": "win.determine", "node_type": "victory", "normalized_statement": "Determine the winner.", "verification_status": "unverified"}
+        ],
+        "edges": [{"from_rule_id": "end.game", "to_rule_id": "win.determine", "relation_type": "next"}]
+      },
+      "expected_node_types": ["round_end", "game_end", "victory"]
+    },
+    {
+      "name": "flip7-threshold-continues-round-structural",
+      "graph": {
+        "status": "available",
+        "game_id": "fixture-flip7",
+        "slug": "flip-7-structural-fixture",
+        "rule_set_id": "set-flip7",
+        "nodes": [
+          {"rule_id": "condition.score-threshold", "node_type": "condition", "normalized_statement": "A score threshold has been reached.", "verification_status": "unverified"},
+          {"rule_id": "effect.mark-final-round", "node_type": "effect", "normalized_statement": "Mark the current round as the final round.", "verification_status": "unverified"},
+          {"rule_id": "condition.duplicate-number", "node_type": "condition", "normalized_statement": "A duplicate number is drawn.", "verification_status": "unverified"},
+          {"rule_id": "effect.bust", "node_type": "effect", "normalized_statement": "Resolve the bust state.", "verification_status": "unverified"},
+          {"rule_id": "target.stayed-player", "node_type": "targeting", "normalized_statement": "A stayed player may remain a legal target when the rule permits it.", "verification_status": "unverified"},
+          {"rule_id": "variant.brutal", "node_type": "variant", "normalized_statement": "An optional variant changes selected scoring or interaction rules.", "verification_status": "unverified"},
+          {"rule_id": "end.game", "node_type": "game_end", "normalized_statement": "The game ends after the final-round condition is resolved.", "verification_status": "unverified"}
+        ],
+        "edges": [
+          {"from_rule_id": "condition.score-threshold", "to_rule_id": "effect.mark-final-round", "relation_type": "condition_effect"},
+          {"from_rule_id": "condition.duplicate-number", "to_rule_id": "effect.bust", "relation_type": "condition_effect"},
+          {"from_rule_id": "effect.mark-final-round", "to_rule_id": "end.game", "relation_type": "results_in"}
+        ]
+      },
+      "expected_node_types": ["condition", "effect", "targeting", "variant", "game_end"]
+    },
+    {
+      "name": "exception-overrides-base",
+      "graph": {
+        "status": "available",
+        "game_id": "fixture-exception",
+        "slug": "fixture-exception",
+        "rule_set_id": "set-exception",
+        "nodes": [
+          {"rule_id": "action.base", "node_type": "action", "normalized_statement": "Apply the base action rule.", "verification_status": "unverified"},
+          {"rule_id": "exception.special", "node_type": "exception", "normalized_statement": "Apply the special exception instead.", "verification_status": "unverified"}
+        ],
+        "edges": [{"from_rule_id": "exception.special", "to_rule_id": "action.base", "relation_type": "overrides"}]
+      },
+      "expected_relations": ["overrides"]
+    },
+    {
+      "name": "variant-delta",
+      "graph": {
+        "status": "available",
+        "game_id": "fixture-variant",
+        "slug": "fixture-variant",
+        "rule_set_id": "set-variant",
+        "nodes": [
+          {"rule_id": "score.base", "node_type": "scoring", "normalized_statement": "Use base scoring.", "verification_status": "unverified"},
+          {"rule_id": "variant.optional", "node_type": "variant", "normalized_statement": "Use the optional scoring change.", "verification_status": "unverified"}
+        ],
+        "edges": [{"from_rule_id": "variant.optional", "to_rule_id": "score.base", "relation_type": "variant_of"}]
+      },
+      "expected_relations": ["variant_of"]
+    }
+  ]
+}


### PR DESCRIPTION
Closes #149

## What changed
- add canonical `rule_sets / rule_nodes / rule_edges` PostgreSQL contract
- add typed Pydantic Rule Graph v1 with fail-closed validation
- add `GET /api/games/{slug}/rule-graph?types=...`
- distinguish setup/turn/scoring/round end/game end/victory/exception/targeting/variant
- model explicit Condition -> Effect and override/variant relations
- preserve edition/language/source revision and provenance references
- add versioned structural fixtures including Flip 7-shaped threshold/bust/targeting/variant coverage
- add dedicated Rule Graph CI
- document legacy summary -> Rule Graph migration mapping and Quick Rules projection contract

## Safety
- no legacy prose is auto-promoted to verified Rule nodes
- missing migration/data returns `status=not_available` with zero nodes/edges
- fixtures are explicitly structural test data, not production evidence

## Verification
CI must compile the new modules and run `backend/tests/test_rule_graph.py` before merge.