### PR TITLE
Introduce canonical RuleSet identity boundaries

### DIFF
--- a/.github/workflows/test-ruleset-identity.yml
+++ b/.github/workflows/test-ruleset-identity.yml
@@ -1,0 +1,165 @@
+name: RuleSet identity contract
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/ruleset.py"
+      - "backend/app/services/rulesets.py"
+      - "backend/app/services/rule_graph.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/010_rule_graph.sql"
+      - "backend/app/db/migrations/013_ruleset_identity.sql"
+      - "backend/tests/test_ruleset_identity.py"
+      - "backend/tests/test_rule_graph.py"
+      - "docs/RULESET_IDENTITY_V1.md"
+      - "docs/README.md"
+      - ".github/workflows/test-ruleset-identity.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/models/ruleset.py"
+      - "backend/app/services/rulesets.py"
+      - "backend/app/services/rule_graph.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/010_rule_graph.sql"
+      - "backend/app/db/migrations/013_ruleset_identity.sql"
+      - "backend/tests/test_ruleset_identity.py"
+      - "backend/tests/test_rule_graph.py"
+      - "docs/RULESET_IDENTITY_V1.md"
+      - "docs/README.md"
+      - ".github/workflows/test-ruleset-identity.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ruleset-identity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ruleset_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d ruleset_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/ruleset_test
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile RuleSet modules
+        run: >-
+          uv run python -m compileall -q
+          backend/app/models/ruleset.py
+          backend/app/services/rulesets.py
+          backend/app/services/rule_graph.py
+          backend/app/routers/games.py
+
+      - name: Run RuleSet and Rule Graph contract tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_ruleset_identity.py
+          backend/tests/test_rule_graph.py
+
+      - name: Verify RuleSet migration supports parallel identities
+        shell: bash
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE TABLE public.game_works (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid()
+          );
+          CREATE TABLE public.games (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            slug text NOT NULL UNIQUE,
+            work_id uuid REFERENCES public.game_works(id)
+          );
+          INSERT INTO public.game_works DEFAULT VALUES;
+          INSERT INTO public.games(slug, work_id)
+          SELECT 'example', id FROM public.game_works LIMIT 1;
+          SQL
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/010_rule_graph.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/013_ruleset_identity.sql
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.rule_sets (
+            game_id, version, language_code, edition_label, platform,
+            status, verification_status, is_active
+          )
+          SELECT id, 1, 'ja', 'base', 'physical', 'active', 'source_bound', true
+          FROM public.games WHERE slug = 'example';
+
+          INSERT INTO public.rule_sets (
+            game_id, version, language_code, edition_label, platform,
+            status, verification_status, is_active
+          )
+          SELECT id, 1, 'en', 'digital', 'boardgamearena', 'active', 'source_bound', true
+          FROM public.games WHERE slug = 'example';
+
+          INSERT INTO public.rule_sets (
+            game_id, version, language_code, edition_label, platform,
+            status, verification_status, is_active
+          )
+          SELECT id, 1, 'ja', 'revised', 'physical', 'active', 'unknown', true
+          FROM public.games WHERE slug = 'example';
+          SQL
+
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.rule_sets rs join public.games g on g.id=rs.game_id where g.slug='example' and rs.is_active;")" = "3"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.rule_sets rs join public.games g on g.id=rs.game_id where g.slug='example' and rs.revision_label is not null;")" = "0"
+
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.rule_sets (
+            game_id, version, language_code, edition_label, platform,
+            status, verification_status, is_active
+          )
+          SELECT id, 2, 'ja', 'base', 'physical', 'active', 'unknown', true
+          FROM public.games WHERE slug = 'example';
+          SQL
+          then
+            echo "duplicate active RuleSet identity unexpectedly accepted"
+            exit 1
+          fi
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.rule_sets (
+            game_id, version, language_code, edition_label, platform,
+            status, verification_status, is_active
+          )
+          SELECT id, 2, 'ja', 'base', 'physical', 'superseded', 'source_bound', false
+          FROM public.games WHERE slug = 'example';
+
+          WITH base AS (
+            SELECT rs.id, rs.game_id
+            FROM public.rule_sets rs
+            JOIN public.games g ON g.id = rs.game_id
+            WHERE g.slug = 'example' AND rs.platform = 'physical' AND rs.edition_label = 'base' AND rs.is_active
+            LIMIT 1
+          )
+          INSERT INTO public.rule_sets (
+            game_id, version, language_code, edition_label, platform,
+            status, is_active, base_rule_set_id, relation_type, variant_label
+          )
+          SELECT game_id, 1, 'ja', 'base', 'physical', 'active', true, id, 'variant_of', 'Expert Mode'
+          FROM base;
+          SQL
+
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.rule_sets where relation_type='variant_of' and variant_label='Expert Mode';")" = "1"

