### PR TITLE
Refine curated game fast path to single-input v2

### DIFF
--- a/.github/workflows/curated-game-fast-path.yml
+++ b/.github/workflows/curated-game-fast-path.yml
@@ -5,24 +5,32 @@ on:
     paths:
       - "data/curated-games/**"
       - "backend/app/scripts/curated_game_workflow.py"
+      - "backend/app/scripts/curated_game_fast_path_v2.py"
       - "backend/tests/test_curated_game_workflow.py"
+      - "backend/tests/test_curated_game_fast_path_v2.py"
       - "frontend/src/lib/curatedRuleGuides.js"
       - "frontend/src/lib/generatedCuratedRuleGuides.js"
+      - "frontend/public/curated-guides-manifest.json"
       - "Taskfile.yml"
       - "docs/CURATED_GAME_FAST_PATH.md"
       - ".github/workflows/curated-game-fast-path.yml"
+      - ".github/workflows/curated-game-release-verification.yml"
   push:
     branches:
       - main
     paths:
       - "data/curated-games/**"
       - "backend/app/scripts/curated_game_workflow.py"
+      - "backend/app/scripts/curated_game_fast_path_v2.py"
       - "backend/tests/test_curated_game_workflow.py"
+      - "backend/tests/test_curated_game_fast_path_v2.py"
       - "frontend/src/lib/curatedRuleGuides.js"
       - "frontend/src/lib/generatedCuratedRuleGuides.js"
+      - "frontend/public/curated-guides-manifest.json"
       - "Taskfile.yml"
       - "docs/CURATED_GAME_FAST_PATH.md"
       - ".github/workflows/curated-game-fast-path.yml"
+      - ".github/workflows/curated-game-release-verification.yml"
 
 permissions:
   contents: read
@@ -40,8 +48,11 @@ jobs:
       - name: Run focused workflow tests
         env:
           PYTHONPATH: backend
-        run: uv run pytest -q backend/tests/test_curated_game_workflow.py
-      - name: Check structured inputs and generated registry
+        run: >-
+          uv run pytest -q
+          backend/tests/test_curated_game_workflow.py
+          backend/tests/test_curated_game_fast_path_v2.py
+      - name: Check all structured inputs and generated release artifacts
         env:
           PYTHONPATH: backend
-        run: uv run python backend/app/scripts/curated_game_workflow.py --all --offline --check-materialization
+        run: uv run python backend/app/scripts/curated_game_fast_path_v2.py check-all

