### PR TITLE
Use Vercel Git integration as the single production deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build Preview with Vercel
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
-  Deploy-Production:
+  Production-Build-And-Verify:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
@@ -98,5 +98,13 @@ jobs:
         run: python scripts/check_google_oauth.py .vercel/.env.production.local
       - name: Build Production with Vercel
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - name: Deploy Production to Vercel
-        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Verify canonical Vercel Git production deployment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          python scripts/verify_vercel_git_deployment.py
+          --sha "${GITHUB_SHA}"
+          --project-id "${VERCEL_PROJECT_ID}"
+          --team-id "${VERCEL_ORG_ID}"
+          --timeout-seconds 180
+          --poll-seconds 5

--- a/.github/workflows/test-vercel-git-deployment.yml
+++ b/.github/workflows/test-vercel-git-deployment.yml
@@ -1,0 +1,44 @@
+name: Vercel Git deployment verifier
+
+on:
+  pull_request:
+    paths:
+      - "scripts/verify_vercel_git_deployment.py"
+      - "backend/tests/test_vercel_git_deployment.py"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/test-vercel-git-deployment.yml"
+  push:
+    branches: [main]
+    paths:
+      - "scripts/verify_vercel_git_deployment.py"
+      - "backend/tests/test_vercel_git_deployment.py"
+      - ".github/workflows/deploy.yml"
+      - ".github/workflows/test-vercel-git-deployment.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verifier-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Install dependencies
+        run: uv sync --frozen --dev
+      - name: Compile verifier
+        run: uv run python -m compileall -q scripts/verify_vercel_git_deployment.py
+      - name: Test exact-SHA production verification
+        env:
+          PYTHONPATH: .
+        run: uv run pytest -q backend/tests/test_vercel_git_deployment.py
+      - name: Assert Actions does not create a second production deployment
+        shell: bash
+        run: |
+          if grep -Eq 'vercel (deploy|--prod)( |$)' .github/workflows/deploy.yml; then
+            echo "deploy.yml must not create a second Vercel production deployment; Git integration is canonical"
+            exit 1
+          fi
+          grep -F 'verify_vercel_git_deployment.py' .github/workflows/deploy.yml

--- a/backend/tests/test_vercel_git_deployment.py
+++ b/backend/tests/test_vercel_git_deployment.py
@@ -1,0 +1,80 @@
+import pytest
+
+from scripts.verify_vercel_git_deployment import DeploymentMatch, find_deployment_for_sha
+
+
+def test_finds_exact_ready_production_sha():
+    payload = {
+        "deployments": [
+            {
+                "uid": "dpl_new",
+                "url": "example-new.vercel.app",
+                "state": "READY",
+                "target": "production",
+                "meta": {"githubCommitSha": "abc123"},
+            },
+            {
+                "uid": "dpl_old",
+                "url": "example-old.vercel.app",
+                "state": "READY",
+                "target": "production",
+                "meta": {"githubCommitSha": "older"},
+            },
+        ]
+    }
+
+    assert find_deployment_for_sha(payload, "abc123") == DeploymentMatch(
+        deployment_id="dpl_new",
+        url="example-new.vercel.app",
+        state="READY",
+        commit_sha="abc123",
+    )
+
+
+def test_does_not_treat_different_sha_as_current_production():
+    payload = {
+        "deployments": [
+            {
+                "uid": "dpl_old",
+                "state": "READY",
+                "target": "production",
+                "meta": {"githubCommitSha": "older"},
+            }
+        ]
+    }
+    assert find_deployment_for_sha(payload, "expected") is None
+
+
+def test_ignores_preview_for_same_sha():
+    payload = {
+        "deployments": [
+            {
+                "uid": "dpl_preview",
+                "state": "READY",
+                "target": "preview",
+                "meta": {"githubCommitSha": "abc123"},
+            }
+        ]
+    }
+    assert find_deployment_for_sha(payload, "abc123") is None
+
+
+def test_preserves_terminal_failure_state_for_caller():
+    payload = {
+        "deployments": [
+            {
+                "uid": "dpl_error",
+                "state": "ERROR",
+                "target": "production",
+                "meta": {"githubCommitSha": "abc123"},
+            }
+        ]
+    }
+    match = find_deployment_for_sha(payload, "abc123")
+    assert match is not None
+    assert match.state == "ERROR"
+
+
+def test_missing_meta_is_not_inferred_from_position():
+    payload = {"deployments": [{"uid": "dpl_latest", "state": "READY", "target": "production", "meta": {}}]}
+    assert find_deployment_for_sha(payload, "abc123") is None

