### PR TITLE
Add quota-aware Vercel deployment defer and catch-up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 * * * *"
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -98,7 +101,89 @@ jobs:
         run: python scripts/check_google_oauth.py .vercel/.env.production.local
       - name: Build Production with Vercel
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Inspect Vercel deployment budget
+        id: budget
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          python scripts/vercel_deployment_budget.py
+          --sha "${GITHUB_SHA}"
+          --project-id "${VERCEL_PROJECT_ID}"
+          --team-id "${VERCEL_ORG_ID}"
+      - name: Record quota-deferred production state
+        if: steps.budget.outputs.state == 'quota_saturated'
+        run: |
+          echo "Production build passed; deployment verification is deferred because the Vercel team is at the observed 24h deployment limit." >> "$GITHUB_STEP_SUMMARY"
+          echo "No deployment creation was attempted by GitHub Actions." >> "$GITHUB_STEP_SUMMARY"
       - name: Verify canonical Vercel Git production deployment
+        if: steps.budget.outputs.state == 'deployable' || steps.budget.outputs.state == 'unknown'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          python scripts/verify_vercel_git_deployment.py
+          --sha "${GITHUB_SHA}"
+          --project-id "${VERCEL_PROJECT_ID}"
+          --team-id "${VERCEL_ORG_ID}"
+          --timeout-seconds 180
+          --poll-seconds 5
+
+  Production-Catch-Up:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Inspect Vercel deployment budget
+        id: budget
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          python scripts/vercel_deployment_budget.py
+          --sha "${GITHUB_SHA}"
+          --project-id "${VERCEL_PROJECT_ID}"
+          --team-id "${VERCEL_ORG_ID}"
+      - name: Record deferred catch-up
+        if: steps.budget.outputs.state == 'quota_saturated'
+        run: echo "Catch-up deferred; no Vercel deployment was created while the observed 24h budget is saturated." >> "$GITHUB_STEP_SUMMARY"
+      - name: Record already-current production
+        if: steps.budget.outputs.state == 'current'
+        run: echo "Production already matches latest main; catch-up is a no-op." >> "$GITHUB_STEP_SUMMARY"
+      - name: Record unknown budget state
+        if: steps.budget.outputs.state == 'unknown'
+        run: echo "Budget state is unknown; catch-up fails closed and will not create a deployment." >> "$GITHUB_STEP_SUMMARY"
+      - name: Install Vercel CLI
+        if: steps.budget.outputs.state == 'deployable'
+        run: npm install --global vercel@59.0.0
+      - name: Pull Vercel Environment Information
+        if: steps.budget.outputs.state == 'deployable'
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Verify Google OAuth provider redirect
+        if: steps.budget.outputs.state == 'deployable'
+        run: python scripts/check_google_oauth.py .vercel/.env.production.local
+      - name: Build latest main for catch-up
+        if: steps.budget.outputs.state == 'deployable'
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy latest main once
+        if: steps.budget.outputs.state == 'deployable'
+        id: catchup
+        shell: bash
+        run: |
+          set +e
+          output="$(vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1)"
+          code=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$code" -eq 0 ]; then
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$output" | grep -Fq 'api-deployments-free-per-day'; then
+            echo "deployed=false" >> "$GITHUB_OUTPUT"
+            echo "Catch-up reached Vercel quota after preflight; deployment is deferred without retry." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          exit "$code"
+      - name: Verify catch-up production deployment
+        if: steps.catchup.outputs.deployed == 'true'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: >-

--- a/.github/workflows/test-vercel-git-deployment.yml
+++ b/.github/workflows/test-vercel-git-deployment.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "scripts/verify_vercel_git_deployment.py"
+      - "scripts/vercel_deployment_budget.py"
       - "backend/tests/test_vercel_git_deployment.py"
       - ".github/workflows/deploy.yml"
       - ".github/workflows/test-vercel-git-deployment.yml"
@@ -11,6 +12,7 @@ on:
     branches: [main]
     paths:
       - "scripts/verify_vercel_git_deployment.py"
+      - "scripts/vercel_deployment_budget.py"
       - "backend/tests/test_vercel_git_deployment.py"
       - ".github/workflows/deploy.yml"
       - ".github/workflows/test-vercel-git-deployment.yml"
@@ -28,17 +30,21 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Install dependencies
         run: uv sync --frozen --dev
-      - name: Compile verifier
-        run: uv run python -m compileall -q scripts/verify_vercel_git_deployment.py
-      - name: Test exact-SHA production verification
+      - name: Compile deployment controls
+        run: >-
+          uv run python -m compileall -q
+          scripts/verify_vercel_git_deployment.py
+          scripts/vercel_deployment_budget.py
+      - name: Test exact-SHA and budget decisions
         env:
           PYTHONPATH: .
         run: uv run pytest -q backend/tests/test_vercel_git_deployment.py
-      - name: Assert Actions does not create a second production deployment
+      - name: Assert production push never creates a deployment
         shell: bash
         run: |