--- a/.github/workflows/curated-game-release-verification.yml
+++ b/.github/workflows/curated-game-release-verification.yml
@@ -1,0 +1,30 @@
+name: Curated game release verification
+
+on:
+  workflow_run:
+    workflows: ["Vercel Deployment"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      - name: Install Python dependencies
+        run: uv sync --frozen
+      - name: Verify deployed curated registry revision
+        env:
+          PYTHONPATH: backend
+        run: uv run python backend/app/scripts/curated_game_fast_path_v2.py release-check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -133,41 +133,30 @@ tasks:
     cmd: uv run python -m app.scripts.validate_urls --hours 24
 
   game:add:
-    desc: "一次情報付きゲームを検証→guide生成→DB upsert→本番確認 (SLUG=... SOURCE_URL=... DATA=data/curated-games/xxx.json)"
+    desc: "curated gameを一次情報検証→identity preflight→生成→DB公開→catalog確認 (GAME=<slug>)"
     requires:
-      vars: [SLUG, SOURCE_URL, DATA]
+      vars: [GAME]
     dir: backend
-    cmd: >-
-      uv run python app/scripts/curated_game_workflow.py
-      --file "../{{.DATA}}"
-      --expected-slug "{{.SLUG}}"
-      --expected-source-url "{{.SOURCE_URL}}"
-      --write
-      --verify-production
+    cmd: uv run python app/scripts/curated_game_fast_path_v2.py add --game "{{.GAME}}"
 
   game:check:
-    desc: "curated game入力とgenerated guideをofflineで検証 (DATA=...)"
+    desc: "curated game入力・generated guide・deployment manifestをoffline検証 (GAME=<slug>)"
     requires:
-      vars: [DATA]
+      vars: [GAME]
     dir: backend
-    cmd: >-
-      uv run python app/scripts/curated_game_workflow.py
-      --file "../{{.DATA}}"
-      --offline
-      --check-materialization
+    cmd: uv run python app/scripts/curated_game_fast_path_v2.py check --game "{{.GAME}}"
 
   game:verify:
-    desc: "既存curated gameの一次情報・generated guide・本番URLを再検証"
+    desc: "catalogとfrontend releaseの両fixed pointを検証 (GAME=<slug>)"
     requires:
-      vars: [SLUG, SOURCE_URL, DATA]
+      vars: [GAME]
     dir: backend
-    cmd: >-
-      uv run python app/scripts/curated_game_workflow.py
-      --file "../{{.DATA}}"
-      --expected-slug "{{.SLUG}}"
-      --expected-source-url "{{.SOURCE_URL}}"
-      --check-materialization
-      --verify-production
+    cmd: uv run python app/scripts/curated_game_fast_path_v2.py verify --game "{{.GAME}}"
+
+  game:release-check:
+    desc: "production frontendのcurated registry revisionをmainと照合"
+    dir: backend
+    cmd: uv run python app/scripts/curated_game_fast_path_v2.py release-check
 
   gemini:verify:
     desc: "Gemini model existence + generateContent smoke check"

--- a/backend/app/scripts/curated_game_fast_path_v2.py
+++ b/backend/app/scripts/curated_game_fast_path_v2.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from app.scripts.curated_game_workflow import (
+    CURATED_DIR,
+    GENERATED_GUIDES_PATH,
+    REPO_ROOT,
+    CuratedGameSpec,
+    IdentityPlan,
+    WorkflowError,
+    load_all_specs,
+    load_spec,
+    materialize_registry,
+    preflight_identity,
+    render_generated_registry,
+    validate_assertions,
+    validate_runtime_guide,
+)
+
+DEFAULT_BASE_URL = "https://bodoge-no-mikata.vercel.app"
+DEPLOYMENT_MANIFEST_PATH = REPO_ROOT / "frontend" / "public" / "curated-guides-manifest.json"
+
+
+def resolve_spec_path(game: str) -> Path:
+    candidate = CURATED_DIR / f"{game}.json"
+    if not candidate.is_file():
+        raise WorkflowError(f"curated game spec not found: {candidate.relative_to(REPO_ROOT)}")
+    spec = load_spec(candidate)
+    if candidate.stem != spec.slug or game != spec.slug:
+        raise WorkflowError("spec filename, GAME, and canonical slug must match")
+    return candidate
+
+
+def load_named_spec(game: str, specs: list[CuratedGameSpec]) -> CuratedGameSpec:
+    path = resolve_spec_path(game)
+    selected = load_spec(path)
+    matches = [spec for spec in specs if spec.slug == selected.slug]
+    if len(matches) != 1:
+        raise WorkflowError(f"expected exactly one structured spec for {selected.slug}")
+    return matches[0]
+
+
+def verify_source_reachable_streamed(spec: CuratedGameSpec) -> None:
+    headers = {"User-Agent": "BodogeNoMikataSourceVerifier/2.0 (+https://bodoge-no-mikata.vercel.app/)"}
+    with httpx.Client(follow_redirects=True, timeout=20, headers=headers) as client:
+        with client.stream("GET", spec.source.url) as response:
+            if response.status_code < 200 or response.status_code >= 400:
+                raise WorkflowError(
+                    f"primary source is not reachable: HTTP {response.status_code} {spec.source.url}"
+                )
+
+
+def deployment_manifest_payload(specs: list[CuratedGameSpec]) -> dict[str, Any]:
+    registry = render_generated_registry(specs)
+    digest = hashlib.sha256(registry.encode("utf-8")).hexdigest()
+    games = {
+        spec.slug: {
+            "rule_version": spec.source.rule_version,
+            "source_revision": spec.source.revision,
+        }
+        for spec in sorted(specs, key=lambda item: item.slug)
+    }
+    return {
+        "schema_version": 1,
+        "registry_sha256": digest,
+        "games": games,
+    }
+
+
+def render_deployment_manifest(specs: list[CuratedGameSpec]) -> str:
+    return json.dumps(
+        deployment_manifest_payload(specs),
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    ) + "\n"
+
+
+def materialize_artifacts(specs: list[CuratedGameSpec], check_only: bool) -> None:
+    materialize_registry(specs, check_only=check_only)
+    expected = render_deployment_manifest(specs)
+    current = DEPLOYMENT_MANIFEST_PATH.read_text(encoding="utf-8") if DEPLOYMENT_MANIFEST_PATH.exists() else ""
+    if check_only:
+        if current != expected:
+            raise WorkflowError("curated-guides-manifest.json is stale; run task game:add GAME=<slug>")
+        return
+    if current != expected:
+        DEPLOYMENT_MANIFEST_PATH.parent.mkdir(parents=True, exist_ok=True)
+        DEPLOYMENT_MANIFEST_PATH.write_text(expected, encoding="utf-8")
+
+
+def preflight_catalog(spec: CuratedGameSpec) -> tuple[Any, IdentityPlan]:
+    from app.core import supabase
+
+    client = supabase._get_client()
+    plan = preflight_identity(client, spec)
+    return client, plan
+
+
+def write_catalog_with_plan(client: Any, spec: CuratedGameSpec, plan: IdentityPlan) -> dict[str, Any]:
+    created_work_id: str | None = None
+    work_id = plan.work_id
+
+    if plan.create_work:
+        rows = (
+            client.table("game_works")
+            .insert(
+                {
+                    "canonical_title": spec.work.canonical_title,
+                    "identity_status": spec.work.identity_status,
+                }
+            )
+            .execute()
+            .data
+        )
+        if not rows:
+            raise WorkflowError("failed to create canonical game work")
+        created_work_id = str(rows[0]["id"])
+        work_id = created_work_id
+
+    payload = dict(spec.game)
+    payload["work_id"] = work_id
+
+    try:
+        if plan.game_id:
+            rows = client.table("games").update(payload).eq("id", plan.game_id).execute().data
+        else:
+            rows = client.table("games").insert(payload).execute().data
+    except Exception:
+        if created_work_id:
+            client.table("game_works").delete().eq("id", created_work_id).execute()
+        raise
+
+    if not rows:
+        raise WorkflowError("catalog write returned no game row")
+    row = rows[0]
+    if row.get("slug") != spec.slug:
+        raise WorkflowError("catalog write returned unexpected slug")
+    return row
+
+
+def verify_catalog_live(spec: CuratedGameSpec, base_url: str) -> None:
+    base = base_url.rstrip("/")
+    with httpx.Client(follow_redirects=True, timeout=20) as client:
+        api_response = client.get(f"{base}/api/games/{spec.slug}")
+        if api_response.status_code != 200:
+            raise WorkflowError(f"production API failed: HTTP {api_response.status_code}")
+        payload = api_response.json()
+        if payload.get("slug") != spec.slug:
+            raise WorkflowError("production API returned the wrong slug")
+        if payload.get("source_url") != spec.source.url:
+            raise WorkflowError("production API source provenance does not match structured input")
+        if not payload.get("work_id"):
+            raise WorkflowError("production API record has no canonical work_id")
+
+        page_response = client.get(f"{base}/games/{spec.slug}")
+        if page_response.status_code != 200:
+            raise WorkflowError(f"production page failed: HTTP {page_response.status_code}")
+        expected_title = str(spec.game.get("title_ja") or spec.game["title"])
+        if expected_title not in page_response.text:
+            raise WorkflowError("production page does not contain the expected title")
+
+
+def validate_release_manifest(
+    expected: dict[str, Any],
+    deployed: dict[str, Any],
+    game: str | None = None,
+) -> None:
+    if deployed.get("schema_version") != expected.get("schema_version"):
+        raise WorkflowError("deployed curated manifest schema version mismatch")
+    if deployed.get("registry_sha256") != expected.get("registry_sha256"):
+        raise WorkflowError("deployed curated registry digest does not match main")
+    if game is not None:
+        expected_game = (expected.get("games") or {}).get(game)
+        deployed_game = (deployed.get("games") or {}).get(game)
+        if expected_game is None:
+            raise WorkflowError(f"local deployment manifest has no game {game}")
+        if deployed_game != expected_game:
+            raise WorkflowError(f"deployed curated manifest revision mismatch for {game}")
+
+
+def verify_frontend_release(
+    specs: list[CuratedGameSpec],
+    base_url: str,
+    game: str | None = None,
+) -> None:
+    expected = deployment_manifest_payload(specs)
+    url = f"{base_url.rstrip('/')}/curated-guides-manifest.json"
+    with httpx.Client(follow_redirects=True, timeout=20) as client:
+        response = client.get(url)
+    if response.status_code != 200:
+        raise WorkflowError(f"production curated manifest failed: HTTP {response.status_code}")
+    validate_release_manifest(expected, response.json(), game=game)
+
+
+def routine_files(spec: CuratedGameSpec) -> list[str]:
+    return [
+        f"data/curated-games/{spec.slug}.json",
+        str(GENERATED_GUIDES_PATH.relative_to(REPO_ROOT)),
+        str(DEPLOYMENT_MANIFEST_PATH.relative_to(REPO_ROOT)),
+    ]
+
+
+def print_routine_files(spec: CuratedGameSpec) -> None:
+    print("Routine PR files:")
+    for path in routine_files(spec):
+        print(f"- {path}")
+
+
+def prepare_add(
+    spec: CuratedGameSpec,
+    specs: list[CuratedGameSpec],
+) -> tuple[Any, IdentityPlan]:
+    validate_assertions(spec)
+    verify_source_reachable_streamed(spec)
+    client, plan = preflight_catalog(spec)
+    materialize_artifacts(specs, check_only=False)
+    validate_runtime_guide(spec)
+    return client, plan
+
+
+def add_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec], base_url: str) -> None:
+    client, plan = prepare_add(spec, specs)
+    write_catalog_with_plan(client, spec, plan)
+    verify_catalog_live(spec, base_url)
+    print_routine_files(spec)
+    print("Catalog fixed point: verified")
+    print("Frontend release fixed point: pending deployment; run task game:verify GAME=<slug> after deploy")
+
+
+def check_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec]) -> None:
+    validate_assertions(spec)
+    materialize_artifacts(specs, check_only=True)
+    validate_runtime_guide(spec)
+    print_routine_files(spec)
+
+
+def verify_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec], base_url: str) -> None:
+    validate_assertions(spec)
+    verify_source_reachable_streamed(spec)
+    materialize_artifacts(specs, check_only=True)
+    validate_runtime_guide(spec)
+    verify_catalog_live(spec, base_url)
+    verify_frontend_release(specs, base_url, game=spec.slug)
+    print("Catalog fixed point: verified")
+    print("Frontend release fixed point: verified")
+
+
+def check_all(specs: list[CuratedGameSpec]) -> None:
+    for spec in specs:
+        validate_assertions(spec)
+    materialize_artifacts(specs, check_only=True)
+    for spec in specs:
+        validate_runtime_guide(spec)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("mode", choices=("add", "check", "verify", "check-all", "release-check"))
+    parser.add_argument("--game")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    specs = load_all_specs()
+
+    if args.mode in {"add", "check", "verify"}:
+        if not args.game:
+            raise WorkflowError(f"{args.mode} requires --game")
+        spec = load_named_spec(args.game, specs)
+        if args.mode == "add":
+            add_game(spec, specs, args.base_url)
+        elif args.mode == "check":
+            check_game(spec, specs)
+        else:
+            verify_game(spec, specs, args.base_url)
+        return
+
+    if args.game:
+        raise WorkflowError(f"{args.mode} does not accept --game")
+
+    if args.mode == "check-all":
+        check_all(specs)
+    else:
+        materialize_artifacts(specs, check_only=True)
+        verify_frontend_release(specs, args.base_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/scripts/curated_game_fast_path_v2.py
+++ b/backend/app/scripts/curated_game_fast_path_v2.py
@@ -68,7 +68,7 @@ def deployment_manifest_payload(specs: list[CuratedGameSpec]) -> dict[str, Any]:
     digest = hashlib.sha256(revision_contract.encode("utf-8")).hexdigest()
     return {
         "schema_version": 1,
-        "registry_sha256": digest,
+        "revision_contract_sha256": digest,
         "games": games,
     }
 
@@ -174,8 +174,8 @@ def validate_release_manifest(
 ) -> None:
     if deployed.get("schema_version") != expected.get("schema_version"):
         raise WorkflowError("deployed curated manifest schema version mismatch")
-    if deployed.get("registry_sha256") != expected.get("registry_sha256"):
-        raise WorkflowError("deployed curated registry digest does not match main")
+    if deployed.get("revision_contract_sha256") != expected.get("revision_contract_sha256"):
+        raise WorkflowError("deployed curated revision contract does not match main")
     if game is not None:
         expected_game = (expected.get("games") or {}).get(game)
         deployed_game = (deployed.get("games") or {}).get(game)

--- a/backend/app/scripts/curated_game_fast_path_v2.py
+++ b/backend/app/scripts/curated_game_fast_path_v2.py
@@ -19,7 +19,6 @@ from app.scripts.curated_game_workflow import (
     load_spec,
     materialize_registry,
     preflight_identity,
-    render_generated_registry,
     validate_assertions,
     validate_runtime_guide,
 )
@@ -58,8 +57,6 @@ def verify_source_reachable_streamed(spec: CuratedGameSpec) -> None:
 
 
 def deployment_manifest_payload(specs: list[CuratedGameSpec]) -> dict[str, Any]:
-    registry = render_generated_registry(specs)
-    digest = hashlib.sha256(registry.encode("utf-8")).hexdigest()
     games = {
         spec.slug: {
             "rule_version": spec.source.rule_version,
@@ -67,6 +64,8 @@ def deployment_manifest_payload(specs: list[CuratedGameSpec]) -> dict[str, Any]:
         }
         for spec in sorted(specs, key=lambda item: item.slug)
     }
+    revision_contract = json.dumps(games, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(revision_contract.encode("utf-8")).hexdigest()
     return {
         "schema_version": 1,
         "registry_sha256": digest,

--- a/backend/tests/test_curated_game_fast_path_v2.py
+++ b/backend/tests/test_curated_game_fast_path_v2.py
@@ -35,7 +35,7 @@ def test_deployment_manifest_is_deterministic_and_revision_bound():
 
     assert first == second
     payload = v2.deployment_manifest_payload(specs)
-    assert len(payload["registry_sha256"]) == 64
+    assert len(payload["revision_contract_sha256"]) == 64
     assert payload["games"]["skull-king"] == {
         "rule_version": "grandpa-becks-current-2026-08-14",
         "source_revision": "grandpa-becks-current-rulebook-accessed-2026-08-14",
@@ -75,9 +75,9 @@ def test_release_manifest_digest_mismatch_fails():
     specs = load_all_specs()
     expected = v2.deployment_manifest_payload(specs)
     deployed = dict(expected)
-    deployed["registry_sha256"] = "0" * 64
+    deployed["revision_contract_sha256"] = "0" * 64
 
-    with pytest.raises(WorkflowError, match="registry digest"):
+    with pytest.raises(WorkflowError, match="revision contract"):
         v2.validate_release_manifest(expected, deployed, game="skull-king")
 
 

--- a/backend/tests/test_curated_game_fast_path_v2.py
+++ b/backend/tests/test_curated_game_fast_path_v2.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+import pytest
+
+import app.scripts.curated_game_fast_path_v2 as v2
+from app.scripts.curated_game_workflow import WorkflowError, load_all_specs, load_spec
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKULL_KING = REPO_ROOT / "data" / "curated-games" / "skull-king.json"
+
+
+def test_single_input_resolves_canonical_spec():
+    specs = load_all_specs()
+    spec = v2.load_named_spec("skull-king", specs)
+
+    assert spec.slug == "skull-king"
+    assert v2.resolve_spec_path("skull-king") == SKULL_KING
+
+
+def test_filename_game_and_slug_must_match(tmp_path, monkeypatch):
+    source = SKULL_KING.read_text(encoding="utf-8")
+    fake_dir = tmp_path / "curated-games"
+    fake_dir.mkdir()
+    (fake_dir / "wrong-name.json").write_text(source, encoding="utf-8")
+    monkeypatch.setattr(v2, "CURATED_DIR", fake_dir)
+
+    with pytest.raises(WorkflowError, match="filename, GAME, and canonical slug"):
+        v2.resolve_spec_path("wrong-name")
+
+
+def test_deployment_manifest_is_deterministic_and_revision_bound():
+    specs = load_all_specs()
+    first = v2.render_deployment_manifest(specs)
+    second = v2.render_deployment_manifest(list(reversed(specs)))
+
+    assert first == second
+    payload = v2.deployment_manifest_payload(specs)
+    assert len(payload["registry_sha256"]) == 64
+    assert payload["games"]["skull-king"] == {
+        "rule_version": "grandpa-becks-current-2026-08-14",
+        "source_revision": "grandpa-becks-current-rulebook-accessed-2026-08-14",
+    }
+
+
+def test_prepare_add_preflights_before_materialization(monkeypatch):
+    spec = load_spec(SKULL_KING)
+    specs = [spec]
+    events = []
+    plan = object()
+    client = object()
+
+    monkeypatch.setattr(v2, "validate_assertions", lambda value: events.append("assertions"))
+    monkeypatch.setattr(v2, "verify_source_reachable_streamed", lambda value: events.append("source"))
+
+    def fake_preflight(value):
+        events.append("preflight")
+        return client, plan
+
+    monkeypatch.setattr(v2, "preflight_catalog", fake_preflight)
+    monkeypatch.setattr(
+        v2,
+        "materialize_artifacts",
+        lambda values, check_only: events.append("materialize"),
+    )
+    monkeypatch.setattr(v2, "validate_runtime_guide", lambda value: events.append("runtime"))
+
+    actual_client, actual_plan = v2.prepare_add(spec, specs)
+
+    assert actual_client is client
+    assert actual_plan is plan
+    assert events == ["assertions", "source", "preflight", "materialize", "runtime"]
+
+
+def test_release_manifest_digest_mismatch_fails():
+    specs = load_all_specs()
+    expected = v2.deployment_manifest_payload(specs)
+    deployed = dict(expected)
+    deployed["registry_sha256"] = "0" * 64
+
+    with pytest.raises(WorkflowError, match="registry digest"):
+        v2.validate_release_manifest(expected, deployed, game="skull-king")
+
+
+def test_routine_files_are_deterministic_and_ignore_worktree_noise():
+    spec = load_spec(SKULL_KING)
+
+    assert v2.routine_files(spec) == [
+        "data/curated-games/skull-king.json",
+        "frontend/src/lib/generatedCuratedRuleGuides.js",
+        "frontend/public/curated-guides-manifest.json",
+    ]

--- a/docs/CURATED_GAME_FAST_PATH.md
+++ b/docs/CURATED_GAME_FAST_PATH.md
@@ -4,113 +4,147 @@ Status: canonical operator workflow for source-grounded game additions.
 
 ## Goal
 
-Add one verified game to ボドゲのミカタ with the smallest safe change set and no unrelated repair work.
+Add one verified game to ボドゲのミカタ with the smallest safe routine change set and no unrelated repair work.
 
-## One-command path
+## Routine path
 
-Prepare one structured file under `data/curated-games/<slug>.json`, then run:
+Prepare exactly one structured source file:
+
+`data/curated-games/<slug>.json`
+
+Then run only:
 
 ```bash
-task game:add \
-  SLUG=skull-king \
-  SOURCE_URL=https://www.grandpabecksgames.com/pages/skull-king \
-  DATA=data/curated-games/skull-king.json
+task game:add GAME=<slug>
 ```
 
-`game:add` performs the fixed path in one process:
+`GAME` is the only routine operator input. The command derives the spec path, canonical slug, primary source URL, rule version, source revision, assertions, and production expectations from the structured file. Filename, `GAME`, and `spec.slug` must match exactly.
 
-1. validates the structured input and source/revision contract;
-2. checks the primary source URL is reachable;
-3. validates focused game assertions;
-4. materializes `frontend/src/lib/generatedCuratedRuleGuides.js` from every structured curated input;
-5. validates the runtime guide returned by `getCuratedRuleGuide(slug)`;
-6. checks production `slug -> work` identity before any write;
-7. updates the existing canonical edition idempotently, or creates one canonical work+edition when none exists;
-8. verifies the production API provenance and `/games/{slug}` page once;
-9. prints the exact PR-ready changed-file set.
+## Ordered gates
 
-A slug collision with a different canonical work fails before mutation. A canonical work that already has the same edition/language under another slug also fails before mutation.
+`game:add` executes these gates in this order:
+
+1. load the one canonical structured spec;
+2. validate schema/cross-field invariants and focused assertions;
+3. verify the primary source HTTP status with a streamed request, without consuming the full response body;
+4. preflight production `slug -> work -> edition/language` identity;
+5. only after preflight succeeds, materialize generated frontend artifacts;
+6. validate the runtime guide returned by `getCuratedRuleGuide(slug)`;
+7. perform one idempotent catalog write using the already-resolved identity plan;
+8. verify the catalog fixed point once through the production API and game page;
+9. print the deterministic three-file routine PR set.
+
+A slug/work/edition collision therefore fails before generated files or production catalog rows are changed.
+
+## Routine PR shape
+
+For a normal new curated game, the routine change set is fixed to:
+
+1. `data/curated-games/<slug>.json`
+2. `frontend/src/lib/generatedCuratedRuleGuides.js`
+3. `frontend/public/curated-guides-manifest.json`
+
+Do not add a game-specific Python importer or game-specific test file. Assertions belong inside the structured spec and the generic focused CI evaluates them for every curated game.
 
 ## Structured input contract
 
-`data/curated-games/schema-v1.json` defines the versioned external contract. Each file contains:
+`data/curated-games/schema-v1.json` defines the external contract. Each file contains:
 
 - `work`: canonical work title and identity status;
 - `source`: explicit HTTPS primary source, rule version, and source revision;
-- `game`: the production catalog payload, including `source_url`, `source_revision`, and `generated_from_source_revision`;
-- `guide`: the reviewed Quick Rules/scoring/flow object;
-- `assertions`: focused facts that must remain true for this game.
+- `game`: production catalog payload including source provenance;
+- `guide`: reviewed Quick Rules/scoring/flow object;
+- `assertions`: game-specific facts that must remain true.
 
-The workflow also enforces cross-field invariants that JSON Schema alone cannot express: slug equality, source URL equality, source revision equality, and guide/source rule-version equality.
+The workflow additionally enforces cross-field invariants such as slug equality, source URL equality, source revision equality, and guide/source rule-version equality.
 
-## Generated guide boundary
+## Generated artifact boundary
 
-`frontend/src/lib/generatedCuratedRuleGuides.js` is generated output. Do not hand-edit it.
+Never hand-edit either generated artifact:
 
-Structured curated games are merged into the runtime registry by `frontend/src/lib/curatedRuleGuides.js`. Legacy hand-maintained guides may remain there, but migrated games must exist only in the structured input/generated registry. Skull King is the replay fixture for this contract.
+- `frontend/src/lib/generatedCuratedRuleGuides.js`
+- `frontend/public/curated-guides-manifest.json`
 
-## Fast path
+The deployment manifest contains a deterministic digest of the curated revision contract plus each game's rule/source revision. It provides a cheap production proof that the deployed frontend corresponds to the expected curated registry revision without Playwright or bundle scraping.
 
-1. **Lock one current primary source.** Record the official URL and the source/revision date. Do not keep searching after the primary source is sufficient unless a contradiction appears.
-2. **Check canonical identity once.** The command checks the production catalog for the work/slug before any write. If the same canonical edition already exists, update it instead of creating a duplicate.
-3. **Prepare one structured file.** Do not hand-edit a large JS guide block or create a game-specific import script.
-4. **Run `task game:add` once.** It handles validation, materialization, the idempotent DB write, production verification, and changed-file reporting.
-5. **Open one branch and one PR.** Do not create replacement branches/PRs for the same game unless the canonical branch is unusable.
-6. **Use the targeted CI gate first.** `Curated game fast path` runs the workflow unit tests plus offline materialization/runtime checks without installing browsers or running the full UI suite.
-7. **Retry a flaky CI job at most once.** Re-run the failed job/run directly. If it fails again, preserve the canonical work line and report the blocker.
-8. **Separate unrelated infrastructure failures.** If the curated-game gate passes but generic deployment infrastructure fails, open/link a separate infrastructure Issue. Do not repair deployment internals inside the game-add task.
-9. **Merge once and stop after the fixed point.** `task game:verify` is available when a post-merge production re-check is required.
+## Two fixed points
 
-## Commands
+Catalog publication and frontend release are deliberately separate.
 
-Offline validation without writes or source/network checks:
+### Catalog fixed point
 
-```bash
-task game:check DATA=data/curated-games/skull-king.json
-```
+`task game:add GAME=<slug>` completes when the production API and `/games/<slug>` expose the intended canonical game/source provenance. This can become live immediately for database-backed content.
 
-Post-merge production verification without a database write:
+### Frontend release fixed point
+
+After a successful Vercel production deployment, `Curated game release verification` automatically checks the deployed `curated-guides-manifest.json` against the commit that was deployed.
+
+Manual fallback:
 
 ```bash
-task game:verify \
-  SLUG=skull-king \
-  SOURCE_URL=https://www.grandpabecksgames.com/pages/skull-king \
-  DATA=data/curated-games/skull-king.json
+task game:verify GAME=<slug>
 ```
+
+Global deployed-registry check:
+
+```bash
+task game:release-check
+```
+
+A generic deployment failure is a separate infrastructure blocker; it does not cause the game-add workflow to branch into deployment repair.
+
+## Other commands
+
+Offline structured/generated-artifact validation:
+
+```bash
+task game:check GAME=<slug>
+```
+
+Full game fixed-point verification after deployment:
+
+```bash
+task game:verify GAME=<slug>
+```
+
+## CI
+
+`Curated game fast path` is path-scoped and browser-free. It runs:
+
+- generic v1/v2 workflow tests;
+- all structured assertions;
+- generated-guide freshness;
+- deployment-manifest freshness;
+- runtime guide integration.
+
+Do not make the full UI suite a prerequisite for routine curated-game changes.
 
 ## Minimal completion evidence
 
-A game-add task is complete when all of these are true:
+A curated game is fully released when:
 
-- the production catalog contains exactly one canonical game identity for the intended work/edition;
-- the current primary source URL/revision is stored;
-- the structured guide has focused regression assertions;
-- generated guide output is current and runtime-visible;
-- the targeted curated-game CI gate passes;
-- the production API returns matching source provenance and the production game page returns the expected title.
-
-A general deployment workflow failure does not invalidate an already-live database-backed game page. It becomes a separate infrastructure blocker unless the requested game content itself is unavailable.
+- production contains exactly one intended canonical work/edition identity;
+- the current primary source URL and revision are stored;
+- structured assertions pass;
+- generated artifacts are current;
+- targeted curated-game CI passes;
+- catalog fixed point is verified;
+- the post-deploy manifest verification confirms the frontend release fixed point.
 
 ## Scope guard
 
 During a game-add task, do not:
 
-- redesign unrelated schemas or UI;
-- repair generic deployment infrastructure;
-- perform repeated repository-wide searches after canonical paths are known;
-- create multiple speculative PRs;
-- rerun full CI suites to diagnose a single targeted failure before reading the failed job;
-- continue source research after the official source is locked without contradictory evidence;
-- hand-edit `generatedCuratedRuleGuides.js`.
+- repeat source research after the primary source/revision is locked unless contradictory evidence appears;
+- repeat repository-wide searches once canonical paths are known;
+- provide `SLUG`, `SOURCE_URL`, or `DATA` separately when they are already in the spec;
+- mutate generated files before identity preflight succeeds;
+- hand-edit generated artifacts;
+- create a game-specific regression test when the structured assertions can express the contract;
+- repair unrelated Vercel/CI infrastructure inside the game-add branch;
+- create replacement branches/PRs for the same task;
+- retry a failed job more than once without new evidence.
 
 ## Success retrospective
 
-After a successful addition, spend one short pass on workflow improvement:
-
-1. identify tool calls, searches, retries, branches, or checks that did not change the outcome;
-2. remove them from this fast path;
-3. automate only repeated deterministic steps;
-4. keep evidence/identity/source gates fail-closed;
-5. stop when no reusable improvement remains.
-
-Do not turn the retrospective into a second implementation project. Reusable improvements belong in a separate Issue/PR unless they are a trivial documentation/task wrapper change.
+After a successful addition, review only the steps that affected the outcome. Remove repeated deterministic work from the next run, but keep source, identity, semantic, and production fixed-point gates fail-closed. Stop once there is no reusable reduction left.

--- a/frontend/public/curated-guides-manifest.json
+++ b/frontend/public/curated-guides-manifest.json
@@ -1,0 +1,10 @@
+{
+  "games": {
+    "skull-king": {
+      "rule_version": "grandpa-becks-current-2026-08-14",
+      "source_revision": "grandpa-becks-current-rulebook-accessed-2026-08-14"
+    }
+  },
+  "registry_sha256": "f096d2664e5754e54bfb1af0f3a49a8666b13211fe4a244b9544fde7dde75c5c",
+  "schema_version": 1
+}

--- a/frontend/public/curated-guides-manifest.json
+++ b/frontend/public/curated-guides-manifest.json
@@ -5,6 +5,6 @@
       "source_revision": "grandpa-becks-current-rulebook-accessed-2026-08-14"
     }
   },
-  "registry_sha256": "f096d2664e5754e54bfb1af0f3a49a8666b13211fe4a244b9544fde7dde75c5c",
+  "revision_contract_sha256": "f096d2664e5754e54bfb1af0f3a49a8666b13211fe4a244b9544fde7dde75c5c",
   "schema_version": 1
 }


### PR DESCRIPTION
Closes #167

## What changed
- reduce routine operator input from `SLUG + SOURCE_URL + DATA` to only `GAME=<slug>`
- require filename, GAME and canonical slug to match
- move production identity preflight before generated artifact mutation
- verify primary source reachability with streamed/no-body HTTP handling
- add deterministic curated deployment manifest with source/rule revision contract digest
- separate catalog-live and frontend-release fixed points
- add post-Vercel release verification workflow that runs only after a successful main production deploy
- replace global `git status` reporting with deterministic three-file routine PR output
- extend focused CI with v2 tests and manifest freshness; no browser suite added

## Routine path
`task game:add GAME=<slug>`

Normal per-game PR content is now only:
1. `data/curated-games/<slug>.json`
2. `frontend/src/lib/generatedCuratedRuleGuides.js`
3. `frontend/public/curated-guides-manifest.json`

## Safety
- slug/work/edition collisions fail before generated files or catalog rows are mutated
- deployment failure remains a separate infrastructure blocker
- frontend release verification is explicit rather than inferred from catalog availability
- Skull King remains the replay fixture with no semantic guide change
