### PR TITLE
Codify zero-waste curated game fast path

### DIFF
--- a/docs/CURATED_GAME_FAST_PATH.md
+++ b/docs/CURATED_GAME_FAST_PATH.md
@@ -1,0 +1,58 @@
+# Curated Game Fast Path
+
+Status: canonical operator workflow for source-grounded game additions.
+
+## Goal
+
+Add one verified game to ボドゲのミカタ with the smallest safe change set and no unrelated repair work.
+
+## Fast path
+
+1. **Lock one current primary source.** Record the official URL and the source/revision date. Do not keep searching after the primary source is sufficient unless a contradiction appears.
+2. **Check canonical identity once.** Search the production catalog for the work/slug before any write. If the game already exists, update that record instead of creating a duplicate.
+3. **Prepare only two content changes.** Add/update the curated guide entry and one focused regression assertion for the game-specific facts that are easiest to regress.
+4. **Run targeted validation first.** Build/lint only what the changed paths require and run the focused rule-guide/source-quality gate. Do not run repository-wide diagnostics before a targeted gate fails.
+5. **Perform the idempotent data upsert once.** Use the existing canonical import path. Re-read the resulting record once; do not repeatedly poll it.
+6. **Use one branch and one PR.** Do not create replacement branches/PRs for the same game unless the canonical branch is unusable.
+7. **Retry a flaky CI job at most once.** Re-run the failed job/run directly. If it fails again, preserve the canonical work line and report the blocker.
+8. **Separate unrelated infrastructure failures.** If game-specific build/rule/source gates pass but deployment infrastructure fails, open/link a separate infrastructure Issue. Do not repair deployment internals inside the game-add task.
+9. **Verify production once.** Check `/games/{slug}` for HTTP success and the expected title/source-bound content. Stop after the fixed point is established.
+
+## Minimal completion evidence
+
+A game-add task is complete when all of these are true:
+
+- the production catalog contains exactly one canonical game identity for the intended work/edition;
+- the current primary source URL/revision is stored;
+- the curated guide has focused regression coverage;
+- the game-specific CI gates pass;
+- the production game URL returns the expected game content.
+
+A general deployment workflow failure does not invalidate an already-live database-backed game page. It becomes a separate infrastructure blocker unless the requested game content itself is unavailable.
+
+## Scope guard
+
+During a game-add task, do not:
+
+- redesign unrelated schemas or UI;
+- repair generic deployment infrastructure;
+- perform repeated repository-wide searches after canonical paths are known;
+- create multiple speculative PRs;
+- rerun full CI suites to diagnose a single targeted failure before reading the failed job;
+- continue source research after the official source is locked without contradictory evidence.
+
+## Success retrospective
+
+After a successful addition, spend one short pass on workflow improvement:
+
+1. identify tool calls, searches, retries, branches, or checks that did not change the outcome;
+2. remove them from this fast path;
+3. automate only repeated deterministic steps;
+4. keep evidence/identity/source gates fail-closed;
+5. stop when no reusable improvement remains.
+
+Do not turn the retrospective into a second implementation project. Reusable improvements belong in a separate Issue/PR unless they are a trivial documentation/task wrapper change.
+
+## Current automation target
+
+Issue #163 tracks the next step: structured per-game input plus a one-command evidence-gated materialization/validation workflow.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,9 @@
 - **[`PROJECT_MASTER_GUIDE.md`](./PROJECT_MASTER_GUIDE.md)**
     - プロジェクトの「Single Source of Truth（信頼できる唯一の情報源）」です。要件、アーキテクチャ、データモデル、開発フロー、コーディング規約などが網羅されています。開発者が最初に読むべきドキュメントです。
 
+- **[`CURATED_GAME_FAST_PATH.md`](./CURATED_GAME_FAST_PATH.md)**
+    - 一次情報に基づくゲーム追加の最短運用契約です。1ゲーム=1branch/1PR、対象CI優先、無関係なインフラ障害の分離、成功後の短い効率化レビューを定義します。
+
 - **[`RULE_GRAPH_V1.md`](./RULE_GRAPH_V1.md)**
     - Ontology v2 の canonical Rule Graph v1。RuleSet / RuleNode / RuleEdge、provenance境界、API、legacy migration mappingを定義します。
 


### PR DESCRIPTION
Closes part of #163.

## What changed
- add `docs/CURATED_GAME_FAST_PATH.md` as the canonical minimal operator workflow for source-grounded game additions
- explicitly separate game-add work from unrelated deployment-infrastructure repair
- define one branch/one PR, one retry maximum for flakes, targeted validation first, and one production verification fixed point
- add a mandatory short success retrospective that removes non-value-added searches/retries/checks without turning into a second implementation project
- link the fast path from `docs/README.md`

## Why
The Skull King addition proved that the actual content path is small, while unrelated Vercel deployment debugging can dominate the work if it is not scope-guarded. This PR freezes the successful path before implementing the one-command automation tracked in #163.

## References
- GitHub Actions concurrency: https://docs.github.com/en/actions/concepts/workflows-and-actions/concurrency
- GitHub Actions workflow rerun API: https://docs.github.com/en/rest/actions/workflow-runs
- Vercel production deployment CLI: https://vercel.com/docs/cli/deploy