-          if grep -Eq 'vercel (deploy|--prod)( |$)' .github/workflows/deploy.yml; then
-            echo "deploy.yml must not create a second Vercel production deployment; Git integration is canonical"
-            exit 1
-          fi
-          grep -F 'verify_vercel_git_deployment.py' .github/workflows/deploy.yml
+          test "$(grep -Fc 'vercel deploy --prod --yes' .github/workflows/deploy.yml)" = "1"
+          grep -F "if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'" .github/workflows/deploy.yml
+          grep -F "if: steps.budget.outputs.state == 'deployable'" .github/workflows/deploy.yml
+          grep -F "api-deployments-free-per-day" .github/workflows/deploy.yml
+          grep -F "vercel_deployment_budget.py" .github/workflows/deploy.yml
+          grep -F "verify_vercel_git_deployment.py" .github/workflows/deploy.yml

--- a/backend/tests/test_vercel_git_deployment.py
+++ b/backend/tests/test_vercel_git_deployment.py
@@ -1,5 +1,4 @@
-import pytest
-
+from scripts.vercel_deployment_budget import BudgetDecision, decide_budget, latest_ready_production_sha
 from scripts.verify_vercel_git_deployment import DeploymentMatch, find_deployment_for_sha
 
 
@@ -78,3 +77,61 @@ def test_preserves_terminal_failure_state_for_caller():
 def test_missing_meta_is_not_inferred_from_position():
     payload = {"deployments": [{"uid": "dpl_latest", "state": "READY", "target": "production", "meta": {}}]}
     assert find_deployment_for_sha(payload, "abc123") is None
+
+
+def _production_payload(sha: str = "older"):
+    return {
+        "deployments": [
+            {
+                "uid": "dpl_prod",
+                "state": "READY",
+                "target": "production",
+                "meta": {"githubCommitSha": sha},
+            }
+        ]
+    }
+
+
+def test_budget_is_current_when_latest_production_matches_main():
+    decision = decide_budget(
+        team_payload={"deployments": [{}] * 100},
+        project_payload=_production_payload("abc123"),
+        expected_sha="abc123",
+    )
+    assert decision.state == "current"
+    assert decision.latest_production_sha == "abc123"
+
+
+def test_budget_is_quota_saturated_at_observed_free_limit():
+    decision = decide_budget(
+        team_payload={"deployments": [{}] * 100},
+        project_payload=_production_payload("older"),
+        expected_sha="abc123",
+    )
+    assert decision == BudgetDecision(
+        state="quota_saturated",
+        deployment_count=100,
+        latest_production_sha="older",
+        reason="at least 100 team deployments were observed in the last 24 hours",
+    )
+
+
+def test_budget_is_deployable_below_limit_when_production_is_behind():
+    decision = decide_budget(
+        team_payload={"deployments": [{}] * 42},
+        project_payload=_production_payload("older"),
+        expected_sha="abc123",
+    )
+    assert decision.state == "deployable"
+    assert decision.deployment_count == 42
+
+
+def test_latest_ready_sha_ignores_error_and_preview_deployments():
+    payload = {
+        "deployments": [
+            {"state": "ERROR", "target": "production", "meta": {"githubCommitSha": "bad"}},
+            {"state": "READY", "target": "preview", "meta": {"githubCommitSha": "preview"}},
+            {"state": "READY", "target": "production", "meta": {"githubCommitSha": "good"}},
+        ]
+    }
+    assert latest_ready_production_sha(payload) == "good"

