### PR TITLE
Restore reliable Vercel production deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,5 +98,5 @@ jobs:
         run: python scripts/check_google_oauth.py .vercel/.env.production.local
       - name: Build Production with Vercel
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy Production prebuilt output
-        run: vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Production to Vercel
+        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem
After #159 merged, the production workflow successfully completed `vercel build --prod` but failed before creating any Vercel deployment at `vercel deploy --prebuilt --prod`.

## Fix
- keep `vercel build --prod` as an explicit production build validation gate
- restore the previously proven production deployment command: `vercel deploy --prod --yes`
- keep Vercel CLI pinned at 59.0.0 and preserve the Supabase / Google OAuth environment checks

## Evidence
- Current failed run: production build succeeded; only the prebuilt deploy step failed.
- The prior production workflow used `vercel deploy --prod --yes` and produced READY production deployments.
- Vercel's current official CLI documentation documents `vercel deploy --prod` for production deployments and `vercel deploy --prebuilt` separately for prebuilt artifacts.

This is intentionally a one-line deployment-path correction plus step label change.