--- a/scripts/verify_vercel_git_deployment.py
+++ b/scripts/verify_vercel_git_deployment.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Verify that Vercel Git integration deployed the expected GitHub SHA.
+
+This script is read-only: it never creates or retries a Vercel deployment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+API_BASE = "https://api.vercel.com"
+TERMINAL_FAILURE_STATES = {"ERROR", "CANCELED", "CANCELLED", "BLOCKED"}
+READY_STATE = "READY"
+
+
+@dataclass(frozen=True)
+class DeploymentMatch:
+    deployment_id: str
+    url: str | None
+    state: str
+    commit_sha: str
+
+
+def _deployment_state(deployment: dict) -> str:
+    return str(deployment.get("state") or deployment.get("readyState") or "UNKNOWN").upper()
+
+
+def find_deployment_for_sha(payload: dict, expected_sha: str) -> DeploymentMatch | None:
+    """Return the newest production deployment for the exact GitHub commit SHA."""
+    deployments = payload.get("deployments") or []
+    for deployment in deployments:
+        meta = deployment.get("meta") or {}
+        commit_sha = str(meta.get("githubCommitSha") or "")
+        if commit_sha != expected_sha:
+            continue
+        if deployment.get("target") not in (None, "production"):
+            continue
+        return DeploymentMatch(
+            deployment_id=str(deployment.get("uid") or deployment.get("id") or ""),
+            url=deployment.get("url"),
+            state=_deployment_state(deployment),
+            commit_sha=commit_sha,
+        )
+    return None
+
+
+def fetch_production_deployments(*, token: str, team_id: str, project_id: str, limit: int = 20) -> dict:
+    query = urlencode(
+        {
+            "teamId": team_id,
+            "projectId": project_id,
+            "target": "production",
+            "limit": str(limit),
+        }
+    )
+    request = Request(
+        f"{API_BASE}/v6/deployments?{query}",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    with urlopen(request, timeout=20) as response:  # noqa: S310 - fixed Vercel API origin
+        return json.load(response)
+
+
+def append_summary(message: str) -> None:
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write(message.rstrip() + "\n")
+
+
+def verify(*, token: str, team_id: str, project_id: str, expected_sha: str, timeout_seconds: int, poll_seconds: int) -> DeploymentMatch:
+    deadline = time.monotonic() + timeout_seconds
+    last_state = "not-found"
+    last_error: Exception | None = None
+
+    while True:
+        try:
+            payload = fetch_production_deployments(token=token, team_id=team_id, project_id=project_id)
+            last_error = None
+            match = find_deployment_for_sha(payload, expected_sha)
+            if match:
+                last_state = match.state
+                if match.state == READY_STATE:
+                    return match
+                if match.state in TERMINAL_FAILURE_STATES:
+                    raise RuntimeError(
+                        f"Vercel Git deployment {match.deployment_id} for {expected_sha} ended in {match.state}"
+                    )
+        except RuntimeError:
+            raise
+        except Exception as exc:  # network/API failure: retry only read checks, never deployment creation
+            last_error = exc
+            last_state = "api-unavailable"
+
+        if time.monotonic() >= deadline:
+            detail = f"; last API error: {last_error}" if last_error else ""
+            raise TimeoutError(
+                f"Vercel Git production deployment for {expected_sha} was not READY within "
+                f"{timeout_seconds}s (last state: {last_state}){detail}"
+            )
+        time.sleep(poll_seconds)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--project-id", default=os.getenv("VERCEL_PROJECT_ID"))
+    parser.add_argument("--team-id", default=os.getenv("VERCEL_ORG_ID"))
+    parser.add_argument("--token", default=os.getenv("VERCEL_TOKEN"))
+    parser.add_argument("--timeout-seconds", type=int, default=180)
+    parser.add_argument("--poll-seconds", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    missing = [name for name, value in (("project-id", args.project_id), ("team-id", args.team_id), ("token", args.token)) if not value]
+    if missing:
+        print("Missing required Vercel verification inputs: " + ", ".join(missing), file=sys.stderr)
+        return 2
+
+    try:
+        match = verify(
+            token=args.token,
+            team_id=args.team_id,
+            project_id=args.project_id,
+            expected_sha=args.sha,
+            timeout_seconds=max(1, args.timeout_seconds),
+            poll_seconds=max(1, args.poll_seconds),
+        )
+    except Exception as exc:
+        message = f"### Vercel production verification: FAILED\n\nExpected GitHub SHA: `{args.sha}`\n\n{exc}"
+        append_summary(message)
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    deployment_url = f"https://{match.url}" if match.url else "(URL unavailable)"
+    message = (
+        "### Vercel production verification: READY\n\n"
+        f"- GitHub SHA: `{match.commit_sha}`\n"
+        f"- Deployment: `{match.deployment_id}`\n"
+        f"- URL: {deployment_url}\n"
+        "- Deployment source: Vercel Git integration (GitHub Actions did not create a second deployment)"
+    )
+    append_summary(message)
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #186

## Root cause
The production build itself is healthy. GitHub Actions was creating a second production deployment with `vercel deploy --prod --yes` even though the connected Vercel Git integration already deploys `main` automatically. The duplicate CLI path hit Vercel's Free API deployment limit:

`api-deployments-free-per-day` / more than 100 deployments.

Direct Vercel inspection confirms the Git integration still produces READY production deployments with `meta.githubCommitSha` and `target=production`.

## Fix
- remove production deployment creation from GitHub Actions entirely
- retain `vercel build --prod` as the independent build/environment validation gate
- make Vercel Git integration the sole production deployment creator
- add a read-only verifier that polls the Vercel Deployments API until the exact GitHub SHA reaches READY
- fail if the matching Git deployment reaches ERROR/BLOCKED/CANCELED or never appears
- add tests proving exact-SHA matching and preventing reintroduction of a second `vercel deploy` command

## Why not `--prebuilt`
#162 already documented repository-specific failure of the prebuilt path. This change does not switch back to it; it removes the redundant CLI deployment path instead.

## Primary references
- Vercel Git configuration / automatic Git deployments: https://vercel.com/docs/project-configuration/git-configuration
- Vercel Deployments API: https://vercel.com/docs/rest-api/deployments/list-deployments
- Existing deployment-path repair: #162

## Production verification
The merge commit itself must be deployed by Vercel Git integration. The updated main workflow then verifies that exact SHA through the read-only API without creating a second deployment.