### PR TITLE
Publish curated games only after merge

### DIFF
--- a/.github/workflows/curated-game-fast-path.yml
+++ b/.github/workflows/curated-game-fast-path.yml
@@ -64,6 +64,9 @@ jobs:
     needs: curated-game
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: curated-catalog-publish
+      cancel-in-progress: false
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/curated-game-fast-path.yml
+++ b/.github/workflows/curated-game-fast-path.yml
@@ -58,3 +58,93 @@ jobs:
         env:
           PYTHONPATH: backend
         run: uv run python backend/app/scripts/curated_game_fast_path_v2.py check-all
+
+  publish-catalog:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: curated-game
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Resolve changed curated specs from push event
+        id: changed
+        shell: bash
+        run: |
+          python - "$GITHUB_EVENT_PATH" /tmp/curated-games.txt "$GITHUB_OUTPUT" <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          changed = set()
+          removed = set()
+          prefix = "data/curated-games/"
+          for commit in payload.get("commits", []):
+              for path in [*commit.get("added", []), *commit.get("modified", [])]:
+                  if path.startswith(prefix) and path.endswith(".json") and not Path(path).name.startswith("schema-"):
+                      changed.add(Path(path).stem)
+              for path in commit.get("removed", []):
+                  if path.startswith(prefix) and path.endswith(".json") and not Path(path).name.startswith("schema-"):
+                      removed.add(path)
+          if removed:
+              raise SystemExit("Curated game deletion requires an explicit deprecation workflow: " + ", ".join(sorted(removed)))
+          slugs = sorted(changed)
+          Path(sys.argv[2]).write_text("".join(f"{slug}\n" for slug in slugs), encoding="utf-8")
+          with Path(sys.argv[3]).open("a", encoding="utf-8") as output:
+              output.write(f"count={len(slugs)}\n")
+          print(f"Changed curated games: {len(slugs)}")
+          PY
+      - name: Install uv
+        if: steps.changed.outputs.count != '0'
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      - name: Install Python dependencies
+        if: steps.changed.outputs.count != '0'
+        run: uv sync --frozen
+      - name: Install Vercel CLI
+        if: steps.changed.outputs.count != '0'
+        run: npm install --global vercel@59.0.0
+      - name: Pull production environment only
+        if: steps.changed.outputs.count != '0'
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Export trusted Supabase server credentials
+        if: steps.changed.outputs.count != '0'
+        shell: bash
+        run: |
+          python - .vercel/.env.production.local "$GITHUB_ENV" <<'PY'
+          import sys
+          from pathlib import Path
+
+          source = Path(sys.argv[1])
+          destination = Path(sys.argv[2])
+          values = {}
+          for raw in source.read_text(encoding="utf-8").splitlines():
+              line = raw.strip()
+              if not line or line.startswith("#") or "=" not in line:
+                  continue
+              key, value = line.split("=", 1)
+              value = value.strip()
+              if len(value) >= 2 and value[0] == value[-1] and value[0] in "'\"":
+                  value = value[1:-1]
+              values[key.strip()] = value
+          required = ("SUPABASE_URL", "SUPABASE_SERVICE_ROLE_KEY")
+          missing = [key for key in required if not values.get(key)]
+          if missing:
+              raise SystemExit("Missing trusted production DB variables: " + ", ".join(missing))
+          with destination.open("a", encoding="utf-8") as output:
+              for key in required:
+                  output.write(f"{key}={values[key]}\n")
+          print("Trusted production DB environment loaded")
+          PY
+      - name: Publish changed curated games and verify catalog fixed points
+        if: steps.changed.outputs.count != '0'
+        env:
+          PYTHONPATH: backend
+        shell: bash
+        run: |
+          while IFS= read -r slug; do
+            [ -n "$slug" ] || continue
+            uv run python backend/app/scripts/curated_game_fast_path_v2.py publish --game "$slug"
+          done < /tmp/curated-games.txt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -133,7 +133,7 @@ tasks:
     cmd: uv run python -m app.scripts.validate_urls --hours 24
 
   game:add:
-    desc: "curated gameを一次情報検証→identity preflight→生成→DB公開→catalog確認 (GAME=<slug>)"
+    desc: "curated gameを一次情報検証→read-only identity preflight→生成してPR準備。production writeはmerge後に自動実行 (GAME=<slug>)"
     requires:
       vars: [GAME]
     dir: backend