--- a/scripts/vercel_deployment_budget.py
+++ b/scripts/vercel_deployment_budget.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Read-only Vercel deployment-budget preflight for production workflows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+API_BASE = "https://api.vercel.com"
+DEFAULT_LIMIT = 100
+WINDOW_SECONDS = 24 * 60 * 60
+
+
+@dataclass(frozen=True)
+class BudgetDecision:
+    state: str
+    deployment_count: int | None
+    latest_production_sha: str | None
+    reason: str
+
+
+def _deployments(payload: dict) -> list[dict]:
+    value = payload.get("deployments") or []
+    return value if isinstance(value, list) else []
+
+
+def latest_ready_production_sha(payload: dict) -> str | None:
+    for deployment in _deployments(payload):
+        state = str(deployment.get("state") or deployment.get("readyState") or "").upper()
+        if deployment.get("target") != "production" or state != "READY":
+            continue
+        meta = deployment.get("meta") or {}
+        sha = meta.get("githubCommitSha")
+        if sha:
+            return str(sha)
+    return None
+
+
+def decide_budget(
+    *,
+    team_payload: dict,
+    project_payload: dict,
+    expected_sha: str,
+    threshold: int = DEFAULT_LIMIT,
+) -> BudgetDecision:
+    latest_sha = latest_ready_production_sha(project_payload)
+    if latest_sha == expected_sha:
+        return BudgetDecision("current", len(_deployments(team_payload)), latest_sha, "production already matches current main SHA")
+
+    count = len(_deployments(team_payload))
+    # The API request is capped at `threshold`. Reaching the cap is enough to
+    # know that another deployment would exceed/press the observed Free limit.
+    if count >= threshold:
+        return BudgetDecision(
+            "quota_saturated",
+            count,
+            latest_sha,
+            f"at least {count} team deployments were observed in the last 24 hours",
+        )
+
+    return BudgetDecision("deployable", count, latest_sha, f"{count} team deployments observed in the last 24 hours")
+
+
+def fetch_json(*, token: str, path: str, params: dict[str, str | int]) -> dict:
+    query = urlencode(params)
+    request = Request(
+        f"{API_BASE}{path}?{query}",
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/json"},
+    )
+    with urlopen(request, timeout=20) as response:  # noqa: S310 - fixed Vercel API origin
+        return json.load(response)
+
+
+def inspect_budget(*, token: str, team_id: str, project_id: str, expected_sha: str, now_ms: int | None = None) -> BudgetDecision:
+    now_ms = now_ms if now_ms is not None else int(time.time() * 1000)
+    since_ms = now_ms - WINDOW_SECONDS * 1000
+    team_payload = fetch_json(
+        token=token,
+        path="/v6/deployments",
+        params={"teamId": team_id, "since": since_ms, "limit": DEFAULT_LIMIT},
+    )
+    project_payload = fetch_json(
+        token=token,
+        path="/v6/deployments",
+        params={"teamId": team_id, "projectId": project_id, "target": "production", "limit": 20},
+    )
+    return decide_budget(team_payload=team_payload, project_payload=project_payload, expected_sha=expected_sha)
+
+
+def write_github_output(decision: BudgetDecision) -> None:
+    path = os.getenv("GITHUB_OUTPUT")
+    if not path:
+        return
+    values = {
+        "state": decision.state,
+        "deployment_count": "unknown" if decision.deployment_count is None else str(decision.deployment_count),
+        "latest_production_sha": decision.latest_production_sha or "",
+        "reason": decision.reason.replace("\n", " "),
+    }
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in values.items():
+            handle.write(f"{key}={value}\n")
+
+
+def append_summary(decision: BudgetDecision) -> None:
+    path = os.getenv("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write("### Vercel deployment budget\n\n")
+        handle.write(f"- State: `{decision.state}`\n")
+        handle.write(f"- 24h deployment count: `{decision.deployment_count if decision.deployment_count is not None else 'unknown'}`\n")
+        handle.write(f"- Latest production SHA: `{decision.latest_production_sha or 'unknown'}`\n")
+        handle.write(f"- Reason: {decision.reason}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--project-id", default=os.getenv("VERCEL_PROJECT_ID"))
+    parser.add_argument("--team-id", default=os.getenv("VERCEL_ORG_ID"))
+    parser.add_argument("--token", default=os.getenv("VERCEL_TOKEN"))
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    missing = [name for name, value in (("project-id", args.project_id), ("team-id", args.team_id), ("token", args.token)) if not value]
+    if missing:
+        decision = BudgetDecision("unknown", None, None, "missing inputs: " + ", ".join(missing))
+    else:
+        try:
+            decision = inspect_budget(
+                token=args.token,
+                team_id=args.team_id,
+                project_id=args.project_id,
+                expected_sha=args.sha,
+            )
+        except Exception as exc:
+            # API unavailability is not evidence that production is current or
+            # that quota is available. Catch-up deployment therefore fails closed.
+            decision = BudgetDecision("unknown", None, None, f"Vercel budget API unavailable: {exc}")
+
+    write_github_output(decision)
+    append_summary(decision)
+    print(json.dumps(decision.__dict__, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Continues #186 after production verification showed the Vercel Git integration is also unable to create a new deployment while the observed deployment budget is saturated.

## Changes
- add a read-only Vercel deployment-budget preflight using the Deployments API
- classify production as `current`, `quota_saturated`, `deployable`, or `unknown`
- production push still runs `vercel build --prod`, but skips deployment verification cleanly when quota is known saturated
- GitHub Actions never creates a deployment on normal `main` pushes; Vercel Git integration remains the canonical normal deploy path
- add hourly/manual catch-up that only targets the then-current `main`
- catch-up creates at most one source deployment when production is behind and the observed 24h count is below the limit
- if Vercel still returns `api-deployments-free-per-day` after preflight, classify as deferred and do not retry
- skip catch-up when production already matches current main or budget state is unknown
- verify exact Git SHA after a successful catch-up deployment
- add under-budget / saturated / current / stale / exact-SHA tests

## Why this is needed after #187
#187 removed the duplicate per-push CLI deployment path. Its production run then demonstrated that no new Git deployment appeared while the account/team was still quota-saturated. This follow-up adds the missing defer-and-later-catch-up behavior rather than treating quota exhaustion as a code failure.

## Primary references
- Vercel Deployments API: https://vercel.com/docs/rest-api/deployments/list-deployments
- Vercel automatic Git deployments: https://vercel.com/docs/project-configuration/git-configuration
- Vercel CLI deploy: https://vercel.com/docs/cli/deploy

## Safety
- no `--prebuilt` regression
- no retry loop on quota errors
- unknown API state fails closed for catch-up deployment creation
- scheduled catch-up checks only latest main and never replays old merge commits