### PR TITLE
Introduce generic Component Catalog ontology

### DIFF
--- a/.github/workflows/test-component-catalog.yml
+++ b/.github/workflows/test-component-catalog.yml
@@ -1,0 +1,227 @@
+name: Component Catalog contract
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/component_catalog.py"
+      - "backend/app/services/component_catalog.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/014_component_catalog.sql"
+      - "backend/tests/test_component_catalog.py"
+      - "docs/COMPONENT_CATALOG_V1.md"
+      - "docs/README.md"
+      - ".github/workflows/test-component-catalog.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/app/models/component_catalog.py"
+      - "backend/app/services/component_catalog.py"
+      - "backend/app/routers/games.py"
+      - "backend/app/db/migrations/014_component_catalog.sql"
+      - "backend/tests/test_component_catalog.py"
+      - "docs/COMPONENT_CATALOG_V1.md"
+      - "docs/README.md"
+      - ".github/workflows/test-component-catalog.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  component-catalog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: component_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d component_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/component_test
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile Component Catalog modules
+        run: >-
+          uv run python -m compileall -q
+          backend/app/models/component_catalog.py
+          backend/app/services/component_catalog.py
+          backend/app/routers/games.py
+
+      - name: Run generic Component Catalog tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_component_catalog.py backend/tests/test_ruleset_identity.py backend/tests/test_rule_graph.py
+
+      - name: Verify relational type and RuleSet boundaries
+        shell: bash
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE TABLE public.game_works (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid()
+          );
+          CREATE TABLE public.games (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            slug text NOT NULL UNIQUE,
+            title text,
+            work_id uuid REFERENCES public.game_works(id)
+          );
+          INSERT INTO public.game_works DEFAULT VALUES;
+          INSERT INTO public.games(slug, title, work_id)
+          SELECT 'component-fixture', 'Component Fixture', id FROM public.game_works LIMIT 1;
+          SQL
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/010_rule_graph.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/011_concept_taxonomy.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/013_ruleset_identity.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/014_component_catalog.sql
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.rule_sets(game_id, version, language_code, edition_label, platform, status, is_active)
+          SELECT id, 1, 'en', 'base', 'physical', 'active', true FROM public.games WHERE slug='component-fixture';
+          INSERT INTO public.rule_sets(game_id, version, language_code, edition_label, platform, status, is_active)
+          SELECT id, 1, 'en', 'digital', 'boardgamearena', 'active', true FROM public.games WHERE slug='component-fixture';
+
+          INSERT INTO public.component_catalogs(rule_set_id)
+          SELECT id FROM public.rule_sets;
+
+          INSERT INTO public.concepts(concept_id, concept_type, definition)
+          VALUES ('resource.energy', 'resource', 'Fixture resource concept');
+
+          INSERT INTO public.rule_nodes(rule_set_id, rule_id, node_type, normalized_statement)
+          SELECT id, 'rule.scout', 'effect', 'Scout effect.' FROM public.rule_sets WHERE platform='physical';
+
+          INSERT INTO public.component_sets(catalog_id, rule_set_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'cards', 'Cards', 'card'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id;
+
+          INSERT INTO public.component_sets(catalog_id, rule_set_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'tiles', 'Tiles', 'tile'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.component_sets(catalog_id, rule_set_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'dice', 'Dice', 'die'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.component_sets(catalog_id, rule_set_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'tokens', 'Tokens', 'token'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.component_property_definitions(catalog_id, rule_set_id, property_key, labels, value_type, cardinality, enum_values, filterable)
+          SELECT cc.id, rs.id, 'faction', '{"en":"Faction"}'::jsonb, 'enum', 'one', ARRAY['sun','moon'], true
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id;
+
+          INSERT INTO public.component_property_definitions(catalog_id, rule_set_id, property_key, value_type, cardinality, sortable)
+          SELECT cc.id, rs.id, 'combat_value', 'integer', 'one', true
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.component_property_definitions(catalog_id, rule_set_id, property_key, value_type, cardinality)
+          SELECT cc.id, rs.id, 'resource_type', 'concept_ref', 'one'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.component_property_definitions(catalog_id, rule_set_id, property_key, value_type, cardinality)
+          SELECT cc.id, rs.id, 'targets', 'component_ref', 'many'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.components(catalog_id, rule_set_id, component_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'card.scout', 'cards', 'Scout', 'card'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id;
+
+          INSERT INTO public.components(catalog_id, rule_set_id, component_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'token.energy', 'tokens', 'Energy Token', 'token'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.components(catalog_id, rule_set_id, component_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'tile.forest', 'tiles', 'Forest Tile', 'tile'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.components(catalog_id, rule_set_id, component_id, component_set_id, canonical_name, kind)
+          SELECT cc.id, rs.id, 'die.action', 'dice', 'Action Die', 'die'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, enum_value)
+          SELECT id, 'card.scout', 'faction', 'enum', 'one', 'sun' FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, integer_value)
+          SELECT id, 'card.scout', 'combat_value', 'integer', 'one', 3 FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, concept_ref_id)
+          SELECT id, 'card.scout', 'resource_type', 'concept_ref', 'one', 'resource.energy' FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, ordinal, component_ref_id)
+          SELECT id, 'die.action', 'targets', 'component_ref', 'many', 0, 'token.energy' FROM public.rule_sets WHERE platform='physical';
+
+          INSERT INTO public.component_abilities(rule_set_id, component_id, ability_id, printed_text)
+          SELECT id, 'card.scout', 'ability.scout', 'Scout printed text.' FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_concepts(rule_set_id, component_id, concept_id)
+          SELECT id, 'token.energy', 'resource.energy' FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_rule_nodes(rule_set_id, component_id, rule_id)
+          SELECT id, 'card.scout', 'rule.scout' FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_ability_concepts(rule_set_id, ability_id, concept_id)
+          SELECT id, 'ability.scout', 'resource.energy' FROM public.rule_sets WHERE platform='physical';
+          INSERT INTO public.component_ability_rule_nodes(rule_set_id, ability_id, rule_id)
+          SELECT id, 'ability.scout', 'rule.scout' FROM public.rule_sets WHERE platform='physical';
+          SQL
+
+          # Same stable component ID/name is valid in two RuleSets, but remains two rows.
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.components where component_id='card.scout' and canonical_name='Scout';")" = "2"
+          test "$(psql "$DATABASE_URL" -Atc "select count(distinct kind) from public.components;")" = "4"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_concepts;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_rule_nodes;")" = "1"
+
+          # A cardinality-one definition cannot accept a second value.
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, ordinal, enum_value)
+          SELECT id, 'card.scout', 'faction', 'enum', 'one', 1, 'moon' FROM public.rule_sets WHERE platform='physical';
+          SQL
+          then
+            echo "cardinality-one duplicate unexpectedly accepted"
+            exit 1
+          fi
+
+          # Definition/type mismatch is rejected by the composite FK.
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, text_value)
+          SELECT id, 'card.scout', 'combat_value', 'text', 'one', 'three' FROM public.rule_sets WHERE platform='physical';
+          SQL
+          then
+            echo "property type mismatch unexpectedly accepted"
+            exit 1
+          fi
+
+          # Verified/source-bound data cannot omit source IDs.
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.components(catalog_id, rule_set_id, component_id, canonical_name, kind, verification_status)
+          SELECT cc.id, rs.id, 'card.unsourced', 'Unsourced', 'card', 'verified'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+          SQL
+          then
+            echo "verified unsourced component unexpectedly accepted"
+            exit 1
+          fi
+
+          # Cross-RuleSet component references are rejected by the composite FK.
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.component_property_definitions(catalog_id, rule_set_id, property_key, value_type, cardinality)
+          SELECT cc.id, rs.id, 'digital_target', 'component_ref', 'many'
+          FROM public.component_catalogs cc JOIN public.rule_sets rs ON rs.id=cc.rule_set_id WHERE rs.platform='physical';
+          INSERT INTO public.component_properties(rule_set_id, component_id, property_key, value_type, cardinality, component_ref_id)
+          SELECT id, 'card.scout', 'digital_target', 'component_ref', 'many', 'card.digital-only' FROM public.rule_sets WHERE platform='physical';
+          SQL
+          then
+            echo "cross/missing RuleSet component reference unexpectedly accepted"
+            exit 1
+          fi

--- a/backend/app/db/migrations/014_component_catalog.sql
+++ b/backend/app/db/migrations/014_component_catalog.sql
@@ -1,0 +1,241 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.component_catalogs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_set_id uuid NOT NULL UNIQUE REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  schema_version text NOT NULL DEFAULT '1.0',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.component_sets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalog_id uuid NOT NULL REFERENCES public.component_catalogs(id) ON DELETE CASCADE,
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  component_set_id text NOT NULL CHECK (component_set_id ~ '^[a-z0-9][a-z0-9._:-]{2,127}$'),
+  canonical_name text NOT NULL CHECK (btrim(canonical_name) <> ''),
+  kind text CHECK (kind IS NULL OR kind IN ('card','tile','token','die','board','figure','sheet','role','marker','track','other')),
+  parent_component_set_id text,
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (verification_status IN ('unknown','source_bound','verified','rejected')),
+  source_ids text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_set_id, component_set_id),
+  CHECK (parent_component_set_id IS NULL OR parent_component_set_id <> component_set_id),
+  CHECK (verification_status NOT IN ('source_bound','verified') OR cardinality(source_ids) > 0)
+);
+
+ALTER TABLE public.component_sets
+  DROP CONSTRAINT IF EXISTS component_sets_parent_fkey;
+ALTER TABLE public.component_sets
+  ADD CONSTRAINT component_sets_parent_fkey
+  FOREIGN KEY (rule_set_id, parent_component_set_id)
+  REFERENCES public.component_sets(rule_set_id, component_set_id)
+  ON DELETE RESTRICT;
+
+CREATE TABLE IF NOT EXISTS public.component_property_definitions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalog_id uuid NOT NULL REFERENCES public.component_catalogs(id) ON DELETE CASCADE,
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  property_key text NOT NULL CHECK (property_key ~ '^[a-z][a-z0-9_.:-]{1,127}$'),
+  labels jsonb NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(labels) = 'object'),
+  value_type text NOT NULL CHECK (value_type IN ('text','integer','number','boolean','enum','concept_ref','component_ref')),
+  cardinality text NOT NULL DEFAULT 'one' CHECK (cardinality IN ('one','many')),
+  unit text,
+  enum_values text[] NOT NULL DEFAULT '{}',
+  filterable boolean NOT NULL DEFAULT false,
+  sortable boolean NOT NULL DEFAULT false,
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (verification_status IN ('unknown','source_bound','verified','rejected')),
+  source_ids text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_set_id, property_key),
+  UNIQUE (rule_set_id, property_key, value_type, cardinality),
+  CHECK ((value_type = 'enum' AND cardinality(enum_values) > 0) OR (value_type <> 'enum' AND cardinality(enum_values) = 0)),
+  CHECK (verification_status NOT IN ('source_bound','verified') OR cardinality(source_ids) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.components (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalog_id uuid NOT NULL REFERENCES public.component_catalogs(id) ON DELETE CASCADE,
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  component_id text NOT NULL CHECK (component_id ~ '^[a-z0-9][a-z0-9._:-]{2,127}$'),
+  component_set_id text,
+  canonical_name text NOT NULL CHECK (btrim(canonical_name) <> ''),
+  kind text NOT NULL CHECK (kind IN ('card','tile','token','die','board','figure','sheet','role','marker','track','other')),
+  quantity integer CHECK (quantity IS NULL OR quantity >= 1),
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (verification_status IN ('unknown','source_bound','verified','rejected')),
+  source_ids text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_set_id, component_id),
+  CHECK (verification_status NOT IN ('source_bound','verified') OR cardinality(source_ids) > 0),
+  CONSTRAINT components_set_fkey
+    FOREIGN KEY (rule_set_id, component_set_id)
+    REFERENCES public.component_sets(rule_set_id, component_set_id)
+    ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS public.component_properties (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  component_id text NOT NULL,
+  property_key text NOT NULL,
+  value_type text NOT NULL,
+  cardinality text NOT NULL,
+  ordinal integer NOT NULL DEFAULT 0 CHECK (ordinal >= 0),
+  text_value text,
+  integer_value bigint,
+  number_value double precision,
+  boolean_value boolean,
+  enum_value text,
+  concept_ref_id text REFERENCES public.concepts(concept_id) ON DELETE RESTRICT,
+  component_ref_id text,
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (verification_status IN ('unknown','source_bound','verified','rejected')),
+  source_ids text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_set_id, component_id, property_key, ordinal),
+  CONSTRAINT component_properties_component_fkey
+    FOREIGN KEY (rule_set_id, component_id)
+    REFERENCES public.components(rule_set_id, component_id)
+    ON DELETE CASCADE,
+  CONSTRAINT component_properties_definition_fkey
+    FOREIGN KEY (rule_set_id, property_key, value_type, cardinality)
+    REFERENCES public.component_property_definitions(rule_set_id, property_key, value_type, cardinality)
+    ON DELETE RESTRICT,
+  CONSTRAINT component_properties_component_ref_fkey
+    FOREIGN KEY (rule_set_id, component_ref_id)
+    REFERENCES public.components(rule_set_id, component_id)
+    ON DELETE RESTRICT,
+  CHECK (num_nonnulls(text_value, integer_value, number_value, boolean_value, enum_value, concept_ref_id, component_ref_id) = 1),
+  CHECK (
+    (value_type = 'text' AND text_value IS NOT NULL) OR
+    (value_type = 'integer' AND integer_value IS NOT NULL) OR
+    (value_type = 'number' AND number_value IS NOT NULL) OR
+    (value_type = 'boolean' AND boolean_value IS NOT NULL) OR
+    (value_type = 'enum' AND enum_value IS NOT NULL) OR
+    (value_type = 'concept_ref' AND concept_ref_id IS NOT NULL) OR
+    (value_type = 'component_ref' AND component_ref_id IS NOT NULL)
+  ),
+  CHECK (verification_status NOT IN ('source_bound','verified') OR cardinality(source_ids) > 0)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS component_properties_cardinality_one
+  ON public.component_properties (rule_set_id, component_id, property_key)
+  WHERE cardinality = 'one';
+
+CREATE TABLE IF NOT EXISTS public.component_abilities (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  component_id text NOT NULL,
+  ability_id text NOT NULL CHECK (ability_id ~ '^[a-z0-9][a-z0-9._:-]{2,127}$'),
+  printed_text text,
+  normalized_label text,
+  verification_status text NOT NULL DEFAULT 'unknown' CHECK (verification_status IN ('unknown','source_bound','verified','rejected')),
+  source_ids text[] NOT NULL DEFAULT '{}',
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (rule_set_id, ability_id),
+  CONSTRAINT component_abilities_component_fkey
+    FOREIGN KEY (rule_set_id, component_id)
+    REFERENCES public.components(rule_set_id, component_id)
+    ON DELETE CASCADE,
+  CHECK (COALESCE(btrim(printed_text), '') <> '' OR COALESCE(btrim(normalized_label), '') <> ''),
+  CHECK (verification_status NOT IN ('source_bound','verified') OR cardinality(source_ids) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.component_concepts (
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  component_id text NOT NULL,
+  concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE RESTRICT,
+  reference_kind text NOT NULL DEFAULT 'classifies' CHECK (reference_kind IN ('classifies','mentions','uses','produces')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (rule_set_id, component_id, concept_id, reference_kind),
+  CONSTRAINT component_concepts_component_fkey
+    FOREIGN KEY (rule_set_id, component_id)
+    REFERENCES public.components(rule_set_id, component_id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS public.component_rule_nodes (
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  component_id text NOT NULL,
+  rule_id text NOT NULL,
+  reference_kind text NOT NULL DEFAULT 'governed_by' CHECK (reference_kind IN ('governed_by','mentioned_by','effect_defined_by')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (rule_set_id, component_id, rule_id, reference_kind),
+  CONSTRAINT component_rule_nodes_component_fkey
+    FOREIGN KEY (rule_set_id, component_id)
+    REFERENCES public.components(rule_set_id, component_id)
+    ON DELETE CASCADE,
+  CONSTRAINT component_rule_nodes_rule_fkey
+    FOREIGN KEY (rule_set_id, rule_id)
+    REFERENCES public.rule_nodes(rule_set_id, rule_id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS public.component_ability_concepts (
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  ability_id text NOT NULL,
+  concept_id text NOT NULL REFERENCES public.concepts(concept_id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (rule_set_id, ability_id, concept_id),
+  CONSTRAINT component_ability_concepts_ability_fkey
+    FOREIGN KEY (rule_set_id, ability_id)
+    REFERENCES public.component_abilities(rule_set_id, ability_id)
+    ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS public.component_ability_rule_nodes (
+  rule_set_id uuid NOT NULL REFERENCES public.rule_sets(id) ON DELETE CASCADE,
+  ability_id text NOT NULL,
+  rule_id text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (rule_set_id, ability_id, rule_id),
+  CONSTRAINT component_ability_rule_nodes_ability_fkey
+    FOREIGN KEY (rule_set_id, ability_id)
+    REFERENCES public.component_abilities(rule_set_id, ability_id)
+    ON DELETE CASCADE,
+  CONSTRAINT component_ability_rule_nodes_rule_fkey
+    FOREIGN KEY (rule_set_id, rule_id)
+    REFERENCES public.rule_nodes(rule_set_id, rule_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS component_sets_catalog_idx ON public.component_sets (catalog_id, component_set_id);
+CREATE INDEX IF NOT EXISTS components_catalog_set_idx ON public.components (catalog_id, component_set_id, canonical_name);
+CREATE INDEX IF NOT EXISTS component_properties_component_idx ON public.component_properties (rule_set_id, component_id, property_key, ordinal);
+CREATE INDEX IF NOT EXISTS component_concepts_concept_idx ON public.component_concepts (concept_id, rule_set_id);
+CREATE INDEX IF NOT EXISTS component_rule_nodes_rule_idx ON public.component_rule_nodes (rule_set_id, rule_id);
+
+ALTER TABLE public.component_catalogs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_sets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_property_definitions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.components ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_properties ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_abilities ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_concepts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_rule_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_ability_concepts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.component_ability_rule_nodes ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE VIEW public.component_catalog_audit_summary
+WITH (security_invoker = true) AS
+SELECT
+  (SELECT count(*) FROM public.component_catalogs) AS catalogs,
+  (SELECT count(*) FROM public.component_sets) AS component_sets,
+  (SELECT count(*) FROM public.components) AS components,
+  (SELECT count(*) FROM public.component_property_definitions) AS property_definitions,
+  (SELECT count(*) FROM public.component_properties) AS component_property_values,
+  (SELECT count(*) FROM public.component_abilities) AS abilities,
+  (SELECT count(*) FROM public.component_concepts) AS component_concept_links,
+  (SELECT count(*) FROM public.component_rule_nodes) AS component_rule_links,
+  (SELECT count(*) FROM public.component_properties WHERE verification_status = 'unknown') AS unknown_property_values;
+
+COMMIT;

--- a/backend/app/models/component_catalog.py
+++ b/backend/app/models/component_catalog.py
@@ -1,0 +1,290 @@
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+COMPONENT_CATALOG_SCHEMA_VERSION = "1.0"
+STABLE_ID_PATTERN = r"^[a-z0-9][a-z0-9._:-]{2,127}$"
+PROPERTY_KEY_PATTERN = r"^[a-z][a-z0-9_.:-]{1,127}$"
+
+
+class ComponentKind(StrEnum):
+    CARD = "card"
+    TILE = "tile"
+    TOKEN = "token"
+    DIE = "die"
+    BOARD = "board"
+    FIGURE = "figure"
+    SHEET = "sheet"
+    ROLE = "role"
+    MARKER = "marker"
+    TRACK = "track"
+    OTHER = "other"
+
+
+class PropertyValueType(StrEnum):
+    TEXT = "text"
+    INTEGER = "integer"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    ENUM = "enum"
+    CONCEPT_REF = "concept_ref"
+    COMPONENT_REF = "component_ref"
+
+
+class PropertyCardinality(StrEnum):
+    ONE = "one"
+    MANY = "many"
+
+
+class ComponentVerificationStatus(StrEnum):
+    UNKNOWN = "unknown"
+    SOURCE_BOUND = "source_bound"
+    VERIFIED = "verified"
+    REJECTED = "rejected"
+
+
+class ComponentModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+def _require_sources_for_verified(status: ComponentVerificationStatus, source_ids: list[str]) -> None:
+    if status in {ComponentVerificationStatus.SOURCE_BOUND, ComponentVerificationStatus.VERIFIED} and not source_ids:
+        raise ValueError("source-bound or verified component data requires source_ids")
+
+
+class TextPropertyValue(ComponentModel):
+    value_type: Literal["text"] = "text"
+    value: str = Field(min_length=1)
+
+
+class IntegerPropertyValue(ComponentModel):
+    value_type: Literal["integer"] = "integer"
+    value: int
+
+
+class NumberPropertyValue(ComponentModel):
+    value_type: Literal["number"] = "number"
+    value: float
+
+
+class BooleanPropertyValue(ComponentModel):
+    value_type: Literal["boolean"] = "boolean"
+    value: bool
+
+
+class EnumPropertyValue(ComponentModel):
+    value_type: Literal["enum"] = "enum"
+    value: str = Field(min_length=1)
+
+
+class ConceptRefPropertyValue(ComponentModel):
+    value_type: Literal["concept_ref"] = "concept_ref"
+    value: str = Field(pattern=STABLE_ID_PATTERN)
+
+
+class ComponentRefPropertyValue(ComponentModel):
+    value_type: Literal["component_ref"] = "component_ref"
+    value: str = Field(pattern=STABLE_ID_PATTERN)
+
+
+PropertyValue = Annotated[
+    TextPropertyValue
+    | IntegerPropertyValue
+    | NumberPropertyValue
+    | BooleanPropertyValue
+    | EnumPropertyValue
+    | ConceptRefPropertyValue
+    | ComponentRefPropertyValue,
+    Field(discriminator="value_type"),
+]
+
+
+class PropertyDefinition(ComponentModel):
+    property_key: str = Field(pattern=PROPERTY_KEY_PATTERN)
+    labels: dict[str, str] = Field(default_factory=dict)
+    value_type: PropertyValueType
+    cardinality: PropertyCardinality = PropertyCardinality.ONE
+    unit: str | None = None
+    enum_values: list[str] = Field(default_factory=list)
+    filterable: bool = False
+    sortable: bool = False
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_definition(self):
+        if self.value_type == PropertyValueType.ENUM:
+            if not self.enum_values:
+                raise ValueError("enum property definitions require enum_values")
+            if len(set(self.enum_values)) != len(self.enum_values):
+                raise ValueError("enum_values must be unique")
+        elif self.enum_values:
+            raise ValueError("enum_values are only valid for enum definitions")
+        _require_sources_for_verified(self.verification_status, self.source_ids)
+        return self
+
+
+class ComponentProperty(ComponentModel):
+    property_key: str = Field(pattern=PROPERTY_KEY_PATTERN)
+    values: list[PropertyValue] = Field(min_length=1)
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_values(self):
+        value_types = {value.value_type for value in self.values}
+        if len(value_types) != 1:
+            raise ValueError("all values for one property must use the same value_type")
+        _require_sources_for_verified(self.verification_status, self.source_ids)
+        return self
+
+
+class ComponentSet(ComponentModel):
+    component_set_id: str = Field(pattern=STABLE_ID_PATTERN)
+    ruleset_id: str = Field(min_length=1)
+    canonical_name: str = Field(min_length=1)
+    kind: ComponentKind | None = None
+    parent_component_set_id: str | None = Field(default=None, pattern=STABLE_ID_PATTERN)
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_set(self):
+        if self.parent_component_set_id == self.component_set_id:
+            raise ValueError("component set cannot be its own parent")
+        _require_sources_for_verified(self.verification_status, self.source_ids)
+        return self
+
+
+class Ability(ComponentModel):
+    ability_id: str = Field(pattern=STABLE_ID_PATTERN)
+    printed_text: str | None = None
+    normalized_label: str | None = None
+    rule_ids: list[str] = Field(default_factory=list)
+    concept_ids: list[str] = Field(default_factory=list)
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_ability(self):
+        if not self.printed_text and not self.normalized_label:
+            raise ValueError("ability requires printed_text or normalized_label")
+        _require_sources_for_verified(self.verification_status, self.source_ids)
+        return self
+
+
+class Component(ComponentModel):
+    component_id: str = Field(pattern=STABLE_ID_PATTERN)
+    ruleset_id: str = Field(min_length=1)
+    component_set_id: str | None = Field(default=None, pattern=STABLE_ID_PATTERN)
+    canonical_name: str = Field(min_length=1)
+    kind: ComponentKind
+    quantity: int | None = Field(default=None, ge=1)
+    properties: list[ComponentProperty] = Field(default_factory=list)
+    abilities: list[Ability] = Field(default_factory=list)
+    concept_ids: list[str] = Field(default_factory=list)
+    rule_ids: list[str] = Field(default_factory=list)
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_component(self):
+        keys = [prop.property_key for prop in self.properties]
+        if len(keys) != len(set(keys)):
+            raise ValueError("component properties must have unique property_key values")
+        ability_ids = [ability.ability_id for ability in self.abilities]
+        if len(ability_ids) != len(set(ability_ids)):
+            raise ValueError("component ability_id values must be unique")
+        _require_sources_for_verified(self.verification_status, self.source_ids)
+        return self
+
+
+class ComponentCatalog(ComponentModel):
+    schema_version: Literal["1.0"] = COMPONENT_CATALOG_SCHEMA_VERSION
+    ruleset_id: str = Field(min_length=1)
+    component_sets: list[ComponentSet] = Field(default_factory=list)
+    property_definitions: list[PropertyDefinition] = Field(default_factory=list)
+    components: list[Component] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_catalog(self):
+        set_ids = {item.component_set_id for item in self.component_sets}
+        if len(set_ids) != len(self.component_sets):
+            raise ValueError("duplicate component_set_id")
+        definition_by_key = {item.property_key: item for item in self.property_definitions}
+        if len(definition_by_key) != len(self.property_definitions):
+            raise ValueError("duplicate property_key")
+        component_ids = {item.component_id for item in self.components}
+        if len(component_ids) != len(self.components):
+            raise ValueError("duplicate component_id within ruleset")
+
+        for item in self.component_sets:
+            if item.ruleset_id != self.ruleset_id:
+                raise ValueError("component set belongs to a different ruleset")
+            if item.parent_component_set_id and item.parent_component_set_id not in set_ids:
+                raise ValueError("parent component set is not present in catalog")
+
+        for component in self.components:
+            if component.ruleset_id != self.ruleset_id:
+                raise ValueError("component belongs to a different ruleset")
+            if component.component_set_id and component.component_set_id not in set_ids:
+                raise ValueError("component references an unknown component set")
+            for prop in component.properties:
+                definition = definition_by_key.get(prop.property_key)
+                if definition is None:
+                    raise ValueError(f"unknown property definition: {prop.property_key}")
+                if definition.cardinality == PropertyCardinality.ONE and len(prop.values) != 1:
+                    raise ValueError(f"property {prop.property_key} requires cardinality one")
+                actual_type = prop.values[0].value_type
+                if actual_type != definition.value_type.value:
+                    raise ValueError(f"property {prop.property_key} has the wrong value type")
+                if definition.value_type == PropertyValueType.ENUM:
+                    invalid = [value.value for value in prop.values if value.value not in definition.enum_values]
+                    if invalid:
+                        raise ValueError(f"property {prop.property_key} contains an unknown enum value")
+                if definition.value_type == PropertyValueType.COMPONENT_REF:
+                    unknown = [value.value for value in prop.values if value.value not in component_ids]
+                    if unknown:
+                        raise ValueError(f"property {prop.property_key} references an unknown component")
+        return self
+
+
+class ComponentSetListResponse(ComponentModel):
+    schema_version: Literal["1.0"] = COMPONENT_CATALOG_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    ruleset_id: str
+    component_sets: list[ComponentSet] = Field(default_factory=list)
+    property_definitions: list[PropertyDefinition] = Field(default_factory=list)
+
+
+class ComponentListItem(ComponentModel):
+    component_id: str
+    component_set_id: str | None = None
+    canonical_name: str
+    kind: ComponentKind
+    quantity: int | None = None
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+
+
+class ComponentListResponse(ComponentModel):
+    schema_version: Literal["1.0"] = COMPONENT_CATALOG_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    ruleset_id: str
+    components: list[ComponentListItem] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    limit: int = Field(default=100, ge=1, le=500)
+    offset: int = Field(default=0, ge=0)
+
+
+class ComponentDetailResponse(ComponentModel):
+    schema_version: Literal["1.0"] = COMPONENT_CATALOG_SCHEMA_VERSION
+    status: Literal["available"] = "available"
+    game_id: str
+    slug: str
+    ruleset_id: str
+    component: Component

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -2,11 +2,18 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from app.core.rate_limiter import RateLimiter
 from app.models import GameDetail, GameListResponse, GameUpdate, SearchRequest
+from app.models.component_catalog import (
+    ComponentDetailResponse,
+    ComponentKind,
+    ComponentListResponse,
+    ComponentSetListResponse,
+)
 from app.models.concept_taxonomy import ConceptDetailResponse, GameConceptsReadResponse, GameGlossaryReadResponse
 from app.models.rule_graph import RuleGraphReadResponse, RuleNodeType
 from app.models.ruleset import RuleSetListResponse
 from app.routers.auth import require_catalog_editor
 from app.services import catalog_access
+from app.services.component_catalog import ComponentCatalogService
 from app.services.concept_taxonomy import ConceptTaxonomyService
 from app.services.game_service import GameService
 from app.services.rule_graph import RuleGraphService
@@ -29,6 +36,10 @@ def get_rule_graph_service():
 
 def get_ruleset_service():
     return RuleSetService()
+
+
+def get_component_catalog_service():
+    return ComponentCatalogService()
 
 
 def get_concept_taxonomy_service():
@@ -119,6 +130,54 @@ async def get_game_rule_sets(
     if rulesets is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     return rulesets
+
+
+@router.get("/games/{slug}/component-sets", response_model=ComponentSetListResponse)
+async def get_game_component_sets(
+    slug: str,
+    rule_set_id: str = Query(..., min_length=1),
+    service: ComponentCatalogService = Depends(get_component_catalog_service),
+):
+    result = await service.get_sets(slug, rule_set_id)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return result
+
+
+@router.get("/games/{slug}/components", response_model=ComponentListResponse)
+async def list_game_components(
+    slug: str,
+    rule_set_id: str = Query(..., min_length=1),
+    component_set_id: str | None = Query(default=None),
+    kind: ComponentKind | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    service: ComponentCatalogService = Depends(get_component_catalog_service),
+):
+    result = await service.list_components(
+        slug,
+        rule_set_id,
+        component_set_id=component_set_id,
+        kind=kind.value if kind else None,
+        limit=limit,
+        offset=offset,
+    )
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return result
+
+
+@router.get("/games/{slug}/components/{component_id}", response_model=ComponentDetailResponse)
+async def get_game_component(
+    slug: str,
+    component_id: str,
+    rule_set_id: str = Query(..., min_length=1),
+    service: ComponentCatalogService = Depends(get_component_catalog_service),
+):
+    result = await service.get_component(slug, rule_set_id, component_id)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Component not found")
+    return result
 
 
 @router.get("/games/{slug}/rule-graph", response_model=RuleGraphReadResponse)

--- a/backend/app/services/component_catalog.py
+++ b/backend/app/services/component_catalog.py
@@ -1,0 +1,338 @@
+import logging
+from collections import defaultdict
+
+import anyio
+
+from app.core import supabase
+from app.models.component_catalog import (
+    Ability,
+    BooleanPropertyValue,
+    Component,
+    ComponentDetailResponse,
+    ComponentListItem,
+    ComponentListResponse,
+    ComponentProperty,
+    ComponentRefPropertyValue,
+    ComponentSet,
+    ComponentSetListResponse,
+    ConceptRefPropertyValue,
+    EnumPropertyValue,
+    IntegerPropertyValue,
+    NumberPropertyValue,
+    PropertyDefinition,
+    TextPropertyValue,
+)
+
+logger = logging.getLogger("services.component_catalog")
+
+
+class ComponentCatalogService:
+    async def get_sets(self, slug: str, rule_set_id: str) -> ComponentSetListResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        base = {"game_id": str(game["id"]), "slug": str(game["slug"]), "ruleset_id": rule_set_id}
+        if supabase.is_local():
+            return ComponentSetListResponse(status="not_available", **base)
+        try:
+            return await anyio.to_thread.run_sync(self._load_sets, game, rule_set_id, base)
+        except Exception as exc:
+            logger.warning("Component catalog sets unavailable for %s/%s: %s", slug, rule_set_id, exc)
+            return ComponentSetListResponse(status="not_available", **base)
+
+    async def list_components(
+        self,
+        slug: str,
+        rule_set_id: str,
+        component_set_id: str | None = None,
+        kind: str | None = None,
+        limit: int = 100,
+        offset: int = 0,
+    ) -> ComponentListResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        base = {"game_id": str(game["id"]), "slug": str(game["slug"]), "ruleset_id": rule_set_id}
+        if supabase.is_local():
+            return ComponentListResponse(status="not_available", limit=limit, offset=offset, **base)
+        try:
+            return await anyio.to_thread.run_sync(
+                self._load_component_list,
+                game,
+                rule_set_id,
+                component_set_id,
+                kind,
+                limit,
+                offset,
+                base,
+            )
+        except Exception as exc:
+            logger.warning("Component list unavailable for %s/%s: %s", slug, rule_set_id, exc)
+            return ComponentListResponse(status="not_available", limit=limit, offset=offset, **base)
+
+    async def get_component(self, slug: str, rule_set_id: str, component_id: str) -> ComponentDetailResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        if supabase.is_local():
+            return None
+        try:
+            return await anyio.to_thread.run_sync(self._load_component_detail, game, rule_set_id, component_id)
+        except Exception as exc:
+            logger.warning("Component detail unavailable for %s/%s/%s: %s", slug, rule_set_id, component_id, exc)
+            return None
+
+    @staticmethod
+    def _context(client, game: dict, rule_set_id: str) -> dict | None:
+        rule_sets = (
+            client.table("rule_sets")
+            .select("id,game_id")
+            .eq("id", rule_set_id)
+            .eq("game_id", game["id"])
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rule_sets:
+            return None
+        catalogs = client.table("component_catalogs").select("id").eq("rule_set_id", rule_set_id).limit(1).execute().data
+        if not catalogs:
+            return None
+        return {"catalog_id": catalogs[0]["id"], "rule_set_id": rule_set_id}
+
+    @classmethod
+    def _load_sets(cls, game: dict, rule_set_id: str, base: dict) -> ComponentSetListResponse:
+        client = supabase._get_client()
+        context = cls._context(client, game, rule_set_id)
+        if context is None:
+            return ComponentSetListResponse(status="not_available", **base)
+        set_rows = (
+            client.table("component_sets")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .order("canonical_name")
+            .execute()
+            .data
+        )
+        definition_rows = (
+            client.table("component_property_definitions")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .order("property_key")
+            .execute()
+            .data
+        )
+        return ComponentSetListResponse(
+            status="available",
+            component_sets=[cls._set_model(row) for row in set_rows],
+            property_definitions=[cls._definition_model(row) for row in definition_rows],
+            **base,
+        )
+
+    @classmethod
+    def _load_component_list(
+        cls,
+        game: dict,
+        rule_set_id: str,
+        component_set_id: str | None,
+        kind: str | None,
+        limit: int,
+        offset: int,
+        base: dict,
+    ) -> ComponentListResponse:
+        client = supabase._get_client()
+        context = cls._context(client, game, rule_set_id)
+        if context is None:
+            return ComponentListResponse(status="not_available", limit=limit, offset=offset, **base)
+        query = client.table("components").select("*", count="exact").eq("rule_set_id", rule_set_id)
+        if component_set_id:
+            query = query.eq("component_set_id", component_set_id)
+        if kind:
+            query = query.eq("kind", kind)
+        response = query.order("canonical_name").range(offset, offset + limit - 1).execute()
+        items = [
+            ComponentListItem(
+                component_id=row["component_id"],
+                component_set_id=row.get("component_set_id"),
+                canonical_name=row["canonical_name"],
+                kind=row["kind"],
+                quantity=row.get("quantity"),
+                verification_status=row.get("verification_status", "unknown"),
+            )
+            for row in response.data
+        ]
+        return ComponentListResponse(
+            status="available",
+            components=items,
+            total=response.count if response.count is not None else len(items),
+            limit=limit,
+            offset=offset,
+            **base,
+        )
+
+    @classmethod
+    def _load_component_detail(cls, game: dict, rule_set_id: str, component_id: str) -> ComponentDetailResponse | None:
+        client = supabase._get_client()
+        context = cls._context(client, game, rule_set_id)
+        if context is None:
+            return None
+        rows = (
+            client.table("components")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .eq("component_id", component_id)
+            .limit(1)
+            .execute()
+            .data
+        )
+        if not rows:
+            return None
+        row = rows[0]
+        definitions = {
+            item["property_key"]: cls._definition_model(item)
+            for item in client.table("component_property_definitions").select("*").eq("rule_set_id", rule_set_id).execute().data
+        }
+        property_rows = (
+            client.table("component_properties")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .eq("component_id", component_id)
+            .order("property_key")
+            .order("ordinal")
+            .execute()
+            .data
+        )
+        grouped: dict[str, list[dict]] = defaultdict(list)
+        for prop_row in property_rows:
+            grouped[prop_row["property_key"]].append(prop_row)
+        properties: list[ComponentProperty] = []
+        for property_key, values in grouped.items():
+            definition = definitions[property_key]
+            if definition.cardinality.value == "one" and len(values) != 1:
+                raise ValueError(f"invalid cardinality for {property_key}")
+            typed_values = [cls._property_value(value) for value in values]
+            if any(value.value_type != definition.value_type.value for value in typed_values):
+                raise ValueError(f"invalid property type for {property_key}")
+            if definition.value_type.value == "enum" and any(value.value not in definition.enum_values for value in typed_values):
+                raise ValueError(f"invalid enum value for {property_key}")
+            source_ids = sorted({source for value in values for source in (value.get("source_ids") or [])})
+            statuses = {value.get("verification_status", "unknown") for value in values}
+            status = statuses.pop() if len(statuses) == 1 else "unknown"
+            properties.append(
+                ComponentProperty(
+                    property_key=property_key,
+                    values=typed_values,
+                    verification_status=status,
+                    source_ids=source_ids,
+                )
+            )
+
+        abilities = cls._load_abilities(client, rule_set_id, component_id)
+        concept_ids = [
+            item["concept_id"]
+            for item in client.table("component_concepts").select("concept_id").eq("rule_set_id", rule_set_id).eq("component_id", component_id).execute().data
+        ]
+        rule_ids = [
+            item["rule_id"]
+            for item in client.table("component_rule_nodes").select("rule_id").eq("rule_set_id", rule_set_id).eq("component_id", component_id).execute().data
+        ]
+        component = Component(
+            component_id=row["component_id"],
+            ruleset_id=rule_set_id,
+            component_set_id=row.get("component_set_id"),
+            canonical_name=row["canonical_name"],
+            kind=row["kind"],
+            quantity=row.get("quantity"),
+            properties=properties,
+            abilities=abilities,
+            concept_ids=sorted(set(concept_ids)),
+            rule_ids=sorted(set(rule_ids)),
+            verification_status=row.get("verification_status", "unknown"),
+            source_ids=row.get("source_ids") or [],
+        )
+        return ComponentDetailResponse(
+            game_id=str(game["id"]),
+            slug=str(game["slug"]),
+            ruleset_id=rule_set_id,
+            component=component,
+        )
+
+    @classmethod
+    def _load_abilities(cls, client, rule_set_id: str, component_id: str) -> list[Ability]:
+        rows = (
+            client.table("component_abilities")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .eq("component_id", component_id)
+            .order("ability_id")
+            .execute()
+            .data
+        )
+        abilities: list[Ability] = []
+        for row in rows:
+            concept_ids = [
+                item["concept_id"]
+                for item in client.table("component_ability_concepts").select("concept_id").eq("rule_set_id", rule_set_id).eq("ability_id", row["ability_id"]).execute().data
+            ]
+            rule_ids = [
+                item["rule_id"]
+                for item in client.table("component_ability_rule_nodes").select("rule_id").eq("rule_set_id", rule_set_id).eq("ability_id", row["ability_id"]).execute().data
+            ]
+            abilities.append(
+                Ability(
+                    ability_id=row["ability_id"],
+                    printed_text=row.get("printed_text"),
+                    normalized_label=row.get("normalized_label"),
+                    concept_ids=sorted(set(concept_ids)),
+                    rule_ids=sorted(set(rule_ids)),
+                    verification_status=row.get("verification_status", "unknown"),
+                    source_ids=row.get("source_ids") or [],
+                )
+            )
+        return abilities
+
+    @staticmethod
+    def _set_model(row: dict) -> ComponentSet:
+        return ComponentSet(
+            component_set_id=row["component_set_id"],
+            ruleset_id=str(row["rule_set_id"]),
+            canonical_name=row["canonical_name"],
+            kind=row.get("kind"),
+            parent_component_set_id=row.get("parent_component_set_id"),
+            verification_status=row.get("verification_status", "unknown"),
+            source_ids=row.get("source_ids") or [],
+        )
+
+    @staticmethod
+    def _definition_model(row: dict) -> PropertyDefinition:
+        return PropertyDefinition(
+            property_key=row["property_key"],
+            labels=row.get("labels") or {},
+            value_type=row["value_type"],
+            cardinality=row.get("cardinality", "one"),
+            unit=row.get("unit"),
+            enum_values=row.get("enum_values") or [],
+            filterable=row.get("filterable", False),
+            sortable=row.get("sortable", False),
+            verification_status=row.get("verification_status", "unknown"),
+            source_ids=row.get("source_ids") or [],
+        )
+
+    @staticmethod
+    def _property_value(row: dict):
+        value_type = row["value_type"]
+        if value_type == "text":
+            return TextPropertyValue(value=row["text_value"])
+        if value_type == "integer":
+            return IntegerPropertyValue(value=row["integer_value"])
+        if value_type == "number":
+            return NumberPropertyValue(value=row["number_value"])
+        if value_type == "boolean":
+            return BooleanPropertyValue(value=row["boolean_value"])
+        if value_type == "enum":
+            return EnumPropertyValue(value=row["enum_value"])
+        if value_type == "concept_ref":
+            return ConceptRefPropertyValue(value=row["concept_ref_id"])
+        if value_type == "component_ref":
+            return ComponentRefPropertyValue(value=row["component_ref_id"])
+        raise ValueError(f"unsupported component property value_type: {value_type}")

--- a/backend/tests/test_component_catalog.py
+++ b/backend/tests/test_component_catalog.py
@@ -1,0 +1,240 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from app.models.component_catalog import (
+    Ability,
+    Component,
+    ComponentCatalog,
+    ComponentDetailResponse,
+    ComponentListItem,
+    ComponentListResponse,
+    ComponentProperty,
+    ComponentSet,
+    ComponentSetListResponse,
+    ConceptRefPropertyValue,
+    EnumPropertyValue,
+    IntegerPropertyValue,
+    NumberPropertyValue,
+    PropertyDefinition,
+    ComponentRefPropertyValue,
+)
+from app.routers import games
+
+
+def test_card_catalog_supports_enum_numeric_and_concept_ref_properties():
+    catalog = ComponentCatalog(
+        ruleset_id="ruleset-yro",
+        component_sets=[ComponentSet(component_set_id="adventurers", ruleset_id="ruleset-yro", canonical_name="Adventurers", kind="card")],
+        property_definitions=[
+            PropertyDefinition(property_key="faction", labels={"en": "Faction"}, value_type="enum", enum_values=["sun", "moon"], filterable=True),
+            PropertyDefinition(property_key="combat_value", labels={"en": "Combat Value"}, value_type="integer", sortable=True),
+            PropertyDefinition(property_key="profession", labels={"en": "Profession"}, value_type="concept_ref"),
+        ],
+        components=[
+            Component(
+                component_id="adventurer.scout",
+                ruleset_id="ruleset-yro",
+                component_set_id="adventurers",
+                canonical_name="Scout",
+                kind="card",
+                properties=[
+                    ComponentProperty(property_key="faction", values=[EnumPropertyValue(value="sun")]),
+                    ComponentProperty(property_key="combat_value", values=[IntegerPropertyValue(value=3)]),
+                    ComponentProperty(property_key="profession", values=[ConceptRefPropertyValue(value="profession.scout")]),
+                ],
+            )
+        ],
+    )
+
+    assert catalog.components[0].kind.value == "card"
+    assert catalog.components[0].properties[1].values[0].value == 3
+
+
+def test_tile_catalog_uses_same_generic_contract_without_card_columns():
+    catalog = ComponentCatalog(
+        ruleset_id="ruleset-tile",
+        component_sets=[ComponentSet(component_set_id="terrain.tiles", ruleset_id="ruleset-tile", canonical_name="Terrain Tiles", kind="tile")],
+        property_definitions=[PropertyDefinition(property_key="movement_cost", value_type="number", sortable=True)],
+        components=[
+            Component(
+                component_id="tile.forest",
+                ruleset_id="ruleset-tile",
+                component_set_id="terrain.tiles",
+                canonical_name="Forest",
+                kind="tile",
+                properties=[ComponentProperty(property_key="movement_cost", values=[NumberPropertyValue(value=1.5)])],
+            )
+        ],
+    )
+    assert catalog.components[0].properties[0].values[0].value == 1.5
+
+
+def test_dice_token_catalog_supports_component_ref_and_many_cardinality():
+    catalog = ComponentCatalog(
+        ruleset_id="ruleset-dice",
+        component_sets=[
+            ComponentSet(component_set_id="dice", ruleset_id="ruleset-dice", canonical_name="Dice", kind="die"),
+            ComponentSet(component_set_id="tokens", ruleset_id="ruleset-dice", canonical_name="Tokens", kind="token"),
+        ],
+        property_definitions=[PropertyDefinition(property_key="spends", value_type="component_ref", cardinality="many")],
+        components=[
+            Component(component_id="token.energy", ruleset_id="ruleset-dice", component_set_id="tokens", canonical_name="Energy Token", kind="token"),
+            Component(
+                component_id="die.action",
+                ruleset_id="ruleset-dice",
+                component_set_id="dice",
+                canonical_name="Action Die",
+                kind="die",
+                properties=[
+                    ComponentProperty(
+                        property_key="spends",
+                        values=[ComponentRefPropertyValue(value="token.energy"), ComponentRefPropertyValue(value="token.energy")],
+                    )
+                ],
+            ),
+        ],
+    )
+    assert len(catalog.components[1].properties[0].values) == 2
+
+
+def test_property_type_cardinality_and_enum_are_fail_closed():
+    base = {
+        "ruleset_id": "ruleset-test",
+        "component_sets": [ComponentSet(component_set_id="cards", ruleset_id="ruleset-test", canonical_name="Cards", kind="card")],
+        "property_definitions": [PropertyDefinition(property_key="rank", value_type="enum", enum_values=["low", "high"])],
+    }
+
+    with pytest.raises(ValidationError):
+        ComponentCatalog(
+            **base,
+            components=[
+                Component(
+                    component_id="card.bad-enum",
+                    ruleset_id="ruleset-test",
+                    component_set_id="cards",
+                    canonical_name="Bad Enum",
+                    kind="card",
+                    properties=[ComponentProperty(property_key="rank", values=[EnumPropertyValue(value="unknown")])],
+                )
+            ],
+        )
+
+    with pytest.raises(ValidationError):
+        ComponentCatalog(
+            **base,
+            components=[
+                Component(
+                    component_id="card.bad-cardinality",
+                    ruleset_id="ruleset-test",
+                    component_set_id="cards",
+                    canonical_name="Bad Cardinality",
+                    kind="card",
+                    properties=[ComponentProperty(property_key="rank", values=[EnumPropertyValue(value="low"), EnumPropertyValue(value="high")])],
+                )
+            ],
+        )
+
+
+def test_verified_component_field_requires_source_evidence():
+    with pytest.raises(ValidationError):
+        ComponentProperty(
+            property_key="cost",
+            values=[IntegerPropertyValue(value=2)],
+            verification_status="verified",
+            source_ids=[],
+        )
+
+
+def test_ability_keeps_printed_text_separate_from_rule_and_concept_links():
+    ability = Ability(
+        ability_id="ability.scout.draw",
+        printed_text="Draw one card.",
+        normalized_label="Draw",
+        rule_ids=["rule.draw"],
+        concept_ids=["player_action.draw"],
+    )
+    assert ability.printed_text == "Draw one card."
+    assert ability.rule_ids == ["rule.draw"]
+
+
+def test_same_component_identity_and_name_can_differ_by_ruleset():
+    definition = [PropertyDefinition(property_key="cost", value_type="integer")]
+    first = ComponentCatalog(
+        ruleset_id="ruleset-physical",
+        property_definitions=definition,
+        components=[Component(component_id="card.scout", ruleset_id="ruleset-physical", canonical_name="Scout", kind="card", properties=[ComponentProperty(property_key="cost", values=[IntegerPropertyValue(value=2)])])],
+    )
+    second = ComponentCatalog(
+        ruleset_id="ruleset-digital",
+        property_definitions=definition,
+        components=[Component(component_id="card.scout", ruleset_id="ruleset-digital", canonical_name="Scout", kind="card", properties=[ComponentProperty(property_key="cost", values=[IntegerPropertyValue(value=3)])])],
+    )
+    assert first.components[0].properties[0].values[0].value == 2
+    assert second.components[0].properties[0].values[0].value == 3
+
+
+class FakeComponentCatalogService:
+    async def get_sets(self, slug, rule_set_id):
+        if slug == "missing":
+            return None
+        return ComponentSetListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            ruleset_id=rule_set_id,
+            component_sets=[ComponentSet(component_set_id="cards", ruleset_id=rule_set_id, canonical_name="Cards", kind="card")],
+            property_definitions=[PropertyDefinition(property_key="cost", value_type="integer")],
+        )
+
+    async def list_components(self, slug, rule_set_id, **kwargs):
+        if slug == "missing":
+            return None
+        return ComponentListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            ruleset_id=rule_set_id,
+            components=[ComponentListItem(component_id="card.scout", component_set_id="cards", canonical_name="Scout", kind="card")],
+            total=1,
+            limit=kwargs.get("limit", 100),
+            offset=kwargs.get("offset", 0),
+        )
+
+    async def get_component(self, slug, rule_set_id, component_id):
+        if slug == "missing" or component_id == "missing":
+            return None
+        return ComponentDetailResponse(
+            game_id="game-1",
+            slug=slug,
+            ruleset_id=rule_set_id,
+            component=Component(component_id=component_id, ruleset_id=rule_set_id, component_set_id="cards", canonical_name="Scout", kind="card"),
+        )
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(games.router, prefix="/api")
+    app.dependency_overrides[games.get_component_catalog_service] = lambda: FakeComponentCatalogService()
+    return app
+
+
+def test_component_catalog_api_exposes_sets_list_and_detail():
+    client = TestClient(_app())
+    sets = client.get("/api/games/example/component-sets", params={"rule_set_id": "ruleset-1"})
+    listing = client.get("/api/games/example/components", params={"rule_set_id": "ruleset-1", "kind": "card"})
+    detail = client.get("/api/games/example/components/card.scout", params={"rule_set_id": "ruleset-1"})
+
+    assert sets.status_code == 200
+    assert sets.json()["component_sets"][0]["component_set_id"] == "cards"
+    assert listing.status_code == 200
+    assert listing.json()["total"] == 1
+    assert detail.status_code == 200
+    assert detail.json()["component"]["component_id"] == "card.scout"
+
+
+def test_component_catalog_api_requires_explicit_ruleset_identity():
+    client = TestClient(_app())
+    response = client.get("/api/games/example/components")
+    assert response.status_code == 422

--- a/docs/COMPONENT_CATALOG_V1.md
+++ b/docs/COMPONENT_CATALOG_V1.md
@@ -1,0 +1,230 @@
+# Component Catalog v1
+
+## Purpose
+
+Ontology v2で、意味概念とゲーム内実体を分離する正準component layerです。
+
+```text
+Game
+  └─ RuleSet
+      ├─ Rule Graph
+      ├─ Concept Taxonomy
+      └─ Component Catalog
+          ├─ ComponentSet
+          ├─ PropertyDefinition
+          └─ Component
+              ├─ ComponentProperty
+              └─ Ability
+```
+
+`Concept` は「冒険者カード」「資源トークン」「ドロー」のような意味・分類を表します。`Component` は特定RuleSetに実在する個々のカード種類、タイル種類、トークン、ダイス等を表します。個々のComponentを`ConceptType.COMPONENT`へ大量登録しません。
+
+## RuleSet boundary
+
+Component Catalogは必ず#174の`ruleset_id`に所属します。同じ`component_id` / canonical nameを物理版とdigital版で保持しても、property/abilityを上書きしません。
+
+Game直下へcomponent truthを保存せず、APIも`rule_set_id`を明示必須とします。
+
+## Component kinds
+
+v1:
+
+- card
+- tile
+- token
+- die
+- board
+- figure
+- sheet
+- role
+- marker
+- track
+- other
+
+これは表示カテゴリであり、ゲーム固有の属性列ではありません。
+
+## ComponentSet
+
+Componentを意味のある集合へまとめます。
+
+- stable `component_set_id`
+- `ruleset_id`
+- canonical name
+- optional kind
+- optional parent set
+- verification/source linkage
+
+例: `adventurers`, `quest-cards`, `terrain.tiles`, `resource.tokens`。
+
+## PropertyDefinition
+
+YROの`faction`や`combat_value`のようなgame-specific propertyをglobal `components` tableのnullable columnにはしません。RuleSetごとのPropertyDefinitionで宣言します。
+
+Fields:
+
+- stable `property_key`
+- localized `labels`
+- `value_type`
+- `cardinality`
+- optional `unit`
+- optional enum values
+- `filterable`
+- `sortable`
+- verification/source linkage
+
+Value types:
+
+- text
+- integer
+- number
+- boolean
+- enum
+- concept_ref
+- component_ref
+
+Cardinality:
+
+- one
+- many
+
+Pydantic contractとPostgreSQLのgeneric typed-value columnsの両方で型を表現します。YRO専用、IPSO専用などのproperty columnは追加しません。
+
+## Typed property storage
+
+`component_properties` はゲーム固有列ではなく型ごとのstorage columnを持ちます。
+
+```text
+text_value
+integer_value
+number_value
+boolean_value
+enum_value
+concept_ref_id
+component_ref_id
+```
+
+1 rowではexactly one typed valueだけを許可します。`value_type` / `cardinality` はPropertyDefinitionへの複合FKで一致させ、`cardinality=one`はpartial unique indexで1値に制限します。`component_ref`は同じRuleSet内のComponentへだけ参照できます。
+
+## Component
+
+- stable `component_id` within RuleSet
+- `component_set_id`
+- canonical name
+- kind
+- optional quantity
+- typed properties
+- abilities
+- Concept links
+- RuleNode links
+- verification/source linkage
+
+表示名はidentityではありません。同名componentでもRuleSetが異なれば別versionのproperty/abilityを保持できます。
+
+## Ability
+
+printed component textとnormalized rule truthを分離します。
+
+Abilityは:
+
+- stable `ability_id`
+- optional printed/source text
+- optional normalized label
+- Concept backlinks
+- RuleNode backlinks
+- verification/source linkage
+
+を持ちます。printed text自体をRuleNode statementの代替truthとして扱いません。
+
+## Concept / Rule bridges
+
+Canonical bridge:
+
+```text
+Component -> component_concepts -> Concept
+Component -> component_rule_nodes -> RuleNode
+Ability -> component_ability_concepts -> Concept
+Ability -> component_ability_rule_nodes -> RuleNode
+```
+
+Concept definitionとComponent instance dataを同じrowへ押し込みません。
+
+## Evidence semantics
+
+#175導入前のv1でも`verification_status`と`source_ids`を保持します。
+
+- unknown
+- source_bound
+- verified
+- rejected
+
+`source_bound` / `verified` は空の`source_ids`では保存・model validationできません。source不明propertyをverifiedへ昇格させません。
+
+#175ではこの粗いsource bindingをfield/claim-level EvidenceBindingへ拡張します。v1の`source_ids`を「entity全体が正しい」という意味にはしません。
+
+## API
+
+全routeでRuleSetを明示します。
+
+```http
+GET /api/games/{slug}/component-sets?rule_set_id=...
+GET /api/games/{slug}/components?rule_set_id=...&component_set_id=...&kind=...
+GET /api/games/{slug}/components/{component_id}?rule_set_id=...
+```
+
+Catalog未登録時はlist/set APIを`not_available`でfail-closedにし、legacy keywordやLLMからcomponentを推測生成しません。
+
+## Required generic fixtures
+
+v1 contract testは最低限:
+
+1. card-centric: enum + integer + concept_ref
+2. tile-centric: numeric property
+3. dice/token-centric: component_ref + many cardinality
+
+を同じmodelで検証します。
+
+## PostgreSQL
+
+Migration: `backend/app/db/migrations/014_component_catalog.sql`
+
+主要tables:
+
+- component_catalogs
+- component_sets
+- component_property_definitions
+- components
+- component_properties
+- component_abilities
+- component_concepts
+- component_rule_nodes
+- component_ability_concepts
+- component_ability_rule_nodes
+
+全tableはRLSを有効化し、server-side service pathから読みます。public clientへ暗黙read policyを追加しません。
+
+## Migration / cleanup
+
+014はadditive migrationです。既存Game / Rule Graph / Concept / UIを変更せず導入できます。
+
+- legacy `structured_data.mechanics`へComponentをdual-writeしない
+- game-specific component tableを増やさない
+- component data未登録ゲームは既存UIを変更しない
+- UIは#176でComponent Catalog availabilityを見て段階導入する
+- data ingestionは#178でevidence-gated workflowへ一般化する
+
+## Standards
+
+- W3C SKOS Reference: https://www.w3.org/TR/skos-reference/
+- W3C PROV-O: https://www.w3.org/TR/prov-o/
+- W3C SHACL: https://www.w3.org/TR/shacl/
+
+## Related
+
+- #148 Ontology v2
+- #149 Rule Graph
+- #150 Concept taxonomy
+- #173 Component Catalog
+- #174 RuleSet identity
+- #175 Claim/Evidence Binding
+- #176 Components UI
+- #178 component ingestion

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@
 - **[`CONCEPT_TAXONOMY_V1.md`](./CONCEPT_TAXONOMY_V1.md)**
     - stable concept ID、多言語label、SKOS型relation、Rule Graph backlinks、linked glossary projectionを定義します。
 
+- **[`COMPONENT_CATALOG_V1.md`](./COMPONENT_CATALOG_V1.md)**
+    - Ontology v2 のgame-content instance layer。cards / tiles / tokens / diceを同じgeneric schemaで扱い、PropertyDefinition・typed values・RuleSet/Concept/RuleNode境界を定義します。
+
 - **[`diagrams.md`](./diagrams.md)**
     - システムアーキテクチャ、シーケンス図、ER図などの視覚的な資料が含まれています。
 


### PR DESCRIPTION
Closes #173

## Changes
- add versioned Component Catalog v1 models for ComponentSet / Component / PropertyDefinition / ComponentProperty / Ability
- model card/tile/token/die/board/etc. through one generic ComponentKind contract
- use discriminated typed property values instead of game-specific columns or unbounded `Any`
- add PostgreSQL migration 014 with RuleSet-scoped stable IDs, typed value storage, cardinality constraints, same-RuleSet component references, Concept/RuleNode bridges, Ability bridges, RLS, and audit view
- add explicit RuleSet-scoped read APIs for component sets/property definitions, component lists, and component detail
- keep unknown/unsourced data fail-closed; source-bound/verified fields require source IDs
- validate card-centric, tile-centric, and dice/token-centric fixtures using the same schema
- document Concept vs Component instance boundaries and the handoff to #175/#176/#178

## Compatibility
This is additive. No existing GamePage UI is changed, no component data is inferred from legacy mechanics/keywords, and no existing game receives generated component records.

## Primary references
- W3C SKOS: https://www.w3.org/TR/skos-reference/
- W3C PROV-O: https://www.w3.org/TR/prov-o/
- W3C SHACL: https://www.w3.org/TR/shacl/

## Verification
The dedicated Component Catalog CI applies Rule Graph + Concept + RuleSet + Component migrations to PostgreSQL and verifies type/cardinality/RuleSet constraints in addition to Pydantic/API tests.