--- a/backend/app/scripts/curated_game_fast_path_v2.py
+++ b/backend/app/scripts/curated_game_fast_path_v2.py
@@ -212,7 +212,7 @@ def print_routine_files(spec: CuratedGameSpec) -> None:
         print(f"- {path}")
 
 
-def prepare_add(
+def prepare_game(
     spec: CuratedGameSpec,
     specs: list[CuratedGameSpec],
 ) -> tuple[Any, IdentityPlan]:
@@ -224,13 +224,17 @@ def prepare_add(
     return client, plan
 
 
-def add_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec], base_url: str) -> None:
-    client, plan = prepare_add(spec, specs)
+def add_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec]) -> None:
+    prepare_game(spec, specs)
+    print_routine_files(spec)
+    print("Prepare fixed point: verified; production catalog unchanged until merge")
+
+
+def publish_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec], base_url: str) -> None:
+    client, plan = prepare_game(spec, specs)
     write_catalog_with_plan(client, spec, plan)
     verify_catalog_live(spec, base_url)
-    print_routine_files(spec)
-    print("Catalog fixed point: verified")
-    print("Frontend release fixed point: pending deployment; verified automatically after a successful deploy")
+    print(f"Catalog publish fixed point: verified for {spec.slug}")
 
 
 def check_game(spec: CuratedGameSpec, specs: list[CuratedGameSpec]) -> None:
@@ -261,7 +265,7 @@ def check_all(specs: list[CuratedGameSpec]) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
-    parser.add_argument("mode", choices=("add", "check", "verify", "check-all", "release-check"))
+    parser.add_argument("mode", choices=("add", "publish", "check", "verify", "check-all", "release-check"))
     parser.add_argument("--game")
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
     return parser.parse_args()
@@ -271,12 +275,14 @@ def main() -> None:
     args = parse_args()
     specs = load_all_specs()
 
-    if args.mode in {"add", "check", "verify"}:
+    if args.mode in {"add", "publish", "check", "verify"}:
         if not args.game:
             raise WorkflowError(f"{args.mode} requires --game")
         spec = load_named_spec(args.game, specs)
         if args.mode == "add":
-            add_game(spec, specs, args.base_url)
+            add_game(spec, specs)
+        elif args.mode == "publish":
+            publish_game(spec, specs, args.base_url)
         elif args.mode == "check":
             check_game(spec, specs)
         else:
@@ -286,12 +292,10 @@ def main() -> None:
     if args.game:
         raise WorkflowError(f"{args.mode} does not accept --game")
 
-    generate_artifacts(specs)
     if args.mode == "check-all":
-        for spec in specs:
-            validate_assertions(spec)
-            validate_runtime_guide(spec)
+        check_all(specs)
     else:
+        generate_artifacts(specs)
         verify_frontend_release(specs, args.base_url)
 
 

--- a/backend/tests/test_curated_game_fast_path_v2.py
+++ b/backend/tests/test_curated_game_fast_path_v2.py
@@ -85,7 +85,7 @@ def test_git_tracks_curated_sources_but_ignores_generated_artifacts():
     assert generated_manifest.returncode == 0
 
 
-def test_prepare_add_preflights_before_generation(monkeypatch):
+def test_prepare_preflights_before_generation(monkeypatch):
     spec = load_spec(SKULL_KING)
     specs = [spec]
     events = []
@@ -103,11 +103,47 @@ def test_prepare_add_preflights_before_generation(monkeypatch):
     monkeypatch.setattr(v2, "generate_artifacts", lambda values: events.append("generate"))
     monkeypatch.setattr(v2, "validate_runtime_guide", lambda value: events.append("runtime"))
 
-    actual_client, actual_plan = v2.prepare_add(spec, specs)
+    actual_client, actual_plan = v2.prepare_game(spec, specs)
 
     assert actual_client is client
     assert actual_plan is plan
     assert events == ["assertions", "source", "preflight", "generate", "runtime"]
