### PR TITLE
Add Concept Taxonomy v1 and linked glossary views

### DIFF
--- a/.github/workflows/test-concept-taxonomy.yml
+++ b/.github/workflows/test-concept-taxonomy.yml
@@ -1,0 +1,64 @@
+name: Concept taxonomy contract
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/concept_taxonomy.py"
+      - "backend/app/services/concept_taxonomy.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/011_concept_taxonomy.sql"
+      - "backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql"
+      - "backend/tests/test_concept_taxonomy.py"
+      - "evaluation/taxonomy/concept-taxonomy-v1-fixtures.json"
+      - "docs/CONCEPT_TAXONOMY_V1.md"
+      - "frontend/src/components/game/ConceptGlossary.jsx"
+      - "frontend/src/pages/GamePage.jsx"
+      - ".github/workflows/test-concept-taxonomy.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/app/models/concept_taxonomy.py"
+      - "backend/app/services/concept_taxonomy.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/011_concept_taxonomy.sql"
+      - "backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql"
+      - "backend/tests/test_concept_taxonomy.py"
+      - "evaluation/taxonomy/concept-taxonomy-v1-fixtures.json"
+      - "docs/CONCEPT_TAXONOMY_V1.md"
+      - "frontend/src/components/game/ConceptGlossary.jsx"
+      - "frontend/src/pages/GamePage.jsx"
+      - ".github/workflows/test-concept-taxonomy.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  taxonomy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+      - name: Compile taxonomy modules
+        run: uv run python -m compileall -q backend/app/models/concept_taxonomy.py backend/app/services/concept_taxonomy.py backend/app/routers/games.py
+      - name: Run concept taxonomy contract tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_concept_taxonomy.py
+      - name: Gate audit view security context
+        run: |
+          grep -Fq "ALTER VIEW IF EXISTS public.rule_graph_audit_summary SET (security_invoker = true);" backend/app/db/migrations/011_concept_taxonomy.sql
+          grep -Fq "WITH (security_invoker = true) AS" backend/app/db/migrations/011_concept_taxonomy.sql
+      - name: Gate source-bound first linked glossary seed
+        run: |
+          grep -Fq "rule-pattern.trick" backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+          grep -Fq "player-action.bid" backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+          grep -Fq "rule-pattern.trump-suit" backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+          grep -Fq "component.special-card" backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+          grep -Fq "https://www.grandpabecksgames.com/pages/skull-king" backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+          grep -Fq "'source_bound'" backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+      - name: Build frontend linked glossary projection
+        run: npm --prefix frontend ci && npm --prefix frontend run build