--- a/backend/app/db/migrations/013_ruleset_identity.sql
+++ b/backend/app/db/migrations/013_ruleset_identity.sql
@@ -1,0 +1,129 @@
+BEGIN;
+
+ALTER TABLE public.rule_sets
+  ADD COLUMN IF NOT EXISTS revision_label text,
+  ADD COLUMN IF NOT EXISTS platform text,
+  ADD COLUMN IF NOT EXISTS publisher_name text,
+  ADD COLUMN IF NOT EXISTS publication_date date,
+  ADD COLUMN IF NOT EXISTS effective_date date,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS verification_status text NOT NULL DEFAULT 'unknown',
+  ADD COLUMN IF NOT EXISTS base_rule_set_id uuid REFERENCES public.rule_sets(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS relation_type text,
+  ADD COLUMN IF NOT EXISTS variant_label text,
+  ADD COLUMN IF NOT EXISTS source_ids text[] NOT NULL DEFAULT '{}';
+
+ALTER TABLE public.rule_sets
+  DROP CONSTRAINT IF EXISTS rule_sets_game_id_version_key;
+
+DROP INDEX IF EXISTS public.rule_sets_one_active_per_game;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_status_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_status_check
+      CHECK (status IN ('unknown', 'active', 'superseded'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_verification_status_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_verification_status_check
+      CHECK (verification_status IN ('unknown', 'source_bound', 'verified', 'rejected'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_relation_type_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_relation_type_check
+      CHECK (relation_type IS NULL OR relation_type IN ('derived_from', 'variant_of', 'translation_of', 'supersedes'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_relation_pair_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_relation_pair_check
+      CHECK ((base_rule_set_id IS NULL) = (relation_type IS NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_no_self_parent_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_no_self_parent_check
+      CHECK (base_rule_set_id IS NULL OR base_rule_set_id <> id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_variant_label_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_variant_label_check
+      CHECK (relation_type <> 'variant_of' OR (variant_label IS NOT NULL AND btrim(variant_label) <> ''));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'rule_sets_status_activity_check'
+      AND conrelid = 'public.rule_sets'::regclass
+  ) THEN
+    ALTER TABLE public.rule_sets
+      ADD CONSTRAINT rule_sets_status_activity_check
+      CHECK (
+        (status <> 'superseded' OR NOT is_active)
+        AND (status <> 'active' OR is_active)
+      );
+  END IF;
+END $$;
+
+-- Keep multiple simultaneously active RuleSets for one Game when their identity
+-- axes differ (for example publisher physical rules vs BGA, or ja vs en).
+-- Do not infer any missing edition/language/platform/revision during migration.
+CREATE UNIQUE INDEX IF NOT EXISTS rule_sets_identity_version_unique
+  ON public.rule_sets (
+    game_id,
+    COALESCE(edition_label, ''),
+    COALESCE(language_code, ''),
+    COALESCE(platform, ''),
+    COALESCE(revision_label, ''),
+    COALESCE(variant_label, ''),
+    version
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS rule_sets_one_active_per_identity
+  ON public.rule_sets (
+    game_id,
+    COALESCE(edition_label, ''),
+    COALESCE(language_code, ''),
+    COALESCE(platform, ''),
+    COALESCE(revision_label, ''),
+    COALESCE(variant_label, '')
+  )
+  WHERE is_active;
+
+CREATE INDEX IF NOT EXISTS rule_sets_game_active_idx
+  ON public.rule_sets (game_id, is_active, version DESC);
+
+CREATE INDEX IF NOT EXISTS rule_sets_base_relation_idx
+  ON public.rule_sets (base_rule_set_id, relation_type)
+  WHERE base_rule_set_id IS NOT NULL;
+
+COMMIT;

--- a/backend/app/models/ruleset.py
+++ b/backend/app/models/ruleset.py
@@ -1,0 +1,88 @@
+from datetime import date
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+RULESET_SCHEMA_VERSION = "1.0"
+
+
+class RuleSetStatus(StrEnum):
+    UNKNOWN = "unknown"
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+
+
+class RuleSetVerificationStatus(StrEnum):
+    UNKNOWN = "unknown"
+    SOURCE_BOUND = "source_bound"
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+
+
+class RuleSetRelationType(StrEnum):
+    DERIVED_FROM = "derived_from"
+    VARIANT_OF = "variant_of"
+    TRANSLATION_OF = "translation_of"
+    SUPERSEDES = "supersedes"
+
+
+class RuleSetSchema(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class RuleSet(RuleSetSchema):
+    ruleset_id: str = Field(min_length=1)
+    game_id: str = Field(min_length=1)
+    work_id: str | None = None
+    version: int = Field(default=1, ge=1)
+    schema_version: str = "1.0"
+
+    language_code: str | None = Field(default=None, min_length=2, max_length=35)
+    edition_label: str | None = None
+    revision_label: str | None = None
+    source_revision: str | None = None
+    platform: str | None = None
+    publisher_name: str | None = None
+    publication_date: date | None = None
+    effective_date: date | None = None
+
+    status: RuleSetStatus = RuleSetStatus.UNKNOWN
+    verification_status: RuleSetVerificationStatus = RuleSetVerificationStatus.UNKNOWN
+    is_active: bool = True
+
+    base_rule_set_id: str | None = None
+    relation_type: RuleSetRelationType | None = None
+    variant_label: str | None = None
+    source_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_identity_and_relation(self):
+        if self.base_rule_set_id == self.ruleset_id:
+            raise ValueError("a ruleset cannot derive from itself")
+        if (self.base_rule_set_id is None) != (self.relation_type is None):
+            raise ValueError("base_rule_set_id and relation_type must be provided together")
+        if self.relation_type == RuleSetRelationType.VARIANT_OF and not self.variant_label:
+            raise ValueError("variant_of rulesets require variant_label")
+        if self.status == RuleSetStatus.SUPERSEDED and self.is_active:
+            raise ValueError("superseded rulesets cannot be active")
+        if self.status == RuleSetStatus.ACTIVE and not self.is_active:
+            raise ValueError("active rulesets must be active")
+        return self
+
+
+class RuleSetListResponse(RuleSetSchema):
+    schema_version: Literal["1.0"] = RULESET_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    rulesets: list[RuleSet] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_availability(self):
+        if self.status == "not_available" and self.rulesets:
+            raise ValueError("not_available ruleset responses must be empty")
+        for ruleset in self.rulesets:
+            if ruleset.game_id != self.game_id:
+                raise ValueError("ruleset belongs to a different game")
+        return self

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -4,11 +4,13 @@ from app.core.rate_limiter import RateLimiter
 from app.models import GameDetail, GameListResponse, GameUpdate, SearchRequest
 from app.models.concept_taxonomy import ConceptDetailResponse, GameConceptsReadResponse, GameGlossaryReadResponse
 from app.models.rule_graph import RuleGraphReadResponse, RuleNodeType
+from app.models.ruleset import RuleSetListResponse
 from app.routers.auth import require_catalog_editor
 from app.services import catalog_access
 from app.services.concept_taxonomy import ConceptTaxonomyService
 from app.services.game_service import GameService
 from app.services.rule_graph import RuleGraphService
+from app.services.rulesets import RuleSetService
 
 router = APIRouter()
 
@@ -23,6 +25,10 @@ def get_game_service():
 
 def get_rule_graph_service():
     return RuleGraphService()
+
+
+def get_ruleset_service():
+    return RuleSetService()
 
 
 def get_concept_taxonomy_service():
@@ -104,13 +110,25 @@ async def get_game_glossary(
     return glossary
 
 
+@router.get("/games/{slug}/rule-sets", response_model=RuleSetListResponse)
+async def get_game_rule_sets(
+    slug: str,
+    service: RuleSetService = Depends(get_ruleset_service),
+):
+    rulesets = await service.get_by_slug(slug)
+    if rulesets is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return rulesets
+
+
 @router.get("/games/{slug}/rule-graph", response_model=RuleGraphReadResponse)
 async def get_game_rule_graph(
     slug: str,
     types: list[RuleNodeType] | None = Query(default=None),
+    rule_set_id: str | None = Query(default=None),
     service: RuleGraphService = Depends(get_rule_graph_service),
 ):
-    graph = await service.get_by_slug(slug, rule_types=types)
+    graph = await service.get_by_slug(slug, rule_types=types, rule_set_id=rule_set_id)
     if graph is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     return graph

--- a/backend/app/services/rule_graph.py
+++ b/backend/app/services/rule_graph.py
@@ -19,6 +19,7 @@ class RuleGraphService:
         self,
         slug: str,
         rule_types: Iterable[RuleNodeType] | None = None,
+        rule_set_id: str | None = None,
     ) -> RuleGraphReadResponse | None:
         game = await supabase.get_by_slug(slug)
         if not game:
@@ -28,16 +29,13 @@ class RuleGraphService:
             "game_id": str(game["id"]),
             "slug": str(game["slug"]),
             "work_id": str(game["work_id"]) if game.get("work_id") else None,
-            "edition_label": game.get("edition_label"),
-            "language_code": game.get("language_code"),
-            "source_revision": game.get("source_revision"),
         }
 
         if supabase.is_local():
             return RuleGraphReadResponse(status="not_available", **base)
 
         try:
-            graph = await anyio.to_thread.run_sync(self._load_graph, game, base)
+            graph = await anyio.to_thread.run_sync(self._load_graph, game, base, rule_set_id)
         except Exception as exc:
             # Deploying application code before the database migration must fail closed.
             logger.warning("Rule graph unavailable for %s: %s", slug, exc)
@@ -48,18 +46,37 @@ class RuleGraphService:
         return graph
 
     @staticmethod
-    def _load_graph(game: dict, base: dict) -> RuleGraphReadResponse:
+    def _load_graph(game: dict, base: dict, rule_set_id: str | None) -> RuleGraphReadResponse:
         client = supabase._get_client()
-        rule_sets = (
-            client.table("rule_sets")
-            .select("*")
-            .eq("game_id", game["id"])
-            .eq("is_active", True)
-            .order("version", desc=True)
-            .limit(1)
-            .execute()
-            .data
-        )
+
+        if rule_set_id:
+            rule_sets = (
+                client.table("rule_sets")
+                .select("*")
+                .eq("game_id", game["id"])
+                .eq("id", rule_set_id)
+                .limit(1)
+                .execute()
+                .data
+            )
+        else:
+            # Multiple simultaneously active RuleSets are valid after migration 013
+            # (for example physical publisher rules + BGA implementation). Never
+            # guess which truth boundary the caller intended.
+            rule_sets = (
+                client.table("rule_sets")
+                .select("*")
+                .eq("game_id", game["id"])
+                .eq("is_active", True)
+                .order("version", desc=True)
+                .limit(2)
+                .execute()
+                .data
+            )
+            if len(rule_sets) > 1:
+                logger.info("RuleSet selection required for game %s", game.get("slug"))
+                return RuleGraphReadResponse(status="not_available", **base)
+
         if not rule_sets:
             return RuleGraphReadResponse(status="not_available", **base)
 
@@ -111,8 +128,10 @@ class RuleGraphService:
         return RuleGraphReadResponse(
             status="available",
             rule_set_id=str(rule_set["id"]),
-            source_revision=rule_set.get("source_revision") or base.get("source_revision"),
+            edition_label=rule_set.get("edition_label"),
+            language_code=rule_set.get("language_code"),
+            source_revision=rule_set.get("source_revision"),
             nodes=nodes,
             edges=edges,
-            **{key: value for key, value in base.items() if key != "source_revision"},
+            **base,
         )

--- a/backend/app/services/rulesets.py
+++ b/backend/app/services/rulesets.py
@@ -1,0 +1,78 @@
+import logging
+
+import anyio
+
+from app.core import supabase
+from app.models.ruleset import RuleSet, RuleSetListResponse
+
+logger = logging.getLogger("services.rulesets")
+
+
+class RuleSetService:
+    async def get_by_slug(self, slug: str) -> RuleSetListResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+
+        base = {
+            "game_id": str(game["id"]),
+            "slug": str(game["slug"]),
+        }
+
+        if supabase.is_local():
+            return RuleSetListResponse(status="not_available", **base)
+
+        try:
+            rows = await anyio.to_thread.run_sync(self._load_rulesets, game)
+        except Exception as exc:
+            # Application code may be deployed before migration 013. Fail closed
+            # instead of inferring edition/platform identity from legacy Game data.
+            logger.warning("RuleSet identity unavailable for %s: %s", slug, exc)
+            return RuleSetListResponse(status="not_available", **base)
+
+        if not rows:
+            return RuleSetListResponse(status="not_available", **base)
+
+        return RuleSetListResponse(
+            status="available",
+            rulesets=[self._to_model(row) for row in rows],
+            **base,
+        )
+
+    @staticmethod
+    def _load_rulesets(game: dict) -> list[dict]:
+        return (
+            supabase._get_client()
+            .table("rule_sets")
+            .select("*")
+            .eq("game_id", game["id"])
+            .order("is_active", desc=True)
+            .order("version", desc=True)
+            .execute()
+            .data
+        )
+
+    @staticmethod
+    def _to_model(row: dict) -> RuleSet:
+        return RuleSet(
+            ruleset_id=str(row["id"]),
+            game_id=str(row["game_id"]),
+            work_id=str(row["work_id"]) if row.get("work_id") else None,
+            version=row.get("version", 1),
+            schema_version=row.get("schema_version") or "1.0",
+            language_code=row.get("language_code"),
+            edition_label=row.get("edition_label"),
+            revision_label=row.get("revision_label"),
+            source_revision=row.get("source_revision"),
+            platform=row.get("platform"),
+            publisher_name=row.get("publisher_name"),
+            publication_date=row.get("publication_date"),
+            effective_date=row.get("effective_date"),
+            status=row.get("status", "unknown"),
+            verification_status=row.get("verification_status", "unknown"),
+            is_active=row.get("is_active", True),
+            base_rule_set_id=(str(row["base_rule_set_id"]) if row.get("base_rule_set_id") else None),
+            relation_type=row.get("relation_type"),
+            variant_label=row.get("variant_label"),
+            source_ids=[str(value) for value in (row.get("source_ids") or [])],
+        )

--- a/backend/tests/test_rule_graph.py
+++ b/backend/tests/test_rule_graph.py
@@ -94,14 +94,18 @@ def test_rule_type_projection_returns_only_requested_canonical_nodes():
 
 
 class FakeRuleGraphService:
-    async def get_by_slug(self, slug: str, rule_types=None):
+    def __init__(self):
+        self.last_rule_set_id = None
+
+    async def get_by_slug(self, slug: str, rule_types=None, rule_set_id=None):
+        self.last_rule_set_id = rule_set_id
         if slug == "missing":
             return None
         graph = RuleGraphReadResponse(
             status="available",
             game_id="game-1",
             slug=slug,
-            rule_set_id="set-1",
+            rule_set_id=rule_set_id or "set-1",
             nodes=[
                 _node("score.points", RuleNodeType.SCORING, "Score points."),
                 _node("end.game", RuleNodeType.GAME_END, "End the game."),
@@ -111,10 +115,10 @@ class FakeRuleGraphService:
         return graph.select_types(set(rule_types or []))
 
 
-def _app():
+def _app(service=None):
     app = FastAPI()
     app.include_router(games.router, prefix="/api")
-    app.dependency_overrides[games.get_rule_graph_service] = lambda: FakeRuleGraphService()
+    app.dependency_overrides[games.get_rule_graph_service] = lambda: service or FakeRuleGraphService()
     return app
 
 
@@ -135,6 +139,17 @@ def test_rule_graph_api_can_query_end_scoring_and_exception_types():
         "scoring",
         "exception",
     }
+
+
+def test_rule_graph_api_accepts_explicit_ruleset_identity():
+    service = FakeRuleGraphService()
+    client = TestClient(_app(service))
+
+    response = client.get("/api/games/example/rule-graph", params={"rule_set_id": "bga-ja-v1"})
+
+    assert response.status_code == 200
+    assert response.json()["rule_set_id"] == "bga-ja-v1"
+    assert service.last_rule_set_id == "bga-ja-v1"
 
 
 def test_rule_graph_api_returns_404_for_unknown_game():

--- a/backend/tests/test_ruleset_identity.py
+++ b/backend/tests/test_ruleset_identity.py
@@ -1,7 +1,7 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
-import pytest
 
 from app.models.ruleset import RuleSet, RuleSetListResponse
 from app.routers import games
@@ -77,6 +77,28 @@ def test_ruleset_response_rejects_cross_game_mix():
             slug="example",
             rulesets=[_ruleset(game_id="game-2")],
         )
+
+
+def test_publisher_and_platform_source_lineage_stays_isolated_by_ruleset():
+    publisher = _ruleset(source_ids=["source.publisher.rules"])
+    bga = _ruleset(
+        ruleset_id="set-bga",
+        language_code="en",
+        edition_label="digital",
+        platform="boardgamearena",
+        source_ids=["source.bga.rules"],
+    )
+
+    response = RuleSetListResponse(
+        status="available",
+        game_id="game-1",
+        slug="example",
+        rulesets=[publisher, bga],
+    )
+
+    assert response.rulesets[0].source_ids == ["source.publisher.rules"]
+    assert response.rulesets[1].source_ids == ["source.bga.rules"]
+    assert set(response.rulesets[0].source_ids).isdisjoint(response.rulesets[1].source_ids)
 
 
 class FakeRuleSetService:

--- a/backend/tests/test_ruleset_identity.py
+++ b/backend/tests/test_ruleset_identity.py
@@ -1,0 +1,125 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+import pytest
+
+from app.models.ruleset import RuleSet, RuleSetListResponse
+from app.routers import games
+
+
+def _ruleset(**overrides):
+    payload = {
+        "ruleset_id": "set-physical-ja",
+        "game_id": "game-1",
+        "version": 1,
+        "language_code": "ja",
+        "edition_label": "base",
+        "platform": "physical",
+        "status": "active",
+        "verification_status": "source_bound",
+        "is_active": True,
+    }
+    payload.update(overrides)
+    return RuleSet(**payload)
+
+
+def test_ruleset_keeps_language_platform_and_revision_as_independent_axes():
+    ruleset = _ruleset(revision_label="2026-08", source_revision="publisher-pdf-r2")
+
+    assert ruleset.language_code == "ja"
+    assert ruleset.platform == "physical"
+    assert ruleset.revision_label == "2026-08"
+    assert ruleset.source_revision == "publisher-pdf-r2"
+
+
+def test_unknown_revision_is_preserved_without_inference():
+    ruleset = _ruleset(revision_label=None, source_revision=None)
+    assert ruleset.revision_label is None
+    assert ruleset.source_revision is None
+
+
+def test_variant_and_translation_relations_are_explicit():
+    variant = _ruleset(
+        ruleset_id="set-brutal",
+        base_rule_set_id="set-base",
+        relation_type="variant_of",
+        variant_label="Brutal Mode",
+    )
+    translated = _ruleset(
+        ruleset_id="set-en",
+        language_code="en",
+        base_rule_set_id="set-ja",
+        relation_type="translation_of",
+    )
+
+    assert variant.relation_type.value == "variant_of"
+    assert translated.relation_type.value == "translation_of"
+
+
+def test_relation_requires_parent_and_variant_requires_label():
+    with pytest.raises(ValidationError):
+        _ruleset(relation_type="derived_from")
+
+    with pytest.raises(ValidationError):
+        _ruleset(base_rule_set_id="set-base", relation_type="variant_of", variant_label=None)
+
+
+def test_superseded_ruleset_cannot_remain_active():
+    with pytest.raises(ValidationError):
+        _ruleset(status="superseded", is_active=True)
+
+
+def test_ruleset_response_rejects_cross_game_mix():
+    with pytest.raises(ValidationError):
+        RuleSetListResponse(
+            status="available",
+            game_id="game-1",
+            slug="example",
+            rulesets=[_ruleset(game_id="game-2")],
+        )
+
+
+class FakeRuleSetService:
+    async def get_by_slug(self, slug: str):
+        if slug == "missing":
+            return None
+        return RuleSetListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            rulesets=[
+                _ruleset(),
+                _ruleset(
+                    ruleset_id="set-bga-en",
+                    language_code="en",
+                    platform="boardgamearena",
+                    edition_label="digital",
+                ),
+            ],
+        )
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(games.router, prefix="/api")
+    app.dependency_overrides[games.get_ruleset_service] = lambda: FakeRuleSetService()
+    return app
+
+
+def test_ruleset_api_lists_multiple_rulesets_for_one_game():
+    client = TestClient(_app())
+    response = client.get("/api/games/example/rule-sets")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "available"
+    assert payload["game_id"] == "game-1"
+    assert len(payload["rulesets"]) == 2
+    assert {item["platform"] for item in payload["rulesets"]} == {"physical", "boardgamearena"}
+    assert {item["language_code"] for item in payload["rulesets"]} == {"ja", "en"}
+
+
+def test_ruleset_api_returns_404_only_for_unknown_game():
+    client = TestClient(_app())
+    response = client.get("/api/games/missing/rule-sets")
+    assert response.status_code == 404

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,9 @@
 - **[`CURATED_GAME_FAST_PATH.md`](./CURATED_GAME_FAST_PATH.md)**
     - 一次情報に基づくゲーム追加の最短運用契約です。1ゲーム=1branch/1PR、対象CI優先、無関係なインフラ障害の分離、成功後の短い効率化レビューを定義します。
 
+- **[`RULESET_IDENTITY_V1.md`](./RULESET_IDENTITY_V1.md)**
+    - Ontology v2 の RuleSet identity contract。Gameとは別にedition / language / platform / revision / variantを保持し、Rule Graph・Component Catalogのtruth boundaryを定義します。
+
 - **[`RULE_GRAPH_V1.md`](./RULE_GRAPH_V1.md)**
     - Ontology v2 の canonical Rule Graph v1。RuleSet / RuleNode / RuleEdge、provenance境界、API、legacy migration mappingを定義します。
 

--- a/docs/RULESET_IDENTITY_V1.md
+++ b/docs/RULESET_IDENTITY_V1.md
@@ -100,6 +100,18 @@ RuleSet候補は次で取得します。
 GET /api/games/{slug}/rule-sets
 ```
 
+## Presentation Projection boundary
+
+#151 Presentation Projection は別truth storeを作らず、必ず選択済みRuleSetのRule Graph / Concept / Evidenceから生成します。
+
+- projection request/outputは対象`rule_set_id`を追跡可能にする
+- active RuleSetが複数ある場合、projection側でpublisher/BGAや言語を自動mergeしない
+- `rule_set_id`未選択でtruth boundaryが一意でなければfail-closedする
+- Quick Rules / setup / scoring / end condition等を別RuleSetから継ぎ合わせない
+- source間の矛盾は上書きで消さず、#175のClaim/Evidence BindingでRuleSetごとに保持する
+
+これにより、同じGameのpublisher rulesとplatform implementationで記述が異なっても、表示projectionが暗黙に混合しません。
+
 ## API response
 
 `RuleSetListResponse`は:
@@ -131,6 +143,7 @@ Rollbackで旧`one active per game`制約を復元すると複数RuleSetを表�
 
 - #148 Ontology v2
 - #149 Rule Graph
+- #151 Presentation Projection
 - #173 Component Catalog
 - #174 RuleSet identity
 - #175 Claim/Evidence Binding

--- a/docs/RULESET_IDENTITY_V1.md
+++ b/docs/RULESET_IDENTITY_V1.md
@@ -1,0 +1,136 @@
+# RuleSet Identity v1
+
+## Purpose
+
+`Game` identityと、実際に適用されるルールの版・言語・platform・revisionを分離するためのcanonical contractです。
+
+```text
+Game
+  └─ RuleSet
+      ├─ RuleNode / RuleEdge
+      └─ ComponentCatalog (Ontology v2 follow-up)
+```
+
+同一Gameに物理版、Board Game Arena実装、改訂版、翻訳版、optional variantが存在しても、RuleNodeやComponentを混線させないことを目的とします。
+
+## Identity boundary
+
+`public.rule_sets.id` をstable `ruleset_id`として扱います。表示ラベルや翻訳名をIDとして使用しません。
+
+RuleSet identityの主要軸は独立して保持します。
+
+- `game_id`: canonical Game identity
+- `edition_label`: edition名。確認できない場合はNULL
+- `language_code`: BCP 47相当のlanguage/locale文字列。確認できない場合はNULL
+- `platform`: `physical`, `boardgamearena`等の実装platform。sourceで確認できる場合のみ
+- `revision_label`: 人間向けrevision label。確認できない場合はNULL
+- `source_revision`: source document/API側のrevision識別子
+- `variant_label`: variant名
+- `version`: repository/database内でのRuleSet record version
+
+NULLはunknownを意味します。migrationやread pathでGame直下のlegacy値からedition/platform/revisionを推測して埋めません。
+
+## Lifecycle and verification
+
+### status
+
+- `unknown`
+- `active`
+- `superseded`
+
+`superseded` RuleSetは`is_active=false`でなければなりません。`active` RuleSetは`is_active=true`でなければなりません。既存recordはmigration時に根拠なく`active`へ昇格させず、`status=unknown`を保持します。
+
+### verification_status
+
+- `unknown`
+- `source_bound`
+- `verified`
+- `rejected`
+
+source URLが存在することとRuleSet identityがverifiedであることは別状態です。field/claim-level evidenceは #175 で追加します。
+
+## Relations
+
+RuleSet間の関係は`base_rule_set_id + relation_type`で明示します。
+
+- `derived_from`
+- `variant_of`
+- `translation_of`
+- `supersedes`
+
+`variant_of`は`variant_label`必須です。self relationは禁止します。
+
+PROV-Oのderivation semanticsと整合するよう、派生関係はGame identityの複製ではなくRuleSet間relationとして保持します。
+
+Primary reference: https://www.w3.org/TR/prov-o/
+
+## PostgreSQL constraints
+
+旧schemaの以下を廃止します。
+
+```text
+UNIQUE(game_id, version)
+UNIQUE active RuleSet per game
+```
+
+これらは同一Gameに物理版+BGA版、またはja+enを同時保持できないためです。
+
+v1ではidentity軸ごとに:
+
+- `(game, edition, language, platform, revision, variant, version)` の重複を禁止
+- active uniquenessは同じidentity軸の組み合わせ内だけに限定
+
+します。異なるplatform/languageのactive RuleSetは同時に存在できます。
+
+PostgreSQL partial unique index reference: https://www.postgresql.org/docs/current/indexes-partial.html
+
+## Rule Graph selection
+
+`GET /api/games/{slug}/rule-graph` は次の契約です。
+
+- active RuleSetが1件だけ: 後方互換としてそのgraphを返せる
+- active RuleSetが複数: 未指定では`not_available`としてfail-closed
+- `rule_set_id`を明示: そのGameに属する指定RuleSetだけを読む
+
+版が複数ある状態で「最新版らしいもの」を自動選択しません。
+
+RuleSet候補は次で取得します。
+
+```http
+GET /api/games/{slug}/rule-sets
+```
+
+## API response
+
+`RuleSetListResponse`は:
+
+- `status`
+- `game_id`
+- `slug`
+- `rulesets[]`
+
+を返します。migration未適用、またはcanonical RuleSet未登録の場合は、Gameが存在していても`status=not_available`・空配列を返し、legacy Game fieldからRuleSetを生成しません。
+
+## Component Catalog contract
+
+#173で導入するComponent Catalogは必ず`ruleset_id`へ所属させます。同名カードでも、改訂版・digital implementation・variantで値や能力が異なる場合に上書きしないためです。
+
+## Migration / rollback
+
+Migration: `backend/app/db/migrations/013_ruleset_identity.sql`
+
+- 既存`rule_sets`を破棄しないadditive migration
+- edition/language/platform/revisionの自動backfillをしない
+- old one-active-per-game indexを削除
+- identity-scope uniquenessへ移行
+- relation/lifecycle/verification constraintsを追加
+
+Rollbackで旧`one active per game`制約を復元すると複数RuleSetを表現できなくなるため、production dataに複数active identityが入った後は単純rollbackしません。必要時はread pathをfail-closedにし、dataを保持したままapplication側を停止します。
+
+## Related issues
+
+- #148 Ontology v2
+- #149 Rule Graph
+- #173 Component Catalog
+- #174 RuleSet identity
+- #175 Claim/Evidence Binding


### PR DESCRIPTION
Closes #174

## Changes
- extend `rule_sets` from one-active-per-game into explicit edition/language/platform/revision/variant identity axes
- preserve existing RuleSet UUID as stable `ruleset_id`
- add lifecycle, verification, base/derived/variant/translation/supersedes relations without inferring missing revision metadata
- add `GET /api/games/{slug}/rule-sets`
- allow `GET /api/games/{slug}/rule-graph?rule_set_id=...` to select an explicit truth boundary
- fail closed when multiple active RuleSets exist and no `rule_set_id` is supplied instead of guessing a preferred edition/platform
- add Pydantic contract tests plus a PostgreSQL migration CI fixture proving physical/BGA/language/revised/variant RuleSets can coexist
- document the canonical RuleSet identity and future Component Catalog ownership boundary

## Migration safety
Migration 013 is additive for existing rows. It does not backfill edition/language/platform/revision from legacy Game fields. Existing rows retain `status=unknown` unless evidence explicitly establishes lifecycle state.

## Primary references
- W3C PROV-O: https://www.w3.org/TR/prov-o/
- Schema.org Game: https://schema.org/Game
- PostgreSQL partial indexes: https://www.postgresql.org/docs/current/indexes-partial.html

## Verification
CI must pass both the Rule Graph contract and the new RuleSet identity contract before merge.