+
+
+def test_game_add_is_prepare_only_and_never_writes(monkeypatch):
+    spec = load_spec(SKULL_KING)
+    events = []
+
+    monkeypatch.setattr(v2, "prepare_game", lambda value, specs: events.append("prepare"))
+    monkeypatch.setattr(v2, "print_routine_files", lambda value: events.append("report"))
+    monkeypatch.setattr(v2, "write_catalog_with_plan", lambda *args: events.append("write"))
+
+    v2.add_game(spec, [spec])
+
+    assert events == ["prepare", "report"]
+
+
+def test_publish_is_the_only_catalog_write_path(monkeypatch):
+    spec = load_spec(SKULL_KING)
+    client = object()
+    plan = object()
+    events = []
+
+    def fake_prepare(value, specs):
+        events.append("prepare")
+        return client, plan
+
+    monkeypatch.setattr(v2, "prepare_game", fake_prepare)
+    monkeypatch.setattr(
+        v2,
+        "write_catalog_with_plan",
+        lambda actual_client, value, actual_plan: events.append("write"),
+    )
+    monkeypatch.setattr(v2, "verify_catalog_live", lambda value, base_url: events.append("verify"))
+
+    v2.publish_game(spec, [spec], "https://example.invalid")
+
+    assert events == ["prepare", "write", "verify"]
 
 
 def test_release_manifest_digest_mismatch_fails():

--- a/backend/tests/test_curated_game_fast_path_v2.py
+++ b/backend/tests/test_curated_game_fast_path_v2.py
@@ -11,6 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SKULL_KING = REPO_ROOT / "data" / "curated-games" / "skull-king.json"
 GENERATED_GUIDES = REPO_ROOT / "frontend" / "src" / "lib" / "generatedCuratedRuleGuides.js"
 PACKAGE_JSON = REPO_ROOT / "frontend" / "package.json"
+FAST_PATH_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "curated-game-fast-path.yml"
 
 
 def test_single_input_resolves_canonical_spec():
@@ -144,6 +145,18 @@ def test_publish_is_the_only_catalog_write_path(monkeypatch):
     v2.publish_game(spec, [spec], "https://example.invalid")
 
     assert events == ["prepare", "write", "verify"]
+
+
+def test_catalog_publish_job_is_main_only_and_depends_on_validation():
+    workflow = FAST_PATH_WORKFLOW.read_text(encoding="utf-8")
+    validation, publish = workflow.split("  publish-catalog:\n", 1)
+
+    assert "publish --game" not in validation
+    assert "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" in publish
+    assert "needs: curated-game" in publish
+    assert "vercel pull --yes --environment=production" in publish
+    assert "SUPABASE_SERVICE_ROLE_KEY" in publish
+    assert "publish --game \"$slug\"" in publish
 
 
 def test_release_manifest_digest_mismatch_fails():

--- a/docs/CURATED_GAME_FAST_PATH.md
+++ b/docs/CURATED_GAME_FAST_PATH.md
@@ -4,9 +4,9 @@ Status: canonical operator workflow for source-grounded game additions.
 
 ## Goal
 
-Add one verified game to ボドゲのミカタ with one canonical source file, fail-closed evidence/identity checks, and no committed generated artifacts.
+Add one verified game to ボドゲのミカタ with one canonical source file, fail-closed evidence/identity checks, and production writes only after reviewed source reaches `main`.
 
-## Routine path
+## Routine operator path
 
 Create or update exactly one Git-tracked source file:
 
