### PR TITLE
Finish one-command curated game workflow

### DIFF
--- a/.github/workflows/curated-game-fast-path.yml
+++ b/.github/workflows/curated-game-fast-path.yml
@@ -1,0 +1,47 @@
+name: Curated game fast path
+
+on:
+  pull_request:
+    paths:
+      - "data/curated-games/**"
+      - "backend/app/scripts/curated_game_workflow.py"
+      - "backend/tests/test_curated_game_workflow.py"
+      - "frontend/src/lib/curatedRuleGuides.js"
+      - "frontend/src/lib/generatedCuratedRuleGuides.js"
+      - "Taskfile.yml"
+      - "docs/CURATED_GAME_FAST_PATH.md"
+      - ".github/workflows/curated-game-fast-path.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "data/curated-games/**"
+      - "backend/app/scripts/curated_game_workflow.py"
+      - "backend/tests/test_curated_game_workflow.py"
+      - "frontend/src/lib/curatedRuleGuides.js"
+      - "frontend/src/lib/generatedCuratedRuleGuides.js"
+      - "Taskfile.yml"
+      - "docs/CURATED_GAME_FAST_PATH.md"
+      - ".github/workflows/curated-game-fast-path.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  curated-game:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+      - name: Run focused workflow tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_curated_game_workflow.py
+      - name: Check structured inputs and generated registry
+        env:
+          PYTHONPATH: backend
+        run: uv run python backend/app/scripts/curated_game_workflow.py --all --offline --check-materialization

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -132,6 +132,43 @@ tasks:
     dir: backend
     cmd: uv run python -m app.scripts.validate_urls --hours 24
 
+  game:add:
+    desc: "一次情報付きゲームを検証→guide生成→DB upsert→本番確認 (SLUG=... SOURCE_URL=... DATA=data/curated-games/xxx.json)"
+    requires:
+      vars: [SLUG, SOURCE_URL, DATA]
+    dir: backend
+    cmd: >-
+      uv run python app/scripts/curated_game_workflow.py
+      --file "../{{.DATA}}"
+      --expected-slug "{{.SLUG}}"
+      --expected-source-url "{{.SOURCE_URL}}"
+      --write
+      --verify-production
+
+  game:check:
+    desc: "curated game入力とgenerated guideをofflineで検証 (DATA=...)"
+    requires:
+      vars: [DATA]
+    dir: backend
+    cmd: >-
+      uv run python app/scripts/curated_game_workflow.py
+      --file "../{{.DATA}}"
+      --offline
+      --check-materialization
+
+  game:verify:
+    desc: "既存curated gameの一次情報・generated guide・本番URLを再検証"
+    requires:
+      vars: [SLUG, SOURCE_URL, DATA]
+    dir: backend
+    cmd: >-
+      uv run python app/scripts/curated_game_workflow.py
+      --file "../{{.DATA}}"
+      --expected-slug "{{.SLUG}}"
+      --expected-source-url "{{.SOURCE_URL}}"
+      --check-materialization
+      --verify-production
+
   gemini:verify:
     desc: "Gemini model existence + generateContent smoke check"
     dir: backend

--- a/backend/app/scripts/curated_game_workflow.py
+++ b/backend/app/scripts/curated_game_workflow.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CURATED_DIR = REPO_ROOT / "data" / "curated-games"
+GENERATED_GUIDES_PATH = REPO_ROOT / "frontend" / "src" / "lib" / "generatedCuratedRuleGuides.js"
+CURATED_GUIDES_PATH = REPO_ROOT / "frontend" / "src" / "lib" / "curatedRuleGuides.js"
+DEFAULT_BASE_URL = "https://bodoge-no-mikata.vercel.app"
+SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+class WorkflowError(RuntimeError):
+    pass
+
+
+class WorkSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    canonical_title: str = Field(min_length=1)
+    identity_status: str = Field(pattern=r"^(verified|needs_review|unverified)$")
+
+
+class SourceSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(pattern=r"^https://")
+    rule_version: str = Field(min_length=1)
+    revision: str = Field(min_length=1)
+
+
+class AssertionSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(min_length=1)
+    equals: Any | None = None
+    contains: str | None = None
+
+    @model_validator(mode="after")
+    def require_one_operator(self):
+        has_equals = "equals" in self.model_fields_set
+        has_contains = "contains" in self.model_fields_set
+        if has_equals == has_contains:
+            raise ValueError("assertion requires exactly one of equals or contains")
+        if has_contains and not self.contains:
+            raise ValueError("contains must be non-empty")
+        return self
+
+
+class CuratedGameSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str
+    slug: str
+    work: WorkSpec
+    source: SourceSpec
+    game: dict[str, Any]
+    guide: dict[str, Any]
+    assertions: list[AssertionSpec] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_contract(self):
+        if self.schema_version != "1":
+            raise ValueError("schema_version must be 1")
+        if not SLUG_RE.fullmatch(self.slug):
+            raise ValueError("slug must be canonical kebab-case")
+        required_game = {
+            "slug",
+            "title",
+            "summary",
+            "rules_content",
+            "source_url",
+            "source_revision",
+            "generated_from_source_revision",
+        }
+        missing = sorted(key for key in required_game if not self.game.get(key))
+        if missing:
+            raise ValueError(f"game fields missing: {', '.join(missing)}")
+        if self.game["slug"] != self.slug:
+            raise ValueError("game.slug must match slug")
+        if self.game["source_url"] != self.source.url:
+            raise ValueError("game.source_url must match source.url")
+        if self.game["source_revision"] != self.source.revision:
+            raise ValueError("game.source_revision must match source.revision")
+        if self.game["generated_from_source_revision"] != self.source.revision:
+            raise ValueError("generated_from_source_revision must match source.revision")
+        if self.guide.get("reviewed") is not True:
+            raise ValueError("guide.reviewed must be true")
+        if self.guide.get("ruleVersion") != self.source.rule_version:
+            raise ValueError("guide.ruleVersion must match source.rule_version")
+        guide_source = self.guide.get("source") or {}
+        if guide_source.get("url") != self.source.url:
+            raise ValueError("guide.source.url must match source.url")
+        if guide_source.get("ruleVersion") != self.source.rule_version:
+            raise ValueError("guide.source.ruleVersion must match source.rule_version")
+        quick = self.guide.get("quick") or {}
+        if not quick.get("win") or not quick.get("end"):
+            raise ValueError("guide quick win/end are required")
+        if not quick.get("turnSteps") or not quick.get("turnEndChecks"):
+            raise ValueError("guide turnSteps/turnEndChecks are required")
+        if len(self.guide.get("flow") or []) < 2:
+            raise ValueError("guide flow requires at least two nodes")
+        return self
+
+
+@dataclass(frozen=True)
+class IdentityPlan:
+    game_id: str | None
+    work_id: str | None
+    create_work: bool
+
+
+def load_spec(path: Path) -> CuratedGameSpec:
+    return CuratedGameSpec.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def load_all_specs() -> list[CuratedGameSpec]:
+    paths = sorted(path for path in CURATED_DIR.glob("*.json") if not path.name.startswith("schema-"))
+    specs = [load_spec(path) for path in paths]
+    slugs = [spec.slug for spec in specs]
+    if len(slugs) != len(set(slugs)):
+        raise WorkflowError("duplicate slug in structured curated inputs")
+    return specs
+
+
+def get_path(value: Any, path: str) -> Any:
+    current = value
+    for segment in path.split("."):
+        if isinstance(current, dict) and segment in current:
+            current = current[segment]
+            continue
+        raise WorkflowError(f"assertion path not found: {path}")
+    return current
+
+
+def validate_assertions(spec: CuratedGameSpec) -> None:
+    for assertion in spec.assertions:
+        actual = get_path(spec.guide, assertion.path)
+        if "equals" in assertion.model_fields_set and actual != assertion.equals:
+            raise WorkflowError(f"assertion failed: {assertion.path} != {assertion.equals!r}")
+        if "contains" in assertion.model_fields_set:
+            expected = assertion.contains or ""
+            if isinstance(actual, list):
+                matched = any(expected in str(item) for item in actual)
+            else:
+                matched = expected in str(actual)
+            if not matched:
+                raise WorkflowError(f"assertion failed: {assertion.path} does not contain {expected!r}")
+
+
+def render_generated_registry(specs: list[CuratedGameSpec]) -> str:
+    registry = {spec.slug: spec.guide for spec in sorted(specs, key=lambda item: item.slug)}
+    rendered = json.dumps(registry, ensure_ascii=False, indent=2)
+    return f"export const GENERATED_CURATED_RULE_GUIDES = {rendered}\n"
+
+
+def materialize_registry(specs: list[CuratedGameSpec], check_only: bool) -> None:
+    expected = render_generated_registry(specs)
+    current = GENERATED_GUIDES_PATH.read_text(encoding="utf-8") if GENERATED_GUIDES_PATH.exists() else ""
+    if check_only:
+        if current != expected:
+            raise WorkflowError("generatedCuratedRuleGuides.js is stale; run task game:add or materialize the registry")
+        return
+    if current != expected:
+        GENERATED_GUIDES_PATH.write_text(expected, encoding="utf-8")
+
+
+def validate_runtime_guide(spec: CuratedGameSpec) -> None:
+    module_uri = CURATED_GUIDES_PATH.resolve().as_uri()
+    expression = (
+        f"import {{ getCuratedRuleGuide }} from {json.dumps(module_uri)}; "
+        f"process.stdout.write(JSON.stringify(getCuratedRuleGuide({json.dumps(spec.slug)})));"
+    )
+    result = subprocess.run(
+        ["node", "--input-type=module", "-e", expression],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    runtime_guide = json.loads(result.stdout or "null")
+    if runtime_guide != spec.guide:
+        raise WorkflowError(f"runtime curated guide differs from structured input: {spec.slug}")
+
+
+def verify_source_reachable(spec: CuratedGameSpec) -> None:
+    headers = {"User-Agent": "BodogeNoMikataSourceVerifier/1.0 (+https://bodoge-no-mikata.vercel.app/)"}
+    with httpx.Client(follow_redirects=True, timeout=20, headers=headers) as client:
+        response = client.get(spec.source.url)
+    if response.status_code < 200 or response.status_code >= 400:
+        raise WorkflowError(f"primary source is not reachable: HTTP {response.status_code} {spec.source.url}")
+
+
+def plan_identity(
+    spec: CuratedGameSpec,
+    slug_rows: list[dict[str, Any]],
+    work_rows: list[dict[str, Any]],
+    edition_rows: list[dict[str, Any]],
+) -> IdentityPlan:
+    if len(slug_rows) > 1:
+        raise WorkflowError(f"multiple games already use slug {spec.slug}")
+    if len(work_rows) > 1:
+        raise WorkflowError(f"multiple canonical works match {spec.work.canonical_title}")
+
+    slug_row = slug_rows[0] if slug_rows else None
+    work_row = work_rows[0] if work_rows else None
+
+    if slug_row:
+        slug_work_id = str(slug_row.get("work_id") or "") or None
+        if not slug_work_id:
+            raise WorkflowError(f"existing slug {spec.slug} has no canonical work_id")
+        if work_row and slug_work_id != str(work_row["id"]):
+            raise WorkflowError(f"slug {spec.slug} belongs to a different canonical work")
+        return IdentityPlan(game_id=str(slug_row["id"]), work_id=slug_work_id, create_work=False)
+
+    if work_row:
+        edition_label = spec.game.get("edition_label")
+        language_code = spec.game.get("language_code")
+        for row in edition_rows:
+            if row.get("edition_label") == edition_label and row.get("language_code") == language_code:
+                raise WorkflowError(
+                    f"canonical work already has this edition/language under slug {row.get('slug')}; refusing duplicate"
+                )
+        return IdentityPlan(game_id=None, work_id=str(work_row["id"]), create_work=False)
+
+    return IdentityPlan(game_id=None, work_id=None, create_work=True)
+
+
+def preflight_identity(client: Any, spec: CuratedGameSpec) -> IdentityPlan:
+    slug_rows = (
+        client.table("games")
+        .select("id,slug,work_id,edition_label,language_code,source_url,source_revision")
+        .eq("slug", spec.slug)
+        .execute()
+        .data
+    )
+    work_rows = (
+        client.table("game_works")
+        .select("id,canonical_title,identity_status")
+        .eq("canonical_title", spec.work.canonical_title)
+        .execute()
+        .data
+    )
+
+    if slug_rows and not work_rows:
+        slug_work_id = slug_rows[0].get("work_id")
+        if slug_work_id:
+            actual_work = client.table("game_works").select("id,canonical_title,identity_status").eq("id", slug_work_id).execute().data
+            if not actual_work or actual_work[0].get("canonical_title") != spec.work.canonical_title:
+                raise WorkflowError(f"slug {spec.slug} resolves to a different canonical work")
+            work_rows = actual_work
+
+    edition_rows: list[dict[str, Any]] = []
+    if work_rows:
+        edition_rows = (
+            client.table("games")
+            .select("id,slug,work_id,edition_label,language_code,source_url,source_revision")
+            .eq("work_id", work_rows[0]["id"])
+            .execute()
+            .data
+        )
+
+    return plan_identity(spec, slug_rows, work_rows, edition_rows)
+
+
+def write_catalog(spec: CuratedGameSpec) -> dict[str, Any]:
+    from app.core import supabase
+
+    client = supabase._get_client()
+    plan = preflight_identity(client, spec)
+    created_work_id: str | None = None
+    work_id = plan.work_id
+
+    if plan.create_work:
+        rows = (
+            client.table("game_works")
+            .insert({"canonical_title": spec.work.canonical_title, "identity_status": spec.work.identity_status})
+            .execute()
+            .data
+        )
+        if not rows:
+            raise WorkflowError("failed to create canonical game work")
+        created_work_id = str(rows[0]["id"])
+        work_id = created_work_id
+
+    payload = dict(spec.game)
+    payload["work_id"] = work_id
+
+    try:
+        if plan.game_id:
+            rows = client.table("games").update(payload).eq("id", plan.game_id).execute().data
+        else:
+            rows = client.table("games").insert(payload).execute().data
+    except Exception:
+        if created_work_id:
+            client.table("game_works").delete().eq("id", created_work_id).execute()
+        raise
+
+    if not rows:
+        raise WorkflowError("catalog write returned no game row")
+    return rows[0]
+
+
+def verify_production(spec: CuratedGameSpec, base_url: str) -> None:
+    base = base_url.rstrip("/")
+    with httpx.Client(follow_redirects=True, timeout=20) as client:
+        api_response = client.get(f"{base}/api/games/{spec.slug}")
+        if api_response.status_code != 200:
+            raise WorkflowError(f"production API failed: HTTP {api_response.status_code}")
+        payload = api_response.json()
+        if payload.get("slug") != spec.slug:
+            raise WorkflowError("production API returned the wrong slug")
+        if payload.get("source_url") != spec.source.url:
+            raise WorkflowError("production API source provenance does not match structured input")
+        if not payload.get("work_id"):
+            raise WorkflowError("production API record has no canonical work_id")
+
+        page_response = client.get(f"{base}/games/{spec.slug}")
+        if page_response.status_code != 200:
+            raise WorkflowError(f"production page failed: HTTP {page_response.status_code}")
+        expected_title = str(spec.game.get("title_ja") or spec.game["title"])
+        if expected_title not in page_response.text:
+            raise WorkflowError("production page does not contain the expected title")
+
+
+def validate_expectations(spec: CuratedGameSpec, expected_slug: str | None, expected_source_url: str | None) -> None:
+    if expected_slug is not None and spec.slug != expected_slug:
+        raise WorkflowError(f"expected slug {expected_slug}, got {spec.slug}")
+    if expected_source_url is not None and spec.source.url != expected_source_url:
+        raise WorkflowError("SOURCE_URL does not match the structured primary source")
+
+
+def print_pr_ready_files() -> None:
+    result = subprocess.run(
+        ["git", "status", "--short"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    paths = []
+    for line in result.stdout.splitlines():
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        if path:
+            paths.append(path)
+    print("PR-ready changed files:")
+    for path in sorted(set(paths)):
+        print(f"- {path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--file")
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("--expected-slug")
+    parser.add_argument("--expected-source-url")
+    parser.add_argument("--offline", action="store_true")
+    parser.add_argument("--check-materialization", action="store_true")
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--verify-production", action="store_true")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.all == bool(args.file):
+        raise WorkflowError("provide exactly one of --file or --all")
+
+    specs = load_all_specs() if args.all else [load_spec(Path(args.file).resolve())]
+    all_specs = load_all_specs()
+
+    for spec in specs:
+        validate_expectations(spec, args.expected_slug, args.expected_source_url)
+        validate_assertions(spec)
+        if not args.offline:
+            verify_source_reachable(spec)
+
+    materialize_registry(all_specs, args.check_materialization)
+
+    for spec in specs:
+        validate_runtime_guide(spec)
+        if args.write:
+            row = write_catalog(spec)
+            if row.get("slug") != spec.slug:
+                raise WorkflowError("catalog write returned unexpected slug")
+        if args.verify_production:
+            verify_production(spec, args.base_url)
+
+    print_pr_ready_files()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_curated_game_workflow.py
+++ b/backend/tests/test_curated_game_workflow.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+
+import pytest
+
+from app.scripts.curated_game_workflow import (
+    GENERATED_GUIDES_PATH,
+    WorkflowError,
+    load_all_specs,
+    load_spec,
+    plan_identity,
+    render_generated_registry,
+    validate_assertions,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKULL_KING = REPO_ROOT / "data" / "curated-games" / "skull-king.json"
+
+
+def test_skull_king_replays_from_structured_input_without_semantic_diff():
+    spec = load_spec(SKULL_KING)
+    validate_assertions(spec)
+
+    assert spec.slug == "skull-king"
+    assert spec.source.url == "https://www.grandpabecksgames.com/pages/skull-king"
+    assert spec.source.revision == "grandpa-becks-current-rulebook-accessed-2026-08-14"
+    assert spec.guide["facts"]["rounds"] == 10
+    assert spec.guide["scoring"]["summary"].find("配札枚数×10点") >= 0
+    assert render_generated_registry(load_all_specs()) == GENERATED_GUIDES_PATH.read_text(encoding="utf-8")
+
+
+def test_existing_slug_for_same_work_is_idempotent_update():
+    spec = load_spec(SKULL_KING)
+    plan = plan_identity(
+        spec,
+        slug_rows=[{"id": "game-1", "work_id": "work-1"}],
+        work_rows=[{"id": "work-1", "canonical_title": "Skull King"}],
+        edition_rows=[{"id": "game-1", "slug": "skull-king"}],
+    )
+
+    assert plan.game_id == "game-1"
+    assert plan.work_id == "work-1"
+    assert plan.create_work is False
+
+
+def test_slug_collision_with_different_work_fails_before_write():
+    spec = load_spec(SKULL_KING)
+    with pytest.raises(WorkflowError, match="different canonical work"):
+        plan_identity(
+            spec,
+            slug_rows=[{"id": "game-1", "work_id": "other-work"}],
+            work_rows=[{"id": "work-1", "canonical_title": "Skull King"}],
+            edition_rows=[],
+        )
+
+
+def test_duplicate_work_edition_under_another_slug_fails_before_write():
+    spec = load_spec(SKULL_KING)
+    with pytest.raises(WorkflowError, match="refusing duplicate"):
+        plan_identity(
+            spec,
+            slug_rows=[],
+            work_rows=[{"id": "work-1", "canonical_title": "Skull King"}],
+            edition_rows=[
+                {
+                    "id": "game-2",
+                    "slug": "skull-king-copy",
+                    "edition_label": "Grandpa Beck's Games current edition",
+                    "language_code": None,
+                }
+            ],
+        )

--- a/data/curated-games/schema-v1.json
+++ b/data/curated-games/schema-v1.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://bodoge-no-mikata.vercel.app/schemas/curated-game-v1.json",
+  "title": "ボドゲのミカタ curated game input v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "slug", "work", "source", "game", "guide", "assertions"],
+  "properties": {
+    "schema_version": {"const": "1"},
+    "slug": {"type": "string", "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$"},
+    "work": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["canonical_title", "identity_status"],
+      "properties": {
+        "canonical_title": {"type": "string", "minLength": 1},
+        "identity_status": {"enum": ["verified", "needs_review", "unverified"]}
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "rule_version", "revision"],
+      "properties": {
+        "url": {"type": "string", "pattern": "^https://"},
+        "rule_version": {"type": "string", "minLength": 1},
+        "revision": {"type": "string", "minLength": 1}
+      }
+    },
+    "game": {
+      "type": "object",
+      "required": ["slug", "title", "summary", "rules_content", "source_url", "source_revision", "generated_from_source_revision"],
+      "properties": {
+        "slug": {"type": "string"},
+        "title": {"type": "string", "minLength": 1},
+        "summary": {"type": "string", "minLength": 1},
+        "rules_content": {"type": "string", "minLength": 1},
+        "source_url": {"type": "string", "pattern": "^https://"},
+        "source_revision": {"type": "string", "minLength": 1},
+        "generated_from_source_revision": {"type": "string", "minLength": 1}
+      }
+    },
+    "guide": {
+      "type": "object",
+      "required": ["reviewed", "ruleVersion", "source", "facts", "quick", "scoring", "flow"],
+      "properties": {
+        "reviewed": {"const": true},
+        "ruleVersion": {"type": "string", "minLength": 1},
+        "source": {
+          "type": "object",
+          "required": ["label", "url", "ruleVersion"],
+          "properties": {
+            "label": {"type": "string", "minLength": 1},
+            "url": {"type": "string", "pattern": "^https://"},
+            "ruleVersion": {"type": "string", "minLength": 1}
+          }
+        },
+        "quick": {
+          "type": "object",
+          "required": ["win", "turnSteps", "turnEndChecks", "end"]
+        },
+        "flow": {"type": "array", "minItems": 2}
+      }
+    },
+    "assertions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path"],
+        "properties": {
+          "path": {"type": "string", "minLength": 1},
+          "equals": {},
+          "contains": {"type": "string", "minLength": 1}
+        },
+        "oneOf": [
+          {"required": ["equals"], "not": {"required": ["contains"]}},
+          {"required": ["contains"], "not": {"required": ["equals"]}}
+        ]
+      }
+    }
+  }
+}

--- a/data/curated-games/skull-king.json
+++ b/data/curated-games/skull-king.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": "1",
+  "slug": "skull-king",
+  "work": {
+    "canonical_title": "Skull King",
+    "identity_status": "verified"
+  },
+  "source": {
+    "url": "https://www.grandpabecksgames.com/pages/skull-king",
+    "rule_version": "grandpa-becks-current-2026-08-14",
+    "revision": "grandpa-becks-current-rulebook-accessed-2026-08-14"
+  },
+  "game": {
+    "slug": "skull-king",
+    "title": "Skull King",
+    "title_ja": "スカルキング",
+    "title_en": "Skull King",
+    "description": "Grandpa Beck's Gamesの現行版Skull King。通常ゲームは10ラウンドで、毎ラウンド配られた手札を見て獲得トリック数をビッドします。黒は切り札で、海賊・スカルキング・人魚などの特殊カードが通常の数字カードより強い相互作用を持ちます。ビッドを正確に当てることと、ボーナスカードを取ることが得点につながります。",
+    "summary": "各ラウンドで取るトリック数を予想してビッドし、予想どおりに取ることを目指す海賊テーマのトリックテイキング。",
+    "rules_content": "# スカルキング\n\n## 目的\n10ラウンドを通して得点し、終了時に合計得点が最も高いプレイヤーが勝ちます。各ラウンドの最初に、そのラウンドで自分が取るトリック数をビッドします。\n\n## 通常ゲームの準備\n1. ブランクカード、Loot、Kraken、White Whaleを通常デッキから外します。これらは任意の上級ルール用です。\n2. 残りのカードをシャッフルします。\n3. 第1ラウンドは1枚、第2ラウンドは2枚というように、通常はラウンド数と同じ枚数を各プレイヤーへ配ります。第10ラウンドは10枚です。8人戦では第9・第10ラウンドも8枚ずつ配ります。\n\n## ビッド\n手札を見て、そのラウンドで自分が取ると思うトリック数を宣言します。0もビッドできます。\n\n## 1トリックの流れ\n1. ディーラー左隣のプレイヤーが最初のトリックをリードし、以後は直前のトリックの勝者が次をリードします。\n2. 数字カードがリードされ、数字カードを出す場合、リードされたスートを持っていれば同じスートを出します。特殊カードはいつでも出せます。\n3. 全員が1枚ずつ出したら、最も強いカードを出したプレイヤーがトリックを取ります。\n\n## カードの基本関係\n- 緑・黄・紫は通常スートです。同じスート同士なら数字が高い方が勝ちます。\n- 黒（Jolly Roger）は切り札で、通常スートより強いです。\n- Pirateはすべての数字カードより強く、複数のPirateが出た場合は先に出たPirateが勝ちます。\n- Tigressは出したときにPirateまたはEscapeとして扱うかを選びます。\n- Skull Kingは数字カードとPirateに勝ち、Mermaidに負けます。\n- MermaidはSkull Kingと数字カードに勝ち、通常はPirateに負けます。ただしPirate・Skull King・Mermaidが同じトリックに揃った場合はMermaidが勝ちます。\n- Escapeは通常は負けます。全員がEscapeまたはEscape扱いのカードだけを出した場合は、最初に出たEscapeが勝ちます。\n\n## 得点\n### 1以上をビッド\n- ビッドどおりなら、取ったトリック1つにつき20点です。\n- 多くても少なくても、ビッドとの差1トリックにつき10点を失います。この場合、取ったトリック自体の得点はありません。\n\n### 0をビッド\n- 0トリックを達成すると、そのラウンドの配札枚数 × 10点を獲得します。\n- 1トリック以上取ると、そのラウンドの配札枚数 × 10点を失います。\n\n### ボーナス\nボーナスはビッドを成功させたラウンドだけ得られます。\n- 緑・黄・紫の14を取る: 各10点\n- 黒の14を取る: 20点\n- PirateでMermaidを取る: Mermaid 1枚につき20点\n- Skull KingでPirateを取る: Pirate 1枚につき30点\n- MermaidでSkull Kingを取る: 40点\n\n## ゲーム終了\n10ラウンド終了後に合計得点を比べます。同点なら、決着するまで追加ラウンドを行います。\n\n## 2人プレイ\n現行版には「Graybeard's Ghost」を使う専用の2人ルールがあります。通常の3人以上の手順とは一部処理が異なるため、2人で遊ぶ場合は公式ルールブックの2人用項目を参照してください。",
+    "setup_summary": "通常ルールでは上級カードを外してシャッフルし、通常はラウンド数と同じ枚数を配る。8人戦の第9・第10ラウンドは8枚ずつ。",
+    "gameplay_summary": "各ラウンドで獲得トリック数をビッドし、数字カードのフォロー義務と特殊カードの例外に従って全手札をプレイする。",
+    "end_game_summary": "10ラウンド終了時に合計得点が最も高いプレイヤーが勝利。同点なら決着まで追加ラウンド。",
+    "min_players": 2,
+    "max_players": 8,
+    "min_age": 8,
+    "published_year": 2013,
+    "publisher": "Grandpa Beck's Games",
+    "edition_label": "Grandpa Beck's Games current edition",
+    "language_code": null,
+    "official_url": "https://www.grandpabecksgames.com/products/copy-of-skull-king%C2%AE",
+    "bga_url": "https://ja.boardgamearena.com/gamepanel?game=skullking",
+    "source_url": "https://www.grandpabecksgames.com/pages/skull-king",
+    "source_revision": "grandpa-becks-current-rulebook-accessed-2026-08-14",
+    "generated_from_source_revision": "grandpa-becks-current-rulebook-accessed-2026-08-14",
+    "source_trust": "official_publisher",
+    "identity_status": "verified",
+    "structured_data": {
+      "keywords": [
+        {"term": "ビッド", "description": "そのラウンドで自分が取ると予想するトリック数。"},
+        {"term": "トリック", "description": "全員が1枚ずつカードを出し、最も強いカードを出した人が取る1回分の勝負。"},
+        {"term": "切り札", "description": "通常スートより強いスート。Skull Kingでは黒のJolly Roger。"},
+        {"term": "特殊カード", "description": "Pirate、Tigress、Skull King、Mermaid、Escapeなど、数字を持たないカード。"}
+      ],
+      "mechanics": ["Trick-taking", "Bidding"],
+      "pro_tips": [],
+      "rule_mistakes": [
+        "数字カードをフォローできる状況でも、特殊カードは出せる。",
+        "Pirate・Skull King・Mermaidが同じトリックに出た場合はMermaidが勝つ。",
+        "ボーナス点はそのラウンドのビッド成功時だけ得られる。"
+      ],
+      "source_documents": [
+        {
+          "url": "https://www.grandpabecksgames.com/pages/skull-king",
+          "type": "publisher_official",
+          "label": "Grandpa Beck's Games — Skull King rules",
+          "locator": "Current rulebook: Setup, Game Play, The Cards, Scoring, Bonus Points, Two-Player Rules",
+          "accessed_at": "2026-08-14"
+        },
+        {
+          "url": "https://www.grandpabecksgames.com/products/copy-of-skull-king%C2%AE",
+          "type": "publisher_official",
+          "label": "Grandpa Beck's Games — Skull King product",
+          "locator": "Players 2-8; Ages 8-99; Minutes 30-45; current edition notes",
+          "accessed_at": "2026-08-14"
+        },
+        {
+          "url": "https://ja.boardgamearena.com/gamepanel?game=skullking",
+          "type": "platform_official_game_page",
+          "label": "Board Game Arena — スカルキング(Skull King)",
+          "locator": "Japanese title, publisher, year, platform implementation and rules summary",
+          "accessed_at": "2026-08-14"
+        }
+      ],
+      "generation_provenance": {
+        "model": "GPT-5.6 Sol",
+        "source_bound": true,
+        "golden_version": "not-applicable",
+        "prompt_version": "manual-primary-source-ingest-2026-08-14",
+        "content_review_status": "ai_draft"
+      }
+    }
+  },
+  "guide": {
+    "reviewed": true,
+    "ruleVersion": "grandpa-becks-current-2026-08-14",
+    "source": {
+      "label": "Grandpa Beck's Games 公式ルール",
+      "url": "https://www.grandpabecksgames.com/pages/skull-king",
+      "ruleVersion": "grandpa-becks-current-2026-08-14"
+    },
+    "facts": {
+      "rounds": 10,
+      "actionCount": 3,
+      "suits": 4,
+      "trumpSuit": "black"
+    },
+    "quick": {
+      "win": "各ラウンドで取るトリック数をビッドし、予想どおりに取って得点する。10ラウンド終了時の合計得点を最も高くする。",
+      "actions": [
+        "数字カードがリードされたら、数字カードを出す場合は同じスートを持っていればそのスートを出す。特殊カードはいつでも出せる。",
+        "黒は切り札。Pirateは数字カードより強く、Skull KingはPirateより強い。MermaidはSkull Kingに勝つ。",
+        "Pirate・Skull King・Mermaidが同じトリックに出た場合は、順番に関係なくMermaidが勝つ。"
+      ],
+      "turnSteps": [
+        "リード役が手札から1枚出す。",
+        "時計回りに各プレイヤーが1枚ずつ出す。数字カードをフォローする場合はリードされたスートに従い、特殊カードはいつでも出せる。",
+        "全員が1枚出したら最も強いカードがトリックを取り、その勝者が次のトリックをリードする。"
+      ],
+      "turnEndChecks": [
+        "自分が取ったトリック数と、ラウンド開始時のビッドを確認する。",
+        "配られたカードをすべて使ったらラウンド終了。ビッドと獲得トリック数から得点し、ビッド成功時だけボーナスを加える。"
+      ],
+      "end": "10ラウンド終了時に合計得点が最も高いプレイヤーが勝つ。同点なら決着するまで追加ラウンドを行う。"
+    },
+    "scoring": {
+      "summary": "1以上のビッドは的中で1トリック20点、外すと差1トリックごとに-10点。0ビッドは成功で配札枚数×10点、失敗で配札枚数×-10点。ボーナスはビッド成功時だけ加算する。",
+      "rules": [
+        {
+          "label": "1以上をビッド",
+          "detail": "ビッドどおりなら取ったトリック1つにつき+20点。多すぎても少なすぎても、差1トリックにつき-10点。外した場合は取ったトリック自体の得点はない。"
+        },
+        {
+          "label": "0をビッド",
+          "detail": "0トリックなら、そのラウンドの配札枚数×10点。1トリック以上取ると、その配札枚数×-10点。"
+        },
+        {
+          "label": "14のボーナス",
+          "detail": "ビッド成功時、緑・黄・紫の14は各+10点、黒の14は+20点。"
+        },
+        {
+          "label": "キャラクターボーナス",
+          "detail": "ビッド成功時、PirateでMermaidを取ると各+20点、Skull KingでPirateを取ると各+30点、MermaidでSkull Kingを取ると+40点。"
+        }
+      ],
+      "example": {
+        "label": "公式ルールの0ビッド例",
+        "total": 70,
+        "items": ["第7ラウンド", "0をビッド", "0トリック成功", "10点 × 配札7枚 = 70点"]
+      }
+    },
+    "flow": [
+      {"id": "deal", "kind": "step", "label": "ラウンドに応じた枚数を配る", "note": "通常は1枚から10枚。8人戦の第9・第10ラウンドは8枚ずつ"},
+      {"id": "bid", "kind": "step", "label": "取ると思うトリック数をビッドする"},
+      {"id": "lead", "kind": "step", "label": "リード役がカードを1枚出す"},
+      {
+        "id": "follow",
+        "kind": "condition",
+        "label": "数字カードがリードされた？",
+        "branches": [
+          {"label": "はい", "detail": "数字カードを出すなら、持っている限り同じスートを出す。特殊カードは出せる"},
+          {"label": "いいえ", "detail": "特殊カードのリード規則に従う"}
+        ]
+      },
+      {"id": "winner", "kind": "step", "label": "最も強いカードがトリックを取る"},
+      {
+        "id": "cards-left",
+        "kind": "condition",
+        "label": "手札が残っている？",
+        "branches": [
+          {"label": "はい", "detail": "トリックの勝者が次をリード"},
+          {"label": "いいえ", "detail": "得点計算へ"}
+        ]
+      },
+      {"id": "score-round", "kind": "step", "label": "ビッドと獲得トリック数から得点する"},
+      {
+        "id": "round-ten",
+        "kind": "condition",
+        "label": "10ラウンド終わった？",
+        "branches": [
+          {"label": "いいえ", "detail": "全カードを混ぜて次のラウンドへ"},
+          {"label": "はい", "detail": "合計得点で勝者を決定"}
+        ]
+      },
+      {"id": "score", "kind": "end", "label": "最高得点者が勝利。同点なら追加ラウンド"}
+    ]
+  },
+  "assertions": [
+    {"path": "facts.rounds", "equals": 10},
+    {"path": "quick.end", "contains": "10ラウンド"},
+    {"path": "quick.actions", "contains": "Pirate・Skull King・Mermaidが同じトリックに出た場合は、順番に関係なくMermaidが勝つ。"},
+    {"path": "scoring.summary", "contains": "1トリック20点"},
+    {"path": "scoring.summary", "contains": "配札枚数×10点"},
+    {"path": "source.url", "equals": "https://www.grandpabecksgames.com/pages/skull-king"}
+  ]
+}

--- a/docs/CURATED_GAME_FAST_PATH.md
+++ b/docs/CURATED_GAME_FAST_PATH.md
@@ -6,17 +6,77 @@ Status: canonical operator workflow for source-grounded game additions.
 
 Add one verified game to ボドゲのミカタ with the smallest safe change set and no unrelated repair work.
 
+## One-command path
+
+Prepare one structured file under `data/curated-games/<slug>.json`, then run:
+
+```bash
+task game:add \
+  SLUG=skull-king \
+  SOURCE_URL=https://www.grandpabecksgames.com/pages/skull-king \
+  DATA=data/curated-games/skull-king.json
+```
+
+`game:add` performs the fixed path in one process:
+
+1. validates the structured input and source/revision contract;
+2. checks the primary source URL is reachable;
+3. validates focused game assertions;
+4. materializes `frontend/src/lib/generatedCuratedRuleGuides.js` from every structured curated input;
+5. validates the runtime guide returned by `getCuratedRuleGuide(slug)`;
+6. checks production `slug -> work` identity before any write;
+7. updates the existing canonical edition idempotently, or creates one canonical work+edition when none exists;
+8. verifies the production API provenance and `/games/{slug}` page once;
+9. prints the exact PR-ready changed-file set.
+
+A slug collision with a different canonical work fails before mutation. A canonical work that already has the same edition/language under another slug also fails before mutation.
+
+## Structured input contract
+
+`data/curated-games/schema-v1.json` defines the versioned external contract. Each file contains:
+
+- `work`: canonical work title and identity status;
+- `source`: explicit HTTPS primary source, rule version, and source revision;
+- `game`: the production catalog payload, including `source_url`, `source_revision`, and `generated_from_source_revision`;
+- `guide`: the reviewed Quick Rules/scoring/flow object;
+- `assertions`: focused facts that must remain true for this game.
+
+The workflow also enforces cross-field invariants that JSON Schema alone cannot express: slug equality, source URL equality, source revision equality, and guide/source rule-version equality.
+
+## Generated guide boundary
+
+`frontend/src/lib/generatedCuratedRuleGuides.js` is generated output. Do not hand-edit it.
+
+Structured curated games are merged into the runtime registry by `frontend/src/lib/curatedRuleGuides.js`. Legacy hand-maintained guides may remain there, but migrated games must exist only in the structured input/generated registry. Skull King is the replay fixture for this contract.
+
 ## Fast path
 
 1. **Lock one current primary source.** Record the official URL and the source/revision date. Do not keep searching after the primary source is sufficient unless a contradiction appears.
-2. **Check canonical identity once.** Search the production catalog for the work/slug before any write. If the game already exists, update that record instead of creating a duplicate.
-3. **Prepare only two content changes.** Add/update the curated guide entry and one focused regression assertion for the game-specific facts that are easiest to regress.
-4. **Run targeted validation first.** Build/lint only what the changed paths require and run the focused rule-guide/source-quality gate. Do not run repository-wide diagnostics before a targeted gate fails.
-5. **Perform the idempotent data upsert once.** Use the existing canonical import path. Re-read the resulting record once; do not repeatedly poll it.
-6. **Use one branch and one PR.** Do not create replacement branches/PRs for the same game unless the canonical branch is unusable.
+2. **Check canonical identity once.** The command checks the production catalog for the work/slug before any write. If the same canonical edition already exists, update it instead of creating a duplicate.
+3. **Prepare one structured file.** Do not hand-edit a large JS guide block or create a game-specific import script.
+4. **Run `task game:add` once.** It handles validation, materialization, the idempotent DB write, production verification, and changed-file reporting.
+5. **Open one branch and one PR.** Do not create replacement branches/PRs for the same game unless the canonical branch is unusable.
+6. **Use the targeted CI gate first.** `Curated game fast path` runs the workflow unit tests plus offline materialization/runtime checks without installing browsers or running the full UI suite.
 7. **Retry a flaky CI job at most once.** Re-run the failed job/run directly. If it fails again, preserve the canonical work line and report the blocker.
-8. **Separate unrelated infrastructure failures.** If game-specific build/rule/source gates pass but deployment infrastructure fails, open/link a separate infrastructure Issue. Do not repair deployment internals inside the game-add task.
-9. **Verify production once.** Check `/games/{slug}` for HTTP success and the expected title/source-bound content. Stop after the fixed point is established.
+8. **Separate unrelated infrastructure failures.** If the curated-game gate passes but generic deployment infrastructure fails, open/link a separate infrastructure Issue. Do not repair deployment internals inside the game-add task.
+9. **Merge once and stop after the fixed point.** `task game:verify` is available when a post-merge production re-check is required.
+
+## Commands
+
+Offline validation without writes or source/network checks:
+
+```bash
+task game:check DATA=data/curated-games/skull-king.json
+```
+
+Post-merge production verification without a database write:
+
+```bash
+task game:verify \
+  SLUG=skull-king \
+  SOURCE_URL=https://www.grandpabecksgames.com/pages/skull-king \
+  DATA=data/curated-games/skull-king.json
+```
 
 ## Minimal completion evidence
 
@@ -24,9 +84,10 @@ A game-add task is complete when all of these are true:
 
 - the production catalog contains exactly one canonical game identity for the intended work/edition;
 - the current primary source URL/revision is stored;
-- the curated guide has focused regression coverage;
-- the game-specific CI gates pass;
-- the production game URL returns the expected game content.
+- the structured guide has focused regression assertions;
+- generated guide output is current and runtime-visible;
+- the targeted curated-game CI gate passes;
+- the production API returns matching source provenance and the production game page returns the expected title.
 
 A general deployment workflow failure does not invalidate an already-live database-backed game page. It becomes a separate infrastructure blocker unless the requested game content itself is unavailable.
 
@@ -39,7 +100,8 @@ During a game-add task, do not:
 - perform repeated repository-wide searches after canonical paths are known;
 - create multiple speculative PRs;
 - rerun full CI suites to diagnose a single targeted failure before reading the failed job;
-- continue source research after the official source is locked without contradictory evidence.
+- continue source research after the official source is locked without contradictory evidence;
+- hand-edit `generatedCuratedRuleGuides.js`.
 
 ## Success retrospective
 
@@ -52,7 +114,3 @@ After a successful addition, spend one short pass on workflow improvement:
 5. stop when no reusable improvement remains.
 
 Do not turn the retrospective into a second implementation project. Reusable improvements belong in a separate Issue/PR unless they are a trivial documentation/task wrapper change.
-
-## Current automation target
-
-Issue #163 tracks the next step: structured per-game input plus a one-command evidence-gated materialization/validation workflow.

--- a/frontend/src/lib/curatedRuleGuides.js
+++ b/frontend/src/lib/curatedRuleGuides.js
@@ -1,3 +1,5 @@
+import { GENERATED_CURATED_RULE_GUIDES } from './generatedCuratedRuleGuides.js'
+
 const GUIDES = {
   ipso: {
     reviewed: true,
@@ -77,100 +79,6 @@ const GUIDES = {
       { id: 'score', kind: 'end', label: '全員の最終処理後、得点計算して終了' },
     ],
   },
-  'skull-king': {
-    reviewed: true,
-    ruleVersion: 'grandpa-becks-current-2026-08-14',
-    source: {
-      label: "Grandpa Beck's Games 公式ルール",
-      url: 'https://www.grandpabecksgames.com/pages/skull-king',
-      ruleVersion: 'grandpa-becks-current-2026-08-14',
-    },
-    facts: {
-      rounds: 10,
-      actionCount: 3,
-      suits: 4,
-      trumpSuit: 'black',
-    },
-    quick: {
-      win: '各ラウンドで取るトリック数をビッドし、予想どおりに取って得点する。10ラウンド終了時の合計得点を最も高くする。',
-      actions: [
-        '数字カードがリードされたら、数字カードを出す場合は同じスートを持っていればそのスートを出す。特殊カードはいつでも出せる。',
-        '黒は切り札。Pirateは数字カードより強く、Skull KingはPirateより強い。MermaidはSkull Kingに勝つ。',
-        'Pirate・Skull King・Mermaidが同じトリックに出た場合は、順番に関係なくMermaidが勝つ。',
-      ],
-      turnSteps: [
-        'リード役が手札から1枚出す。',
-        '時計回りに各プレイヤーが1枚ずつ出す。数字カードをフォローする場合はリードされたスートに従い、特殊カードはいつでも出せる。',
-        '全員が1枚出したら最も強いカードがトリックを取り、その勝者が次のトリックをリードする。',
-      ],
-      turnEndChecks: [
-        '自分が取ったトリック数と、ラウンド開始時のビッドを確認する。',
-        '配られたカードをすべて使ったらラウンド終了。ビッドと獲得トリック数から得点し、ビッド成功時だけボーナスを加える。',
-      ],
-      end: '10ラウンド終了時に合計得点が最も高いプレイヤーが勝つ。同点なら決着するまで追加ラウンドを行う。',
-    },
-    scoring: {
-      summary: '1以上のビッドは的中で1トリック20点、外すと差1トリックごとに-10点。0ビッドは成功で配札枚数×10点、失敗で配札枚数×-10点。ボーナスはビッド成功時だけ加算する。',
-      rules: [
-        {
-          label: '1以上をビッド',
-          detail: 'ビッドどおりなら取ったトリック1つにつき+20点。多すぎても少なすぎても、差1トリックにつき-10点。外した場合は取ったトリック自体の得点はない。',
-        },
-        {
-          label: '0をビッド',
-          detail: '0トリックなら、そのラウンドの配札枚数×10点。1トリック以上取ると、その配札枚数×-10点。',
-        },
-        {
-          label: '14のボーナス',
-          detail: 'ビッド成功時、緑・黄・紫の14は各+10点、黒の14は+20点。',
-        },
-        {
-          label: 'キャラクターボーナス',
-          detail: 'ビッド成功時、PirateでMermaidを取ると各+20点、Skull KingでPirateを取ると各+30点、MermaidでSkull Kingを取ると+40点。',
-        },
-      ],
-      example: {
-        label: '公式ルールの0ビッド例',
-        total: 70,
-        items: ['第7ラウンド', '0をビッド', '0トリック成功', '10点 × 配札7枚 = 70点'],
-      },
-    },
-    flow: [
-      { id: 'deal', kind: 'step', label: 'ラウンドに応じた枚数を配る', note: '通常は1枚から10枚。8人戦の第9・第10ラウンドは8枚ずつ' },
-      { id: 'bid', kind: 'step', label: '取ると思うトリック数をビッドする' },
-      { id: 'lead', kind: 'step', label: 'リード役がカードを1枚出す' },
-      {
-        id: 'follow',
-        kind: 'condition',
-        label: '数字カードがリードされた？',
-        branches: [
-          { label: 'はい', detail: '数字カードを出すなら、持っている限り同じスートを出す。特殊カードは出せる' },
-          { label: 'いいえ', detail: '特殊カードのリード規則に従う' },
-        ],
-      },
-      { id: 'winner', kind: 'step', label: '最も強いカードがトリックを取る' },
-      {
-        id: 'cards-left',
-        kind: 'condition',
-        label: '手札が残っている？',
-        branches: [
-          { label: 'はい', detail: 'トリックの勝者が次をリード' },
-          { label: 'いいえ', detail: '得点計算へ' },
-        ],
-      },
-      { id: 'score-round', kind: 'step', label: 'ビッドと獲得トリック数から得点する' },
-      {
-        id: 'round-ten',
-        kind: 'condition',
-        label: '10ラウンド終わった？',
-        branches: [
-          { label: 'いいえ', detail: '全カードを混ぜて次のラウンドへ' },
-          { label: 'はい', detail: '合計得点で勝者を決定' },
-        ],
-      },
-      { id: 'score', kind: 'end', label: '最高得点者が勝利。同点なら追加ラウンド' },
-    ],
-  },
   splendor: {
     reviewed: true,
     ruleVersion: 'space-cowboys-2024',
@@ -224,6 +132,7 @@ const GUIDES = {
       { id: 'end', kind: 'condition', label: '手番終了時に15点以上？', branches: [{ label: 'はい', detail: '全員の手番回数を揃えて終了' }, { label: 'いいえ', detail: '次のプレイヤーへ' }] },
     ],
   },
+  ...GENERATED_CURATED_RULE_GUIDES,
 }
 
 export function validateRuleGuide(guide) {

--- a/frontend/src/lib/generatedCuratedRuleGuides.js
+++ b/frontend/src/lib/generatedCuratedRuleGuides.js
@@ -1,0 +1,144 @@
+export const GENERATED_CURATED_RULE_GUIDES = {
+  "skull-king": {
+    "reviewed": true,
+    "ruleVersion": "grandpa-becks-current-2026-08-14",
+    "source": {
+      "label": "Grandpa Beck's Games 公式ルール",
+      "url": "https://www.grandpabecksgames.com/pages/skull-king",
+      "ruleVersion": "grandpa-becks-current-2026-08-14"
+    },
+    "facts": {
+      "rounds": 10,
+      "actionCount": 3,
+      "suits": 4,
+      "trumpSuit": "black"
+    },
+    "quick": {
+      "win": "各ラウンドで取るトリック数をビッドし、予想どおりに取って得点する。10ラウンド終了時の合計得点を最も高くする。",
+      "actions": [
+        "数字カードがリードされたら、数字カードを出す場合は同じスートを持っていればそのスートを出す。特殊カードはいつでも出せる。",
+        "黒は切り札。Pirateは数字カードより強く、Skull KingはPirateより強い。MermaidはSkull Kingに勝つ。",
+        "Pirate・Skull King・Mermaidが同じトリックに出た場合は、順番に関係なくMermaidが勝つ。"
+      ],
+      "turnSteps": [
+        "リード役が手札から1枚出す。",
+        "時計回りに各プレイヤーが1枚ずつ出す。数字カードをフォローする場合はリードされたスートに従い、特殊カードはいつでも出せる。",
+        "全員が1枚出したら最も強いカードがトリックを取り、その勝者が次のトリックをリードする。"
+      ],
+      "turnEndChecks": [
+        "自分が取ったトリック数と、ラウンド開始時のビッドを確認する。",
+        "配られたカードをすべて使ったらラウンド終了。ビッドと獲得トリック数から得点し、ビッド成功時だけボーナスを加える。"
+      ],
+      "end": "10ラウンド終了時に合計得点が最も高いプレイヤーが勝つ。同点なら決着するまで追加ラウンドを行う。"
+    },
+    "scoring": {
+      "summary": "1以上のビッドは的中で1トリック20点、外すと差1トリックごとに-10点。0ビッドは成功で配札枚数×10点、失敗で配札枚数×-10点。ボーナスはビッド成功時だけ加算する。",
+      "rules": [
+        {
+          "label": "1以上をビッド",
+          "detail": "ビッドどおりなら取ったトリック1つにつき+20点。多すぎても少なすぎても、差1トリックにつき-10点。外した場合は取ったトリック自体の得点はない。"
+        },
+        {
+          "label": "0をビッド",
+          "detail": "0トリックなら、そのラウンドの配札枚数×10点。1トリック以上取ると、その配札枚数×-10点。"
+        },
+        {
+          "label": "14のボーナス",
+          "detail": "ビッド成功時、緑・黄・紫の14は各+10点、黒の14は+20点。"
+        },
+        {
+          "label": "キャラクターボーナス",
+          "detail": "ビッド成功時、PirateでMermaidを取ると各+20点、Skull KingでPirateを取ると各+30点、MermaidでSkull Kingを取ると+40点。"
+        }
+      ],
+      "example": {
+        "label": "公式ルールの0ビッド例",
+        "total": 70,
+        "items": [
+          "第7ラウンド",
+          "0をビッド",
+          "0トリック成功",
+          "10点 × 配札7枚 = 70点"
+        ]
+      }
+    },
+    "flow": [
+      {
+        "id": "deal",
+        "kind": "step",
+        "label": "ラウンドに応じた枚数を配る",
+        "note": "通常は1枚から10枚。8人戦の第9・第10ラウンドは8枚ずつ"
+      },
+      {
+        "id": "bid",
+        "kind": "step",
+        "label": "取ると思うトリック数をビッドする"
+      },
+      {
+        "id": "lead",
+        "kind": "step",
+        "label": "リード役がカードを1枚出す"
+      },
+      {
+        "id": "follow",
+        "kind": "condition",
+        "label": "数字カードがリードされた？",
+        "branches": [
+          {
+            "label": "はい",
+            "detail": "数字カードを出すなら、持っている限り同じスートを出す。特殊カードは出せる"
+          },
+          {
+            "label": "いいえ",
+            "detail": "特殊カードのリード規則に従う"
+          }
+        ]
+      },
+      {
+        "id": "winner",
+        "kind": "step",
+        "label": "最も強いカードがトリックを取る"
+      },
+      {
+        "id": "cards-left",
+        "kind": "condition",
+        "label": "手札が残っている？",
+        "branches": [
+          {
+            "label": "はい",
+            "detail": "トリックの勝者が次をリード"
+          },
+          {
+            "label": "いいえ",
+            "detail": "得点計算へ"
+          }
+        ]
+      },
+      {
+        "id": "score-round",
+        "kind": "step",
+        "label": "ビッドと獲得トリック数から得点する"
+      },
+      {
+        "id": "round-ten",
+        "kind": "condition",
+        "label": "10ラウンド終わった？",
+        "branches": [
+          {
+            "label": "いいえ",
+            "detail": "全カードを混ぜて次のラウンドへ"
+          },
+          {
+            "label": "はい",
+            "detail": "合計得点で勝者を決定"
+          }
+        ]
+      },
+      {
+        "id": "score",
+        "kind": "end",
+        "label": "最高得点者が勝利。同点なら追加ラウンド"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #163

## What changed
- add versioned structured curated-game schema and migrate Skull King to structured input
- add a one-command `task game:add` workflow: source reachability → assertions → generated guide → canonical identity preflight → idempotent DB write → production verification → PR-ready file list
- reject slug/work collisions before writes
- generate `generatedCuratedRuleGuides.js` deterministically and validate the runtime guide
- add focused Python regression tests and a path-scoped CI gate without Playwright/browser installation
- document `game:add`, `game:check`, and `game:verify`

## Efficiency boundary
- no full UI suite is required for the curated-game gate
- no Vercel/deployment repair is performed inside this workflow
- Skull King is the replay fixture and must produce no semantic guide diff

## Acceptance criteria
All #163 criteria are implemented in this PR; CI will verify structured replay, identity fail-closed behavior, generated registry freshness, and runtime integration.