--- a/backend/app/db/migrations/011_concept_taxonomy.sql
+++ b/backend/app/db/migrations/011_concept_taxonomy.sql
@@ -1,0 +1,132 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.concepts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  concept_id text NOT NULL UNIQUE CHECK (concept_id ~ '^[a-z0-9][a-z0-9._:-]{2,127}$'),
+  concept_type text NOT NULL CHECK (
+    concept_type IN (
+      'mechanic', 'component', 'resource', 'state', 'player_action',
+      'information_structure', 'interaction_pattern', 'rule_pattern'
+    )
+  ),
+  lifecycle_status text NOT NULL DEFAULT 'active' CHECK (
+    lifecycle_status IN ('active', 'deprecated', 'merged')
+  ),
+  replaced_by_concept_id text REFERENCES public.concepts(concept_id) ON DELETE RESTRICT,
+  definition text,
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (
+    verification_status IN ('unknown', 'source_bound', 'verified')
+  ),
+  source_url text,
+  source_locator text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (replaced_by_concept_id IS NULL OR replaced_by_concept_id <> concept_id),
+  CHECK (
+    (lifecycle_status = 'merged' AND replaced_by_concept_id IS NOT NULL)
+    OR (lifecycle_status <> 'merged' AND replaced_by_concept_id IS NULL)
+  )
+);
+
+CREATE TABLE IF NOT EXISTS public.concept_labels (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE CASCADE,
+  language_code text NOT NULL CHECK (length(trim(language_code)) >= 2),
+  label_type text NOT NULL CHECK (label_type IN ('pref', 'alt')),
+  label text NOT NULL CHECK (trim(label) <> ''),
+  normalized_label text NOT NULL CHECK (trim(normalized_label) <> ''),
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS concept_labels_unique_normalized_per_language
+  ON public.concept_labels (concept_id, lower(language_code), normalized_label);
+CREATE UNIQUE INDEX IF NOT EXISTS concept_labels_one_pref_per_language
+  ON public.concept_labels (concept_id, lower(language_code))
+  WHERE label_type = 'pref';
+CREATE INDEX IF NOT EXISTS concept_labels_lookup_idx
+  ON public.concept_labels (lower(language_code), normalized_label);
+
+CREATE TABLE IF NOT EXISTS public.concept_relations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  from_concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE CASCADE,
+  to_concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE CASCADE,
+  relation_type text NOT NULL CHECK (
+    relation_type IN ('broader', 'narrower', 'related', 'replaced_by')
+  ),
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (
+    verification_status IN ('unknown', 'source_bound', 'verified')
+  ),
+  source_url text,
+  source_locator text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (from_concept_id, to_concept_id, relation_type),
+  CHECK (from_concept_id <> to_concept_id)
+);
+
+CREATE INDEX IF NOT EXISTS concept_relations_from_idx
+  ON public.concept_relations (from_concept_id, relation_type);
+CREATE INDEX IF NOT EXISTS concept_relations_to_idx
+  ON public.concept_relations (to_concept_id, relation_type);
+
+CREATE TABLE IF NOT EXISTS public.game_concepts (
+  game_id uuid NOT NULL REFERENCES public.games(id) ON DELETE CASCADE,
+  concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE RESTRICT,
+  usage_role text NOT NULL CHECK (usage_role IN ('core', 'supporting', 'glossary')),
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (
+    verification_status IN ('unknown', 'source_bound', 'verified')
+  ),
+  source_url text,
+  source_locator text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (game_id, concept_id, usage_role)
+);
+
+CREATE TABLE IF NOT EXISTS public.rule_node_concepts (
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  rule_id text NOT NULL,
+  concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE RESTRICT,
+  reference_kind text NOT NULL CHECK (
+    reference_kind IN ('mentions', 'defines', 'requires', 'modifies')
+  ),
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (
+    verification_status IN ('unknown', 'source_bound', 'verified')
+  ),
+  source_url text,
+  source_locator text,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (rule_set_id, rule_id, concept_id, reference_kind),
+  CONSTRAINT rule_node_concepts_rule_fkey
+    FOREIGN KEY (rule_set_id, rule_id)
+    REFERENCES public.rule_nodes(rule_set_id, rule_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS rule_node_concepts_concept_idx
+  ON public.rule_node_concepts (concept_id, rule_set_id);
+
+ALTER TABLE public.concepts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.concept_labels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.concept_relations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.game_concepts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.rule_node_concepts ENABLE ROW LEVEL SECURITY;
+
+-- #149 introduced this audit view before production DDL linting was wired into the rollout.
+-- Preserve the view while making it obey the querying role's permissions/RLS.
+ALTER VIEW IF EXISTS public.rule_graph_audit_summary SET (security_invoker = true);
+
+CREATE OR REPLACE VIEW public.concept_taxonomy_audit_summary
+WITH (security_invoker = true) AS
+SELECT
+  (SELECT count(*) FROM public.concepts) AS concepts,
+  (SELECT count(*) FROM public.concept_labels WHERE label_type = 'pref') AS preferred_labels,
+  (SELECT count(*) FROM public.concept_labels WHERE label_type = 'alt') AS alternate_labels,
+  (SELECT count(*) FROM public.concept_relations) AS relations,
+  (SELECT count(DISTINCT game_id) FROM public.game_concepts) AS games_with_concepts,
+  (SELECT count(*) FROM public.rule_node_concepts) AS rule_concept_links,
+  (SELECT count(*) FROM public.concepts WHERE verification_status <> 'verified') AS unresolved_concepts;
+
+COMMIT;

--- a/backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
+++ b/backend/app/db/migrations/012_seed_skull_king_glossary_concepts.sql
@@ -1,0 +1,121 @@
+BEGIN;
+
+-- Source-bound first production use of Concept Taxonomy v1.
+-- Primary source: Grandpa Beck's Games, current Skull King English rulebook,
+-- Key Terms, printed page 4.
+-- https://www.grandpabecksgames.com/pages/skull-king
+
+INSERT INTO public.concepts (
+  concept_id, concept_type, definition, verification_status, source_url, source_locator
+)
+VALUES
+  (
+    'rule-pattern.trick',
+    'rule_pattern',
+    '各プレイヤーがカードを出し、所定の順位規則で勝者を決める1回のプレイ単位。',
+    'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Key Terms, printed p.4: Trick'
+  ),
+  (
+    'player-action.bid',
+    'player_action',
+    'ラウンドで自分が獲得すると予想するトリック数を宣言する行為。',
+    'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Key Terms, printed p.4: Bid'
+  ),
+  (
+    'rule-pattern.trump-suit',
+    'rule_pattern',
+    '他の通常スートより高い順位を持つスート。',
+    'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Key Terms, printed p.4: Trump Suit'
+  ),
+  (
+    'component.special-card',
+    'component',
+    '通常の数字付きスートカードとは異なる解決規則を持つカードの区分。',
+    'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Key Terms, printed p.4: Special Cards'
+  )
+ON CONFLICT (concept_id) DO UPDATE SET
+  definition = EXCLUDED.definition,
+  verification_status = EXCLUDED.verification_status,
+  source_url = EXCLUDED.source_url,
+  source_locator = EXCLUDED.source_locator,
+  updated_at = now();
+
+WITH labels(concept_id, language_code, label_type, label, normalized_label) AS (
+  VALUES
+    ('rule-pattern.trick', 'en', 'pref', 'Trick', 'trick'),
+    ('rule-pattern.trick', 'ja', 'pref', 'トリック', 'トリック'),
+    ('player-action.bid', 'en', 'pref', 'Bid', 'bid'),
+    ('player-action.bid', 'ja', 'pref', 'ビッド', 'ビッド'),
+    ('rule-pattern.trump-suit', 'en', 'pref', 'Trump Suit', 'trump suit'),
+    ('rule-pattern.trump-suit', 'ja', 'pref', '切り札', '切り札'),
+    ('component.special-card', 'en', 'pref', 'Special Card', 'special card'),
+    ('component.special-card', 'ja', 'pref', '特殊カード', '特殊カード')
+)
+INSERT INTO public.concept_labels (concept_id, language_code, label_type, label, normalized_label)
+SELECT l.concept_id, l.language_code, l.label_type, l.label, l.normalized_label
+FROM labels l
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.concept_labels existing
+  WHERE existing.concept_id = l.concept_id
+    AND lower(existing.language_code) = lower(l.language_code)
+    AND existing.normalized_label = l.normalized_label
+);
+
+INSERT INTO public.concept_relations (
+  from_concept_id, to_concept_id, relation_type, verification_status, source_url, source_locator
+)
+VALUES
+  (
+    'player-action.bid', 'rule-pattern.trick', 'related', 'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Overview and Key Terms, printed pp.3-4'
+  ),
+  (
+    'rule-pattern.trump-suit', 'rule-pattern.trick', 'related', 'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Key Terms, printed p.4'
+  ),
+  (
+    'component.special-card', 'rule-pattern.trick', 'related', 'source_bound',
+    'https://www.grandpabecksgames.com/pages/skull-king',
+    'Current English rulebook, Key Terms, printed p.4'
+  )
+ON CONFLICT (from_concept_id, to_concept_id, relation_type) DO UPDATE SET
+  verification_status = EXCLUDED.verification_status,
+  source_url = EXCLUDED.source_url,
+  source_locator = EXCLUDED.source_locator;
+
+INSERT INTO public.game_concepts (
+  game_id, concept_id, usage_role, verification_status, source_url, source_locator
+)
+SELECT
+  games.id,
+  seed.concept_id,
+  'glossary',
+  'source_bound',
+  'https://www.grandpabecksgames.com/pages/skull-king',
+  seed.source_locator
+FROM public.games games
+CROSS JOIN (
+  VALUES
+    ('rule-pattern.trick', 'Current English rulebook, Key Terms, printed p.4: Trick'),
+    ('player-action.bid', 'Current English rulebook, Key Terms, printed p.4: Bid'),
+    ('rule-pattern.trump-suit', 'Current English rulebook, Key Terms, printed p.4: Trump Suit'),
+    ('component.special-card', 'Current English rulebook, Key Terms, printed p.4: Special Cards')
+) AS seed(concept_id, source_locator)
+WHERE games.slug = 'skull-king'
+ON CONFLICT (game_id, concept_id, usage_role) DO UPDATE SET
+  verification_status = EXCLUDED.verification_status,
+  source_url = EXCLUDED.source_url,
+  source_locator = EXCLUDED.source_locator;
+
+COMMIT;

--- a/backend/app/models/concept_taxonomy.py
+++ b/backend/app/models/concept_taxonomy.py
@@ -1,0 +1,267 @@
+import re
+import unicodedata
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.rule_graph import RuleNodeType
+
+CONCEPT_TAXONOMY_SCHEMA_VERSION = "1.0"
+
+
+def normalize_concept_label(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return re.sub(r"[\s_-]+", " ", normalized).strip()
+
+
+class ConceptType(StrEnum):
+    MECHANIC = "mechanic"
+    COMPONENT = "component"
+    RESOURCE = "resource"
+    STATE = "state"
+    PLAYER_ACTION = "player_action"
+    INFORMATION_STRUCTURE = "information_structure"
+    INTERACTION_PATTERN = "interaction_pattern"
+    RULE_PATTERN = "rule_pattern"
+
+
+class ConceptLifecycleStatus(StrEnum):
+    ACTIVE = "active"
+    DEPRECATED = "deprecated"
+    MERGED = "merged"
+
+
+class ConceptVerificationStatus(StrEnum):
+    UNKNOWN = "unknown"
+    SOURCE_BOUND = "source_bound"
+    VERIFIED = "verified"
+
+
+class ConceptLabelType(StrEnum):
+    PREF = "pref"
+    ALT = "alt"
+
+
+class ConceptRelationType(StrEnum):
+    BROADER = "broader"
+    NARROWER = "narrower"
+    RELATED = "related"
+    REPLACED_BY = "replaced_by"
+
+
+class GameConceptUsageRole(StrEnum):
+    CORE = "core"
+    SUPPORTING = "supporting"
+    GLOSSARY = "glossary"
+
+
+class RuleConceptReferenceKind(StrEnum):
+    MENTIONS = "mentions"
+    DEFINES = "defines"
+    REQUIRES = "requires"
+    MODIFIES = "modifies"
+
+
+class TaxonomyModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ConceptLabel(TaxonomyModel):
+    language_code: str = Field(min_length=2, max_length=35)
+    label_type: ConceptLabelType
+    label: str = Field(min_length=1, max_length=240)
+    normalized_label: str | None = None
+
+    @model_validator(mode="after")
+    def set_normalized_label(self):
+        normalized = normalize_concept_label(self.label)
+        if not normalized:
+            raise ValueError("concept label must contain visible text")
+        if self.normalized_label is not None and self.normalized_label != normalized:
+            raise ValueError("normalized_label must match deterministic normalization")
+        self.normalized_label = normalized
+        return self
+
+
+class Concept(TaxonomyModel):
+    concept_id: str = Field(pattern=r"^[a-z0-9][a-z0-9._:-]{2,127}$")
+    concept_type: ConceptType
+    lifecycle_status: ConceptLifecycleStatus = ConceptLifecycleStatus.ACTIVE
+    replaced_by_concept_id: str | None = None
+    definition: str | None = None
+    verification_status: ConceptVerificationStatus = ConceptVerificationStatus.UNKNOWN
+    source_url: str | None = None
+    source_locator: str | None = None
+    labels: list[ConceptLabel] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_labels_and_lifecycle(self):
+        preferred_languages: set[str] = set()
+        seen_labels: set[tuple[str, str]] = set()
+        for label in self.labels:
+            key = (label.language_code.casefold(), label.normalized_label or "")
+            if key in seen_labels:
+                raise ValueError("duplicate normalized label within concept/language")
+            seen_labels.add(key)
+            if label.label_type == ConceptLabelType.PREF:
+                language = label.language_code.casefold()
+                if language in preferred_languages:
+                    raise ValueError("only one preferred label is allowed per language")
+                preferred_languages.add(language)
+
+        if self.replaced_by_concept_id == self.concept_id:
+            raise ValueError("a concept cannot replace itself")
+        if self.lifecycle_status == ConceptLifecycleStatus.MERGED and not self.replaced_by_concept_id:
+            raise ValueError("merged concepts require replaced_by_concept_id")
+        if self.lifecycle_status != ConceptLifecycleStatus.MERGED and self.replaced_by_concept_id:
+            raise ValueError("replaced_by_concept_id is reserved for merged concepts")
+        return self
+
+
+class ConceptRelation(TaxonomyModel):
+    from_concept_id: str
+    to_concept_id: str
+    relation_type: ConceptRelationType
+    verification_status: ConceptVerificationStatus = ConceptVerificationStatus.UNKNOWN
+    source_url: str | None = None
+    source_locator: str | None = None
+
+    @model_validator(mode="after")
+    def reject_self_relation(self):
+        if self.from_concept_id == self.to_concept_id:
+            raise ValueError("concept relations cannot point to self")
+        return self
+
+
+class RuleConceptReference(TaxonomyModel):
+    rule_id: str
+    node_type: RuleNodeType
+    normalized_statement: str
+    reference_kind: RuleConceptReferenceKind
+    verification_status: ConceptVerificationStatus = ConceptVerificationStatus.UNKNOWN
+
+
+class ConceptGameBacklink(TaxonomyModel):
+    game_id: str
+    slug: str
+    title: str | None = None
+    usage_roles: list[GameConceptUsageRole] = Field(default_factory=list)
+    rule_references: list[RuleConceptReference] = Field(default_factory=list)
+
+
+class ConceptDetailResponse(TaxonomyModel):
+    schema_version: Literal["1.0"] = CONCEPT_TAXONOMY_SCHEMA_VERSION
+    concept: Concept
+    relations: list[ConceptRelation] = Field(default_factory=list)
+    game_backlinks: list[ConceptGameBacklink] = Field(default_factory=list)
+
+
+class GameConceptReference(TaxonomyModel):
+    concept_id: str
+    concept_type: ConceptType
+    usage_role: GameConceptUsageRole
+    verification_status: ConceptVerificationStatus = ConceptVerificationStatus.UNKNOWN
+    preferred_labels: dict[str, str] = Field(default_factory=dict)
+    alternate_labels: dict[str, list[str]] = Field(default_factory=dict)
+    definition: str | None = None
+    related_concept_ids: list[str] = Field(default_factory=list)
+    rule_references: list[RuleConceptReference] = Field(default_factory=list)
+
+
+class GameConceptsReadResponse(TaxonomyModel):
+    schema_version: Literal["1.0"] = CONCEPT_TAXONOMY_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    concepts: list[GameConceptReference] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_availability(self):
+        if self.status == "not_available" and self.concepts:
+            raise ValueError("not_available concept projections must be empty")
+        return self
+
+
+class GlossaryEntry(TaxonomyModel):
+    concept_id: str
+    label: str
+    definition: str | None = None
+    aliases: list[str] = Field(default_factory=list)
+    related_concept_ids: list[str] = Field(default_factory=list)
+    rule_references: list[RuleConceptReference] = Field(default_factory=list)
+
+
+class GameGlossaryReadResponse(TaxonomyModel):
+    schema_version: Literal["1.0"] = CONCEPT_TAXONOMY_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    language_code: str
+    entries: list[GlossaryEntry] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_availability(self):
+        if self.status == "not_available" and self.entries:
+            raise ValueError("not_available glossary projections must be empty")
+        return self
+
+
+class LegacyConceptResolution(TaxonomyModel):
+    resolved: dict[str, str] = Field(default_factory=dict)
+    ambiguous: dict[str, list[str]] = Field(default_factory=dict)
+    unresolved: list[str] = Field(default_factory=list)
+
+
+def validate_relation_set(concepts: list[Concept], relations: list[ConceptRelation]) -> None:
+    concept_ids = {concept.concept_id for concept in concepts}
+    if len(concept_ids) != len(concepts):
+        raise ValueError("duplicate concept_id")
+
+    seen: set[tuple[str, str, ConceptRelationType]] = set()
+    hierarchical_pairs: set[frozenset[str]] = set()
+    related_pairs: set[frozenset[str]] = set()
+    for relation in relations:
+        if relation.from_concept_id not in concept_ids or relation.to_concept_id not in concept_ids:
+            raise ValueError("concept relation references an unknown concept")
+        key = (relation.from_concept_id, relation.to_concept_id, relation.relation_type)
+        if key in seen:
+            raise ValueError("duplicate concept relation")
+        seen.add(key)
+        pair = frozenset((relation.from_concept_id, relation.to_concept_id))
+        if relation.relation_type in {ConceptRelationType.BROADER, ConceptRelationType.NARROWER}:
+            hierarchical_pairs.add(pair)
+        elif relation.relation_type == ConceptRelationType.RELATED:
+            related_pairs.add(pair)
+
+    if hierarchical_pairs & related_pairs:
+        raise ValueError("related cannot overlap a broader/narrower pair")
+
+
+def resolve_legacy_terms(
+    terms: list[str],
+    concepts: list[Concept],
+    language_code: str | None = None,
+) -> LegacyConceptResolution:
+    index: dict[str, set[str]] = {}
+    for concept in concepts:
+        if concept.lifecycle_status == ConceptLifecycleStatus.MERGED:
+            continue
+        for label in concept.labels:
+            if language_code and label.language_code.casefold() != language_code.casefold():
+                continue
+            key = label.normalized_label or normalize_concept_label(label.label)
+            index.setdefault(key, set()).add(concept.concept_id)
+
+    resolved: dict[str, str] = {}
+    ambiguous: dict[str, list[str]] = {}
+    unresolved: list[str] = []
+    for term in terms:
+        matches = sorted(index.get(normalize_concept_label(term), set()))
+        if len(matches) == 1:
+            resolved[term] = matches[0]
+        elif len(matches) > 1:
+            ambiguous[term] = matches
+        else:
+            unresolved.append(term)
+    return LegacyConceptResolution(resolved=resolved, ambiguous=ambiguous, unresolved=unresolved)

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.rate_limiter import RateLimiter
 from app.models import GameDetail, GameListResponse, GameUpdate, SearchRequest
+from app.models.concept_taxonomy import ConceptDetailResponse, GameConceptsReadResponse, GameGlossaryReadResponse
 from app.models.rule_graph import RuleGraphReadResponse, RuleNodeType
 from app.routers.auth import require_catalog_editor
 from app.services import catalog_access
+from app.services.concept_taxonomy import ConceptTaxonomyService
 from app.services.game_service import GameService
 from app.services.rule_graph import RuleGraphService
 
@@ -21,6 +23,10 @@ def get_game_service():
 
 def get_rule_graph_service():
     return RuleGraphService()
+
+
+def get_concept_taxonomy_service():
+    return ConceptTaxonomyService()
 
 
 @router.get("/search", response_model=list[GameDetail])
@@ -62,6 +68,40 @@ async def list_recent_games(limit: int = 100, offset: int = 0, service: GameServ
         "limit": limit,
         "offset": offset,
     }
+
+
+@router.get("/concepts/{concept_id}", response_model=ConceptDetailResponse)
+async def get_concept_detail(
+    concept_id: str,
+    service: ConceptTaxonomyService = Depends(get_concept_taxonomy_service),
+):
+    concept = await service.get_concept(concept_id)
+    if concept is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Concept not found")
+    return concept
+
+
+@router.get("/games/{slug}/concepts", response_model=GameConceptsReadResponse)
+async def get_game_concepts(
+    slug: str,
+    service: ConceptTaxonomyService = Depends(get_concept_taxonomy_service),
+):
+    concepts = await service.get_by_game_slug(slug)
+    if concepts is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return concepts
+
+
+@router.get("/games/{slug}/glossary", response_model=GameGlossaryReadResponse)
+async def get_game_glossary(
+    slug: str,
+    language_code: str = Query(default="ja", min_length=2, max_length=35),
+    service: ConceptTaxonomyService = Depends(get_concept_taxonomy_service),
+):
+    glossary = await service.get_glossary_by_game_slug(slug, language_code=language_code)
+    if glossary is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return glossary
 
 
 @router.get("/games/{slug}/rule-graph", response_model=RuleGraphReadResponse)

--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -1,0 +1,280 @@
+import logging
+
+import anyio
+
+from app.core import supabase
+from app.models.concept_taxonomy import (
+    Concept,
+    ConceptDetailResponse,
+    ConceptGameBacklink,
+    ConceptLabel,
+    ConceptRelation,
+    GameConceptReference,
+    GameConceptsReadResponse,
+    GameGlossaryReadResponse,
+    GlossaryEntry,
+    RuleConceptReference,
+)
+
+logger = logging.getLogger("services.concept_taxonomy")
+
+
+class ConceptTaxonomyService:
+    async def get_concept(self, concept_id: str) -> ConceptDetailResponse | None:
+        if supabase.is_local():
+            return None
+        try:
+            return await anyio.to_thread.run_sync(self._load_concept, concept_id)
+        except Exception as exc:
+            logger.warning("Concept taxonomy unavailable for %s: %s", concept_id, exc)
+            return None
+
+    async def get_by_game_slug(self, slug: str) -> GameConceptsReadResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        base = {"game_id": str(game["id"]), "slug": str(game["slug"])}
+        if supabase.is_local():
+            return GameConceptsReadResponse(status="not_available", **base)
+        try:
+            return await anyio.to_thread.run_sync(self._load_game_concepts, game, base)
+        except Exception as exc:
+            logger.warning("Concept projection unavailable for %s: %s", slug, exc)
+            return GameConceptsReadResponse(status="not_available", **base)
+
+    async def get_glossary_by_game_slug(self, slug: str, language_code: str = "ja") -> GameGlossaryReadResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        base = {
+            "game_id": str(game["id"]),
+            "slug": str(game["slug"]),
+            "language_code": language_code,
+        }
+        if supabase.is_local():
+            return GameGlossaryReadResponse(status="not_available", **base)
+        try:
+            concepts = await anyio.to_thread.run_sync(
+                self._load_game_concepts,
+                game,
+                {"game_id": base["game_id"], "slug": base["slug"]},
+            )
+        except Exception as exc:
+            logger.warning("Glossary projection unavailable for %s: %s", slug, exc)
+            return GameGlossaryReadResponse(status="not_available", **base)
+
+        entries: list[GlossaryEntry] = []
+        for reference in concepts.concepts:
+            if reference.usage_role.value not in {"core", "glossary"}:
+                continue
+            label = reference.preferred_labels.get(language_code)
+            if not label:
+                label = reference.preferred_labels.get("en")
+            if not label and reference.preferred_labels:
+                label = next(iter(reference.preferred_labels.values()))
+            if not label:
+                continue
+            aliases = reference.alternate_labels.get(language_code, [])
+            entries.append(
+                GlossaryEntry(
+                    concept_id=reference.concept_id,
+                    label=label,
+                    definition=reference.definition,
+                    aliases=aliases,
+                    related_concept_ids=reference.related_concept_ids,
+                    rule_references=reference.rule_references,
+                )
+            )
+        if not entries:
+            return GameGlossaryReadResponse(status="not_available", **base)
+        return GameGlossaryReadResponse(status="available", entries=entries, **base)
+
+    @classmethod
+    def _load_concept(cls, concept_id: str) -> ConceptDetailResponse | None:
+        client = supabase._get_client()
+        detail = cls._load_concept_core(client, concept_id)
+        if detail is None:
+            return None
+        backlinks = cls._load_game_backlinks(client, concept_id)
+        return detail.model_copy(update={"game_backlinks": backlinks})
+
+    @classmethod
+    def _load_concept_core(cls, client, concept_id: str) -> ConceptDetailResponse | None:
+        rows = client.table("concepts").select("*").eq("concept_id", concept_id).limit(1).execute().data
+        if not rows:
+            return None
+        row = rows[0]
+        label_rows = (
+            client.table("concept_labels")
+            .select("language_code,label_type,label,normalized_label")
+            .eq("concept_id", concept_id)
+            .execute()
+            .data
+        )
+        outgoing = (
+            client.table("concept_relations")
+            .select("*")
+            .eq("from_concept_id", concept_id)
+            .execute()
+            .data
+        )
+        incoming = (
+            client.table("concept_relations")
+            .select("*")
+            .eq("to_concept_id", concept_id)
+            .execute()
+            .data
+        )
+        relation_rows = {str(item["id"]): item for item in [*outgoing, *incoming]}.values()
+        concept = Concept(
+            concept_id=row["concept_id"],
+            concept_type=row["concept_type"],
+            lifecycle_status=row.get("lifecycle_status", "active"),
+            replaced_by_concept_id=row.get("replaced_by_concept_id"),
+            definition=row.get("definition"),
+            verification_status=row.get("verification_status", "unknown"),
+            source_url=row.get("source_url"),
+            source_locator=row.get("source_locator"),
+            labels=[ConceptLabel.model_validate(label) for label in label_rows],
+        )
+        relations = [
+            ConceptRelation(
+                from_concept_id=relation["from_concept_id"],
+                to_concept_id=relation["to_concept_id"],
+                relation_type=relation["relation_type"],
+                verification_status=relation.get("verification_status", "unknown"),
+                source_url=relation.get("source_url"),
+                source_locator=relation.get("source_locator"),
+            )
+            for relation in relation_rows
+        ]
+        return ConceptDetailResponse(concept=concept, relations=relations)
+
+    @classmethod
+    def _load_game_concepts(cls, game: dict, base: dict) -> GameConceptsReadResponse:
+        client = supabase._get_client()
+        links = (
+            client.table("game_concepts")
+            .select("concept_id,usage_role,verification_status")
+            .eq("game_id", game["id"])
+            .execute()
+            .data
+        )
+        if not links:
+            return GameConceptsReadResponse(status="not_available", **base)
+
+        references: list[GameConceptReference] = []
+        for link in links:
+            detail = cls._load_concept_core(client, link["concept_id"])
+            if detail is None:
+                continue
+            preferred_labels = {
+                label.language_code: label.label
+                for label in detail.concept.labels
+                if label.label_type.value == "pref"
+            }
+            alternate_labels: dict[str, list[str]] = {}
+            for label in detail.concept.labels:
+                if label.label_type.value == "alt":
+                    alternate_labels.setdefault(label.language_code, []).append(label.label)
+            related_ids = sorted(
+                {
+                    relation.to_concept_id if relation.from_concept_id == detail.concept.concept_id else relation.from_concept_id
+                    for relation in detail.relations
+                    if relation.relation_type.value == "related"
+                }
+            )
+            rule_references = cls._load_rule_references(client, str(game["id"]), link["concept_id"])
+            references.append(
+                GameConceptReference(
+                    concept_id=detail.concept.concept_id,
+                    concept_type=detail.concept.concept_type,
+                    usage_role=link["usage_role"],
+                    verification_status=link.get("verification_status", "unknown"),
+                    preferred_labels=preferred_labels,
+                    alternate_labels=alternate_labels,
+                    definition=detail.concept.definition,
+                    related_concept_ids=related_ids,
+                    rule_references=rule_references,
+                )
+            )
+        if not references:
+            return GameConceptsReadResponse(status="not_available", **base)
+        return GameConceptsReadResponse(status="available", concepts=references, **base)
+
+    @classmethod
+    def _load_rule_references(cls, client, game_id: str, concept_id: str) -> list[RuleConceptReference]:
+        rule_sets = (
+            client.table("rule_sets")
+            .select("id")
+            .eq("game_id", game_id)
+            .eq("is_active", True)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rule_sets:
+            return []
+        rule_set_id = rule_sets[0]["id"]
+        links = (
+            client.table("rule_node_concepts")
+            .select("rule_id,reference_kind,verification_status")
+            .eq("rule_set_id", rule_set_id)
+            .eq("concept_id", concept_id)
+            .execute()
+            .data
+        )
+        references: list[RuleConceptReference] = []
+        for link in links:
+            nodes = (
+                client.table("rule_nodes")
+                .select("rule_id,node_type,normalized_statement")
+                .eq("rule_set_id", rule_set_id)
+                .eq("rule_id", link["rule_id"])
+                .limit(1)
+                .execute()
+                .data
+            )
+            if not nodes:
+                continue
+            node = nodes[0]
+            references.append(
+                RuleConceptReference(
+                    rule_id=node["rule_id"],
+                    node_type=node["node_type"],
+                    normalized_statement=node["normalized_statement"],
+                    reference_kind=link["reference_kind"],
+                    verification_status=link.get("verification_status", "unknown"),
+                )
+            )
+        return references
+
+    @classmethod
+    def _load_game_backlinks(cls, client, concept_id: str) -> list[ConceptGameBacklink]:
+        links = (
+            client.table("game_concepts")
+            .select("game_id,usage_role")
+            .eq("concept_id", concept_id)
+            .execute()
+            .data
+        )
+        by_game: dict[str, list[str]] = {}
+        for link in links:
+            by_game.setdefault(str(link["game_id"]), []).append(link["usage_role"])
+
+        backlinks: list[ConceptGameBacklink] = []
+        for game_id, usage_roles in by_game.items():
+            games = client.table("games").select("id,slug,title").eq("id", game_id).limit(1).execute().data
+            if not games:
+                continue
+            game = games[0]
+            backlinks.append(
+                ConceptGameBacklink(
+                    game_id=str(game["id"]),
+                    slug=str(game["slug"]),
+                    title=game.get("title"),
+                    usage_roles=sorted(set(usage_roles)),
+                    rule_references=cls._load_rule_references(client, game_id, concept_id),
+                )
+            )
+        return sorted(backlinks, key=lambda item: item.slug)

--- a/backend/tests/test_concept_taxonomy.py
+++ b/backend/tests/test_concept_taxonomy.py
@@ -1,0 +1,264 @@
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.models.concept_taxonomy import (
+    Concept,
+    ConceptDetailResponse,
+    ConceptGameBacklink,
+    ConceptLabel,
+    ConceptRelation,
+    GameConceptReference,
+    GameConceptsReadResponse,
+    GameGlossaryReadResponse,
+    GlossaryEntry,
+    RuleConceptReference,
+    resolve_legacy_terms,
+    validate_relation_set,
+)
+from app.routers import games
+
+
+def concept(concept_id: str, labels: list[ConceptLabel], **kwargs) -> Concept:
+    return Concept(concept_id=concept_id, concept_type="mechanic", labels=labels, **kwargs)
+
+
+def test_stable_id_is_independent_from_label_rename():
+    before = concept(
+        "fixture.mechanic.risk-choice",
+        [ConceptLabel(language_code="en", label_type="pref", label="Risk Choice")],
+    )
+    after = concept(
+        "fixture.mechanic.risk-choice",
+        [ConceptLabel(language_code="en", label_type="pref", label="Pressing Risk")],
+    )
+    assert before.concept_id == after.concept_id
+    assert before.labels[0].label != after.labels[0].label
+
+
+def test_multilingual_pref_and_alt_labels_normalize_deterministically():
+    item = concept(
+        "fixture.mechanic.choice",
+        [
+            ConceptLabel(language_code="en", label_type="pref", label="Risk Choice"),
+            ConceptLabel(language_code="en", label_type="alt", label="Press Risk"),
+            ConceptLabel(language_code="ja", label_type="pref", label="リスク選択"),
+        ],
+    )
+    assert item.labels[0].normalized_label == "risk choice"
+    assert item.labels[1].normalized_label == "press risk"
+    assert ConceptLabel(language_code="en", label_type="alt", label="risk-choice").normalized_label == "risk choice"
+
+
+def test_redundant_alias_after_normalization_is_rejected():
+    with pytest.raises(ValidationError):
+        concept(
+            "fixture.mechanic.choice",
+            [
+                ConceptLabel(language_code="en", label_type="pref", label="Risk Choice"),
+                ConceptLabel(language_code="en", label_type="alt", label="risk-choice"),
+            ],
+        )
+
+
+def test_duplicate_preferred_label_per_language_is_rejected():
+    with pytest.raises(ValidationError):
+        concept(
+            "fixture.mechanic.choice",
+            [
+                ConceptLabel(language_code="en", label_type="pref", label="Choice One"),
+                ConceptLabel(language_code="EN", label_type="pref", label="Choice Two"),
+            ],
+        )
+
+
+def test_merged_concept_requires_redirect_and_cannot_redirect_to_self():
+    merged = concept(
+        "fixture.mechanic.old",
+        [ConceptLabel(language_code="en", label_type="pref", label="Old")],
+        lifecycle_status="merged",
+        replaced_by_concept_id="fixture.mechanic.new",
+    )
+    assert merged.replaced_by_concept_id == "fixture.mechanic.new"
+
+    with pytest.raises(ValidationError):
+        concept(
+            "fixture.mechanic.old",
+            [ConceptLabel(language_code="en", label_type="pref", label="Old")],
+            lifecycle_status="merged",
+            replaced_by_concept_id="fixture.mechanic.old",
+        )
+
+
+def test_skos_related_cannot_overlap_hierarchical_pair():
+    broader = concept(
+        "fixture.mechanic.broad",
+        [ConceptLabel(language_code="en", label_type="pref", label="Broad")],
+    )
+    narrow = concept(
+        "fixture.mechanic.narrow",
+        [ConceptLabel(language_code="en", label_type="pref", label="Narrow")],
+    )
+    with pytest.raises(ValueError):
+        validate_relation_set(
+            [broader, narrow],
+            [
+                ConceptRelation(from_concept_id=narrow.concept_id, to_concept_id=broader.concept_id, relation_type="broader"),
+                ConceptRelation(from_concept_id=broader.concept_id, to_concept_id=narrow.concept_id, relation_type="related"),
+            ],
+        )
+
+
+def test_legacy_mapping_is_fail_closed_for_ambiguous_and_unknown_labels():
+    one = concept(
+        "fixture.mechanic.one",
+        [ConceptLabel(language_code="en", label_type="pref", label="Shared Term")],
+    )
+    two = Concept(
+        concept_id="fixture.action.two",
+        concept_type="player_action",
+        labels=[ConceptLabel(language_code="en", label_type="alt", label="shared_term")],
+    )
+    unique = concept(
+        "fixture.mechanic.unique",
+        [ConceptLabel(language_code="en", label_type="pref", label="Unique Term")],
+    )
+    resolution = resolve_legacy_terms(["shared-term", "Unique Term", "Unknown"], [one, two, unique], language_code="en")
+    assert resolution.resolved == {"Unique Term": "fixture.mechanic.unique"}
+    assert resolution.ambiguous["shared-term"] == ["fixture.action.two", "fixture.mechanic.one"]
+    assert resolution.unresolved == ["Unknown"]
+
+
+def test_global_definition_and_game_rule_reference_remain_separate():
+    detail = ConceptDetailResponse(
+        concept=Concept(
+            concept_id="fixture.mechanic.trick",
+            concept_type="mechanic",
+            definition="A generic play unit shared by multiple games.",
+            labels=[ConceptLabel(language_code="ja", label_type="pref", label="トリック")],
+        ),
+        game_backlinks=[
+            ConceptGameBacklink(
+                game_id="game-1",
+                slug="example",
+                usage_roles=["glossary"],
+                rule_references=[
+                    RuleConceptReference(
+                        rule_id="example.rule.turn.1",
+                        node_type="turn",
+                        normalized_statement="このゲーム固有のトリック進行。",
+                        reference_kind="mentions",
+                    )
+                ],
+            )
+        ],
+    )
+    assert detail.concept.definition != detail.game_backlinks[0].rule_references[0].normalized_statement
+
+
+def test_versioned_structural_fixtures_validate_without_seeding_production_taxonomy():
+    path = Path(__file__).parents[2] / "evaluation" / "taxonomy" / "concept-taxonomy-v1-fixtures.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["version"] == "concept-taxonomy-fixtures-v1"
+    assert "do not seed" in payload["note"].lower()
+    concepts = [Concept.model_validate(case) for case in payload["cases"]]
+    assert {item.concept_type.value for item in concepts} == {"mechanic", "player_action"}
+
+
+def test_migration_declares_rule_node_concept_backlinks():
+    path = Path(__file__).parents[1] / "app" / "db" / "migrations" / "011_concept_taxonomy.sql"
+    sql = path.read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS public.rule_node_concepts" in sql
+    assert "FOREIGN KEY (rule_set_id, rule_id)" in sql
+    assert "concept_labels_unique_normalized_per_language" in sql
+
+
+class FakeConceptService:
+    async def get_concept(self, concept_id: str):
+        if concept_id == "missing":
+            return None
+        return ConceptDetailResponse(
+            concept=Concept(
+                concept_id=concept_id,
+                concept_type="mechanic",
+                definition="Generic definition",
+                labels=[ConceptLabel(language_code="ja", label_type="pref", label="トリック")],
+            ),
+            game_backlinks=[ConceptGameBacklink(game_id="game-1", slug="example", usage_roles=["glossary"])],
+        )
+
+    async def get_by_game_slug(self, slug: str):
+        if slug == "missing":
+            return None
+        return GameConceptsReadResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            concepts=[
+                GameConceptReference(
+                    concept_id="fixture.mechanic.trick",
+                    concept_type="mechanic",
+                    usage_role="glossary",
+                    preferred_labels={"ja": "トリック"},
+                    definition="Generic definition",
+                )
+            ],
+        )
+
+    async def get_glossary_by_game_slug(self, slug: str, language_code: str = "ja"):
+        if slug == "missing":
+            return None
+        return GameGlossaryReadResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            language_code=language_code,
+            entries=[
+                GlossaryEntry(
+                    concept_id="fixture.mechanic.trick",
+                    label="トリック",
+                    definition="Generic definition",
+                    rule_references=[
+                        RuleConceptReference(
+                            rule_id="example.rule.turn.1",
+                            node_type="turn",
+                            normalized_statement="Game-specific rule reference",
+                            reference_kind="mentions",
+                        )
+                    ],
+                )
+            ],
+        )
+
+
+def app():
+    instance = FastAPI()
+    instance.include_router(games.router, prefix="/api")
+    instance.dependency_overrides[games.get_concept_taxonomy_service] = lambda: FakeConceptService()
+    return instance
+
+
+def test_game_concepts_api_uses_stable_concept_ids():
+    response = TestClient(app()).get("/api/games/example/concepts")
+    assert response.status_code == 200
+    assert response.json()["concepts"][0]["concept_id"] == "fixture.mechanic.trick"
+
+
+def test_linked_glossary_api_exposes_concept_and_rule_reference():
+    response = TestClient(app()).get("/api/games/example/glossary?language_code=ja")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["entries"][0]["concept_id"] == "fixture.mechanic.trick"
+    assert payload["entries"][0]["rule_references"][0]["rule_id"] == "example.rule.turn.1"
+
+
+def test_concept_detail_api_exposes_backlinks_and_missing_boundary():
+    client = TestClient(app())
+    response = client.get("/api/concepts/fixture.mechanic.trick")
+    assert response.status_code == 200
+    assert response.json()["game_backlinks"][0]["slug"] == "example"
+    assert client.get("/api/concepts/missing").status_code == 404

--- a/docs/CONCEPT_TAXONOMY_V1.md
+++ b/docs/CONCEPT_TAXONOMY_V1.md
@@ -1,0 +1,101 @@
+# Concept Taxonomy v1
+
+Status: canonical contract for Issue #150  
+Schema version: `1.0`
+
+## Purpose
+
+Board-game mechanics, components, resources, states, player actions, information structures, interaction patterns, and rule patterns are canonical concepts identified by stable `concept_id` values. Human-readable labels are attributes of a concept, never its identity.
+
+This taxonomy does not seed unverified board-game concepts. Legacy `structured_data.mechanics` and `keywords` are migration inputs only; they may resolve to an existing concept when a label match is unique, otherwise they remain ambiguous/unresolved.
+
+## SKOS alignment
+
+W3C SKOS separates concepts from lexical labels and defines `prefLabel`, `altLabel`, direct hierarchical `broader` / `narrower` relations, and associative `related` relations. Concept Taxonomy v1 adopts those semantics without requiring RDF as the storage engine.
+
+Canonical storage therefore provides:
+
+- one stable concept identifier independent of labels;
+- at most one preferred label per concept/language;
+- any number of alternate labels;
+- direct `broader`, `narrower`, and `related` relations;
+- no automatic transitive assertion as a direct relation;
+- validation that a pair is not both hierarchical and `related`.
+
+## Concept types
+
+- `mechanic`
+- `component`
+- `resource`
+- `state`
+- `player_action`
+- `information_structure`
+- `interaction_pattern`
+- `rule_pattern`
+
+Different semantic types remain distinct even when they share a display word.
+
+## Lifecycle
+
+`active` is the normal state. `deprecated` remains addressable for historical references. `merged` requires `replaced_by_concept_id`; old IDs remain resolvable and can project to the replacement. Renaming a preferred label never changes `concept_id`.
+
+## Verification and provenance
+
+Concepts, concept relations, game links, and rule links use `unknown`, `source_bound`, or `verified`. A relation extracted or inferred without evidence does not become verified. `source_url` and `source_locator` connect taxonomy assertions to the repository's broader evidence/trust contracts.
+
+## Game linkage
+
+`game_concepts` links a canonical game edition to a concept by stable ID with a usage role:
+
+- `core`: central to describing the game;
+- `supporting`: materially present but not central;
+- `glossary`: useful as a term definition/projection.
+
+The GamePage and later Mechanical DNA implementation consume concept IDs rather than compare labels.
+
+## Rule Graph linkage and backlinks
+
+`rule_node_concepts` is the canonical bridge between Rule Graph v1 and Concept Taxonomy v1. It links one `rule_node` to one stable `concept_id` with a `reference_kind`:
+
+- `mentions`: the rule uses the concept;
+- `defines`: the rule gives a game-specific definition or interpretation;
+- `requires`: understanding/applying the rule depends on the concept;
+- `modifies`: the rule changes the normal behavior of the concept for this game/variant.
+
+The global Concept definition and a game-specific RuleNode statement are deliberately separate. For example, a general definition of `trick` does not contain Skull King-specific card resolution. The game-specific rule points back to the same concept instead.
+
+This bridge enables deterministic backlinks:
+
+`Concept -> game_concepts -> Game`
+
+`Concept -> rule_node_concepts -> RuleNode -> RuleSet -> Game`
+
+and the reverse direction:
+
+`RuleNode -> rule_node_concepts -> Concept`.
+
+## Linked glossary projection
+
+The glossary is a projection, not another truth store.
+
+- `GET /api/games/{slug}/glossary?language_code=ja` returns stable concept IDs, localized labels, aliases, global definitions, related concept IDs, and rule references for the selected game.
+- `GET /api/concepts/{concept_id}` returns the canonical concept, semantic relations, and game/rule backlinks.
+- `GET /api/games/{slug}/concepts` exposes the broader game-to-concept projection.
+
+The GamePage uses the canonical glossary when available. Selecting a term opens an inspector showing the stable ID, definition, related concepts, the rules in the current game that reference it, and other games using the concept. If canonical mappings are not available during migration, the existing legacy keyword display remains visible; the UI does not invent canonical mappings.
+
+A later Presentation Projection issue may add a dedicated `/concepts/{concept_id}` page and richer navigation, but the linked identity/backlink contract is owned here.
+
+## Legacy migration
+
+The deterministic resolver applies Unicode NFKC, case folding, and whitespace/hyphen/underscore normalization. A legacy term maps only when exactly one non-merged concept label matches. Zero matches remain unresolved. Multiple matches remain ambiguous and require review. The resolver never creates a new concept or promotes verification state.
+
+## Schema.org projection
+
+For public structured data, `concept_id` can project to Schema.org `DefinedTerm.termCode`, the preferred label to `name`, aliases to `alternateName`, definition to `description`, and the taxonomy scheme to `inDefinedTermSet`. This is a derived web projection, not the canonical database identity.
+
+## Primary references
+
+- W3C SKOS Reference: https://www.w3.org/TR/skos-reference/
+- Schema.org DefinedTerm: https://schema.org/DefinedTerm
+- Schema.org DefinedTermSet: https://schema.org/DefinedTermSet

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,9 @@
 - **[`RULE_GRAPH_V1.md`](./RULE_GRAPH_V1.md)**
     - Ontology v2 の canonical Rule Graph v1。RuleSet / RuleNode / RuleEdge、provenance境界、API、legacy migration mappingを定義します。
 
+- **[`CONCEPT_TAXONOMY_V1.md`](./CONCEPT_TAXONOMY_V1.md)**
+    - stable concept ID、多言語label、SKOS型relation、Rule Graph backlinks、linked glossary projectionを定義します。
+
 - **[`diagrams.md`](./diagrams.md)**
     - システムアーキテクチャ、シーケンス図、ER図などの視覚的な資料が含まれています。
 

--- a/evaluation/taxonomy/concept-taxonomy-v1-fixtures.json
+++ b/evaluation/taxonomy/concept-taxonomy-v1-fixtures.json
@@ -1,0 +1,23 @@
+{
+  "version": "concept-taxonomy-fixtures-v1",
+  "note": "Synthetic structural fixtures only; do not seed or treat them as verified production board-game taxonomy concepts.",
+  "cases": [
+    {
+      "concept_id": "fixture.mechanic.risk-choice",
+      "concept_type": "mechanic",
+      "labels": [
+        {"language_code": "en", "label_type": "pref", "label": "Risk Choice"},
+        {"language_code": "ja", "label_type": "pref", "label": "リスク選択"},
+        {"language_code": "en", "label_type": "alt", "label": "Press Risk"}
+      ]
+    },
+    {
+      "concept_id": "fixture.action.draw",
+      "concept_type": "player_action",
+      "labels": [
+        {"language_code": "en", "label_type": "pref", "label": "Draw"},
+        {"language_code": "ja", "label_type": "pref", "label": "引く"}
+      ]
+    }
+  ]
+}

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -1,0 +1,145 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../../lib/api'
+
+function LegacyGlossary({ keywords }) {
+  if (!keywords?.length) return null
+  return (
+    <div className="pro-card">
+      <div className="pro-card-title">GLOSSARY</div>
+      <div className="tag-list">
+        {keywords.map((kw, i) => (
+          <div key={`${kw.term}-${i}`} className="tag-item" title={kw.description}>{kw.term}</div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export function ConceptGlossary({ slug, legacyKeywords = [] }) {
+  const [entries, setEntries] = useState([])
+  const [selectedId, setSelectedId] = useState(null)
+  const [detail, setDetail] = useState(null)
+  const [canonicalAvailable, setCanonicalAvailable] = useState(false)
+  const [loadedSlug, setLoadedSlug] = useState(null)
+  const hasGlossary = legacyKeywords.length > 0
+
+  useEffect(() => {
+    if (!hasGlossary) return undefined
+
+    let cancelled = false
+    api.get(`/api/games/${slug}/glossary?language_code=ja`)
+      .then((data) => {
+        if (cancelled) return
+        const available = data?.status === 'available' && data.entries?.length > 0
+        setEntries(available ? data.entries : [])
+        setSelectedId(null)
+        setDetail(null)
+        setCanonicalAvailable(Boolean(available))
+        setLoadedSlug(slug)
+      })
+      .catch(() => {
+        if (cancelled) return
+        setEntries([])
+        setSelectedId(null)
+        setDetail(null)
+        setCanonicalAvailable(false)
+        setLoadedSlug(slug)
+      })
+
+    return () => { cancelled = true }
+  }, [slug, hasGlossary])
+
+  const selected = useMemo(
+    () => entries.find((entry) => entry.concept_id === selectedId) || null,
+    [entries, selectedId],
+  )
+
+  const selectConcept = async (conceptId) => {
+    if (selectedId === conceptId) {
+      setSelectedId(null)
+      setDetail(null)
+      return
+    }
+    setSelectedId(conceptId)
+    setDetail(null)
+    try {
+      const response = await api.get(`/api/concepts/${encodeURIComponent(conceptId)}`)
+      setDetail(response)
+    } catch {
+      // The game glossary remains useful even if the deeper backlink view is unavailable.
+    }
+  }
+
+  if (!hasGlossary || loadedSlug !== slug || !canonicalAvailable) {
+    return <LegacyGlossary keywords={legacyKeywords} />
+  }
+
+  return (
+    <div className="pro-card" aria-label="用語集">
+      <div className="pro-card-title">GLOSSARY · LINKED VIEW</div>
+      <div className="tag-list">
+        {entries.map((entry) => (
+          <button
+            key={entry.concept_id}
+            type="button"
+            className="tag-item"
+            aria-expanded={selectedId === entry.concept_id}
+            onClick={() => selectConcept(entry.concept_id)}
+            style={{ cursor: 'pointer', font: 'inherit' }}
+          >
+            {entry.label}
+          </button>
+        ))}
+      </div>
+
+      {selected && (
+        <div
+          role="region"
+          aria-live="polite"
+          aria-label={`${selected.label} の説明`}
+          style={{ marginTop: '1rem', paddingTop: '1rem', borderTop: '1px solid var(--border)' }}
+        >
+          <div style={{ fontWeight: 700 }}>{selected.label}</div>
+          <div style={{ fontSize: '0.72rem', color: 'var(--text-muted)', marginTop: '2px' }}>
+            {selected.concept_id}
+          </div>
+          {selected.definition && (
+            <p style={{ margin: '0.75rem 0', lineHeight: 1.6 }}>{selected.definition}</p>
+          )}
+          {selected.aliases?.length > 0 && (
+            <div className="game-empty-note">別名: {selected.aliases.join(' / ')}</div>
+          )}
+          {selected.related_concept_ids?.length > 0 && (
+            <div style={{ marginTop: '0.75rem' }}>
+              <strong style={{ fontSize: '0.78rem' }}>RELATED</strong>
+              <div className="game-empty-note">{selected.related_concept_ids.join(' · ')}</div>
+            </div>
+          )}
+          {selected.rule_references?.length > 0 && (
+            <div style={{ marginTop: '0.75rem' }}>
+              <strong style={{ fontSize: '0.78rem' }}>このゲームでは</strong>
+              {selected.rule_references.map((reference) => (
+                <div key={`${reference.rule_id}-${reference.reference_kind}`} className="game-empty-note" style={{ marginTop: '6px' }}>
+                  {reference.normalized_statement}
+                </div>
+              ))}
+            </div>
+          )}
+          {detail?.game_backlinks?.length > 0 && (
+            <div style={{ marginTop: '0.75rem' }}>
+              <strong style={{ fontSize: '0.78rem' }}>USED IN</strong>
+              <div style={{ display: 'grid', gap: '6px', marginTop: '6px' }}>
+                {detail.game_backlinks.map((backlink) => (
+                  <Link key={backlink.game_id} to={`/games/${backlink.slug}`} className="back-link">
+                    {backlink.title || backlink.slug}
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -10,6 +10,7 @@ import { ExternalLinks } from '../components/game/ExternalLinks'
 import { InfographicsGallery } from '../components/game/InfographicsGallery'
 import { QuickRulesPanel } from '../components/game/QuickRulesPanel'
 import { RuleFlowDiagram } from '../components/game/RuleFlowDiagram'
+import { ConceptGlossary } from '../components/game/ConceptGlossary'
 
 const IDENTITY_LABELS = {
   verified: 'IDENTITY VERIFIED',
@@ -186,16 +187,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
             </div>
           )}
 
-          {sd.keywords?.length > 0 && (
-            <div className="pro-card">
-              <div className="pro-card-title">GLOSSARY</div>
-              <div className="tag-list">
-                {sd.keywords.map((kw, i) => (
-                  <div key={i} className="tag-item" title={kw.description}>{kw.term}</div>
-                ))}
-              </div>
-            </div>
-          )}
+          <ConceptGlossary slug={slug} legacyKeywords={sd.keywords || []} />
 
           <div className="pro-card">
             <div className="pro-card-title">LINKS</div>


### PR DESCRIPTION
## Summary
- add stable Concept IDs, multilingual pref/alt labels, lifecycle and SKOS-like relations
- add `game_concepts` and `rule_node_concepts` to connect Concept Taxonomy v1 with Rule Graph v1
- expose concept detail, game concepts, and linked glossary APIs
- add GamePage linked glossary inspector with rule backlinks / used-in backlinks
- keep legacy `structured_data.keywords` as a fail-closed migration fallback only
- add versioned docs, fixtures, tests, and dedicated CI

## Linked-view contract
`Concept -> game_concepts -> Game`

`Concept -> rule_node_concepts -> RuleNode -> RuleSet -> Game`

The global concept definition stays separate from game-specific rule statements.

## Verification
CI must pass taxonomy contract tests and frontend build before merge.

Closes #150