@@ -18,23 +18,69 @@ Then run:
 task game:add GAME=<slug>
 ```
 
-`GAME` is the only routine operator input. The command derives the spec path, canonical slug, primary source URL, rule version, source revision, assertions, and production expectations from the structured file. Filename, `GAME`, and `spec.slug` must match exactly.
+`GAME` is the only routine operator input. `game:add` is prepare-only: it validates the source contract, reaches the official source, performs a read-only live identity preflight, regenerates local runtime artifacts, and validates the runtime guide. It never writes the production catalog.
 
-## Ordered gates
+Filename, `GAME`, and `spec.slug` must match exactly.
 
-`game:add` executes these gates in this order:
+## Final lifecycle
+
+1. create/update `data/curated-games/<slug>.json`;
+2. run `task game:add GAME=<slug>`;
+3. open one JSON-only PR;
+4. `Curated game fast path` validates the PR without production-write credentials;
+5. merge to `main`;
+6. the same focused workflow completes its validation on the `main` push;
+7. `publish-catalog` derives only added/modified curated JSON files from the push event;
+8. only when such files exist, it pulls the production environment from Vercel, exports the trusted Supabase server variables, and invokes the internal `publish` mode for those slugs;
+9. `publish` rechecks the primary source and live identity, performs one idempotent catalog write, then verifies the production API/page fixed point once;
+10. Vercel deployment remains independent; after a successful production deploy, `Curated game release verification` checks the deployed revision manifest.
+
+Production therefore cannot get ahead of canonical Git source through the normal game-add path.
+
+## Prepare gate order
+
+`task game:add GAME=<slug>` executes:
 
 1. load the one canonical structured spec;
 2. validate schema/cross-field invariants and focused assertions;
 3. verify the primary source HTTP status with a streamed request without consuming the full body;
-4. preflight production `slug -> work -> edition/language` identity;
+4. preflight production `slug -> work -> edition/language` identity read-only;
 5. only after preflight succeeds, run the single Node artifact generator;
 6. verify the Node-generated deployment manifest against the Python revision contract;
 7. validate the runtime guide returned by `getCuratedRuleGuide(slug)`;
-8. perform one idempotent catalog write using the already-resolved identity plan;
-9. verify the catalog fixed point once through the production API and game page.
+8. report the one-file routine PR set and stop without a DB write.
 
-A slug/work/edition collision therefore fails before generated files or production catalog rows are changed.
+## Main-only publish gate
+
+The internal CLI mode is:
+
+`curated_game_fast_path_v2.py publish --game <slug>`
+
+It is not exposed as the routine Taskfile command. The main workflow is its canonical caller.
+
+Before every write it repeats source reachability, live identity preflight, artifact/runtime validation, then uses the resolved identity plan for the idempotent catalog write. A changed production identity between PR preparation and merge therefore fails closed instead of writing to another work/edition.
+
+The publish job:
+
+- runs only for a `push` to `refs/heads/main`;
+- requires the focused validation job to succeed first;
+- derives changed curated games from the GitHub push event rather than rewriting every curated game;
+- ignores schema-only changes;
+- refuses curated-game source deletion; deletion requires an explicit deprecation workflow;
+- skips uv/Vercel/environment setup entirely when no game spec changed;
+- uses `vercel pull --environment=production` only as the established credential retrieval route;
+- never invokes a Vercel deploy request.
+
+## Credential boundary
+
+Pull-request validation has no production DB write step. Trusted server credentials are consumed only by the main-only `publish-catalog` job after focused validation.
+
+The required server variables are:
+
+- `SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+
+They are loaded from Vercel's production environment and are never replaced by browser-safe anon/publishable keys.
 
 ## Routine PR shape
 
@@ -69,58 +115,33 @@ Generation happens automatically through:
 
 - `npm run dev` via `predev`;
 - `npm run build` via `prebuild`;
-- Vercel production/preview builds, because Vercel runs the frontend build command;
-- `task game:add`, `task game:check`, and focused CI through the same Node generator.
+- Vercel production/preview builds;
+- prepare/publish/check/release verification through the same Node generator.
 
 The Python fast path does not implement a second guide generator. It invokes Node and checks that the resulting deployment manifest exactly matches the Python revision-contract calculation.
 
-## Deployment manifest
-
-`curated-guides-manifest.json` contains each curated game's rule/source revision and a deterministic `revision_contract_sha256`. It is a cheap release proof that the deployed frontend corresponds to the intended curated revision contract without browser automation or bundle scraping.
-
-## Two fixed points
-
-Catalog publication and frontend release remain deliberately separate.
+## Two production fixed points
 
 ### Catalog fixed point
 
-`task game:add GAME=<slug>` completes when the production API and `/games/<slug>` expose the intended canonical game/source provenance. Database-backed content can become live independently of a frontend deployment.
+The main-only publish job verifies the production API and `/games/<slug>` immediately after the idempotent DB write. Database-backed content can become live independently of a frontend deployment.
 
 ### Frontend release fixed point
 
-After a successful Vercel production deployment, `Curated game release verification` automatically checks the deployed manifest against the commit that was deployed.
+After a successful Vercel production deployment, `Curated game release verification` checks the deployed `curated-guides-manifest.json` against the deployed commit.
 
-Manual fallback:
+Manual diagnostics remain available:
 
 ```bash
 task game:verify GAME=<slug>
-```
-
-Global deployed-registry check:
-
-```bash
 task game:release-check
 ```
 
-A generic deployment failure is a separate infrastructure blocker; it does not cause the game-add workflow to branch into deployment repair.
-
-## Other commands
-
-Source/runtime validation without a catalog write:
-
-```bash
-task game:check GAME=<slug>
-```
-
-Full game fixed-point verification after deployment:
-
-```bash
-task game:verify GAME=<slug>
-```
+A generic deployment failure is a separate infrastructure blocker; it does not roll back an already-verified catalog publication or trigger deployment repair inside the game-add branch.
 
 ## CI
 
-`Curated game fast path` is path-scoped and browser-free. From a clean checkout where generated artifacts do not exist, it:
+`Curated game fast path` is path-scoped and browser-free. From a clean checkout it:
 
 - runs generic workflow tests;
 - validates every structured assertion;
@@ -128,34 +149,38 @@ task game:verify GAME=<slug>
 - verifies Node/Python revision-contract agreement;
 - validates runtime guide integration.
 
-Do not make the full UI suite a prerequisite for routine curated-game changes.
+On pull requests it stops there. On `main`, and only after that validation succeeds, the separate `publish-catalog` job may obtain production credentials and publish changed game specs.
+
+Do not make the full UI suite or generic Vercel deploy request a prerequisite for catalog publication.
 
 ## Minimal completion evidence
 
 A curated game is fully released when:
 
+- exactly one canonical JSON source is merged to `main`;
+- source/identity/runtime focused CI passes;
+- main-only publish rechecks live source and identity;
 - production contains exactly one intended canonical work/edition identity;
-- the current primary source URL and revision are stored in the structured source;
-- structured assertions pass;
+- catalog API/page fixed point is verified;
 - generated artifacts are reproducible from source;
-- targeted curated-game CI passes;
-- catalog fixed point is verified;
 - post-deploy manifest verification confirms the frontend release fixed point.
 
 ## Scope guard
 
 During a game-add task, do not:
 
+- write the production DB before merge;
 - repeat source research after the primary source/revision is locked unless contradictory evidence appears;
 - repeat repository-wide searches once canonical paths are known;
 - provide `SLUG`, `SOURCE_URL`, or `DATA` separately when they are already in the spec;
-- mutate generated files before identity preflight succeeds;
 - commit or hand-edit generated artifacts;
 - create a game-specific regression test when structured assertions can express the contract;
+- publish unchanged games on every main push;
+- silently delete a production game because its source JSON disappeared;
 - repair unrelated Vercel/CI infrastructure inside the game-add branch;
 - create replacement branches/PRs for the same task;
 - retry a failed job more than once without new evidence.
 
 ## Success retrospective
 
-After a successful addition, review only the steps that affected the outcome. Remove repeated deterministic work from the next run, but keep source, identity, semantic, and production fixed-point gates fail-closed. Stop once there is no reusable reduction left.
+After a successful addition, review only the steps that affected the outcome. Remove repeated deterministic work from the next run, but keep source, identity, semantic, merge, catalog, and release fixed-point gates fail-closed. Stop once there is no reusable reduction left.


### PR DESCRIPTION
Closes #171

## Final lifecycle
`JSON source → prepare-only game:add → PR → focused CI → merge → main-only catalog publish → catalog verify → independent Vercel deploy → release-manifest verify`

## What changed
- make `task game:add GAME=<slug>` prepare-only; it cannot write production
- add internal `publish` CLI mode as the only catalog-write path
- add main-only `publish-catalog` job after focused validation
- derive only added/modified curated game specs from the push event; unchanged games are not rewritten
- refuse source deletion in the routine path
- skip all publish setup when no curated game spec changed
- reuse `vercel pull --environment=production` only to retrieve trusted Supabase server environment; no deploy request is made
- recheck source reachability and live canonical identity at publish time before write
- verify catalog API/page once after each idempotent publish
- serialize catalog publishes with a single concurrency group
- keep frontend release verification independent and post-deploy

## Security boundary
PR validation contains no production write call. Trusted `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` are loaded only in the main-only publish job after the focused job succeeds.

## Tests
Focused tests prove prepare ordering, write-free `game:add`, publish-only writes, main-only workflow dependency, source-only generation, Git ignore boundary, and manifest/runtime contracts.
