### PR TITLE
feat: publish cacheable VRChat manifest catalog API

### DIFF
--- a/.github/workflows/test-vrchat-catalog.yml
+++ b/.github/workflows/test-vrchat-catalog.yml
@@ -1,0 +1,72 @@
+name: VRChat manifest catalog
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/main.py"
+      - "backend/app/models/vrchat_catalog.py"
+      - "backend/app/routers/vrchat.py"
+      - "backend/app/services/vrchat_manifest_catalog.py"
+      - "backend/app/models/vrchat_manifest.py"
+      - "backend/app/services/vrchat_manifest_projection.py"
+      - "backend/tests/test_vrchat_catalog.py"
+      - "backend/tests/test_vrchat_manifest.py"
+      - "data/vrchat/module-bindings-v1.json"
+      - "schemas/vrchat/board-game-module-manifest-v1.schema.json"
+      - "docs/VRCHAT_MANIFEST_CATALOG_V1.md"
+      - ".github/workflows/test-vrchat-catalog.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/main.py"
+      - "backend/app/models/vrchat_catalog.py"
+      - "backend/app/routers/vrchat.py"
+      - "backend/app/services/vrchat_manifest_catalog.py"
+      - "backend/app/models/vrchat_manifest.py"
+      - "backend/app/services/vrchat_manifest_projection.py"
+      - "backend/tests/test_vrchat_catalog.py"
+      - "backend/tests/test_vrchat_manifest.py"
+      - "data/vrchat/module-bindings-v1.json"
+      - "schemas/vrchat/board-game-module-manifest-v1.schema.json"
+      - "docs/VRCHAT_MANIFEST_CATALOG_V1.md"
+      - ".github/workflows/test-vrchat-catalog.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  vrchat-catalog:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile VRChat catalog modules
+        run: >-
+          uv run python -m compileall -q
+          backend/app/models/vrchat_catalog.py
+          backend/app/routers/vrchat.py
+          backend/app/services/vrchat_manifest_catalog.py
+
+      - name: Ruff VRChat catalog modules and tests
+        run: >-
+          uv run --with ruff ruff check
+          backend/app/models/vrchat_catalog.py
+          backend/app/routers/vrchat.py
+          backend/app/services/vrchat_manifest_catalog.py
+          backend/tests/test_vrchat_catalog.py
+
+      - name: Run manifest and catalog contract tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_vrchat_manifest.py
+          backend/tests/test_vrchat_catalog.py

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import HTMLResponse
 
 from app.core.logger import setup_logging
 from app.middleware.validation import ValidationMiddleware
-from app.routers import auth, games, lists
+from app.routers import auth, games, lists, vrchat
 from app.services.seo_renderer import generate_seo_html
 from app.services.sitemap import get_sitemap_xml
 
@@ -24,6 +24,7 @@ app.add_middleware(
 app.include_router(games.router, prefix="/api", tags=["games"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(lists.router, prefix="/api", tags=["lists"])
+app.include_router(vrchat.router, prefix="/api/vrchat/v1", tags=["vrchat"])
 
 
 @app.get("/health")

--- a/backend/app/models/vrchat_catalog.py
+++ b/backend/app/models/vrchat_catalog.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.vrchat_manifest import MANIFEST_SCHEMA_VERSION, BoardGameModuleManifest, ModuleBinding
+
+CATALOG_SCHEMA_VERSION = "1.0"
+
+
+class CatalogModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class PublicationStatus(StrEnum):
+    PLAYABLE = "playable"
+    UNAVAILABLE = "unavailable"
+    UNSUPPORTED = "unsupported"
+    RETIRED = "retired"
+    INVALID = "invalid"
+
+
+class ManifestReadStatus(StrEnum):
+    AVAILABLE = "available"
+    NOT_REGISTERED = "not_registered"
+    UNAVAILABLE = "unavailable"
+    UNSUPPORTED = "unsupported"
+    RETIRED = "retired"
+    INVALID = "invalid"
+
+
+class BindingRegistryEntry(CatalogModel):
+    slug: str = Field(min_length=1)
+    ruleset_id: str = Field(alias="rulesetId", min_length=1)
+    binding: ModuleBinding
+    publication_status: PublicationStatus = Field(alias="publicationStatus")
+    reason_code: str | None = Field(default=None, alias="reasonCode")
+    snapshot_at: datetime = Field(alias="snapshotAt")
+
+    @model_validator(mode="after")
+    def validate_snapshot(self):
+        if self.snapshot_at.tzinfo is None or self.snapshot_at.utcoffset() is None:
+            raise ValueError("snapshotAt must include a timezone offset")
+        if self.publication_status != PublicationStatus.PLAYABLE and not self.reason_code:
+            raise ValueError("non-playable binding requires reasonCode")
+        return self
+
+
+class BindingRegistryFile(CatalogModel):
+    schema_version: Literal["1.0"] = Field(default=CATALOG_SCHEMA_VERSION, alias="schemaVersion")
+    entries: list[BindingRegistryEntry] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_unique_entries(self):
+        keys = [(entry.slug, entry.ruleset_id) for entry in self.entries]
+        if len(keys) != len(set(keys)):
+            raise ValueError("binding registry entries must have unique slug/rulesetId pairs")
+        return self
+
+
+class ManifestCatalogEntry(CatalogModel):
+    slug: str
+    ruleset_id: str = Field(alias="rulesetId")
+    module_id: str = Field(alias="moduleId")
+    module_version_range: str = Field(alias="moduleVersionRange")
+    status: PublicationStatus
+    reason_code: str | None = Field(default=None, alias="reasonCode")
+    manifest_path: str = Field(alias="manifestPath")
+    manifest_schema_version: Literal["1.0"] = Field(
+        default=MANIFEST_SCHEMA_VERSION,
+        alias="manifestSchemaVersion",
+    )
+
+
+class ManifestCatalog(CatalogModel):
+    schema_version: Literal["1.0"] = Field(default=CATALOG_SCHEMA_VERSION, alias="schemaVersion")
+    catalog_revision: str = Field(alias="catalogRevision", min_length=64, max_length=64)
+    manifest_schema_version: Literal["1.0"] = Field(
+        default=MANIFEST_SCHEMA_VERSION,
+        alias="manifestSchemaVersion",
+    )
+    entries: list[ManifestCatalogEntry] = Field(default_factory=list)
+
+
+class ManifestReadResponse(CatalogModel):
+    schema_version: Literal["1.0"] = Field(default=CATALOG_SCHEMA_VERSION, alias="schemaVersion")
+    status: ManifestReadStatus
+    slug: str
+    ruleset_id: str = Field(alias="rulesetId")
+    reason_code: str | None = Field(default=None, alias="reasonCode")
+    manifest: BoardGameModuleManifest | None = None

--- a/backend/app/routers/vrchat.py
+++ b/backend/app/routers/vrchat.py
@@ -1,0 +1,50 @@
+import hashlib
+import json
+
+from fastapi import APIRouter, Depends, Request, Response
+
+from app.models.vrchat_catalog import CatalogModel
+from app.services.vrchat_manifest_catalog import VrchatManifestCatalogService
+
+router = APIRouter()
+_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=3600"
+
+
+def get_vrchat_manifest_catalog_service():
+    return VrchatManifestCatalogService()
+
+
+def _conditional_json_response(request: Request, payload: CatalogModel) -> Response:
+    content = json.dumps(
+        payload.model_dump(mode="json", by_alias=True),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    etag = f'"{hashlib.sha256(content).hexdigest()}"'
+    headers = {
+        "Cache-Control": _CACHE_CONTROL,
+        "ETag": etag,
+        "X-Content-Type-Options": "nosniff",
+    }
+    if request.headers.get("if-none-match") == etag:
+        return Response(status_code=304, headers=headers)
+    return Response(content=content, media_type="application/json; charset=utf-8", headers=headers)
+
+
+@router.get("/catalog")
+async def get_vrchat_manifest_catalog(
+    request: Request,
+    service: VrchatManifestCatalogService = Depends(get_vrchat_manifest_catalog_service),
+):
+    return _conditional_json_response(request, await service.get_catalog())
+
+
+@router.get("/manifests/{slug}/{ruleset_id}")
+async def get_vrchat_manifest(
+    slug: str,
+    ruleset_id: str,
+    request: Request,
+    service: VrchatManifestCatalogService = Depends(get_vrchat_manifest_catalog_service),
+):
+    return _conditional_json_response(request, await service.get_manifest(slug, ruleset_id))

--- a/backend/app/services/vrchat_manifest_catalog.py
+++ b/backend/app/services/vrchat_manifest_catalog.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from pathlib import Path
+from urllib.parse import quote
+
+from app.models import GameDetail
+from app.models.component_catalog import ComponentCatalog
+from app.models.vrchat_catalog import (
+    BindingRegistryEntry,
+    BindingRegistryFile,
+    ManifestCatalog,
+    ManifestCatalogEntry,
+    ManifestReadResponse,
+    ManifestReadStatus,
+    PublicationStatus,
+)
+from app.services.component_catalog import ComponentCatalogService
+from app.services.game_service import GameService
+from app.services.rule_graph import RuleGraphService
+from app.services.rulesets import RuleSetService
+from app.services.vrchat_manifest_projection import project_board_game_module_manifest
+
+logger = logging.getLogger("services.vrchat_manifest_catalog")
+DEFAULT_REGISTRY_PATH = Path(__file__).resolve().parents[3] / "data" / "vrchat" / "module-bindings-v1.json"
+
+_STATUS_TO_READ_STATUS = {
+    PublicationStatus.UNAVAILABLE: ManifestReadStatus.UNAVAILABLE,
+    PublicationStatus.UNSUPPORTED: ManifestReadStatus.UNSUPPORTED,
+    PublicationStatus.RETIRED: ManifestReadStatus.RETIRED,
+    PublicationStatus.INVALID: ManifestReadStatus.INVALID,
+}
+
+
+class VrchatManifestCatalogService:
+    def __init__(
+        self,
+        *,
+        registry_path: Path = DEFAULT_REGISTRY_PATH,
+        game_service: GameService | None = None,
+        ruleset_service: RuleSetService | None = None,
+        rule_graph_service: RuleGraphService | None = None,
+        component_catalog_service: ComponentCatalogService | None = None,
+    ):
+        self.registry_path = registry_path
+        self.game_service = game_service or GameService()
+        self.ruleset_service = ruleset_service or RuleSetService()
+        self.rule_graph_service = rule_graph_service or RuleGraphService()
+        self.component_catalog_service = component_catalog_service or ComponentCatalogService()
+
+    def load_registry(self) -> BindingRegistryFile:
+        payload = json.loads(self.registry_path.read_text(encoding="utf-8"))
+        return BindingRegistryFile.model_validate(payload)
+
+    async def get_catalog(self) -> ManifestCatalog:
+        registry = self.load_registry()
+        entries: list[ManifestCatalogEntry] = []
+        for registry_entry in sorted(registry.entries, key=lambda item: (item.slug, item.ruleset_id)):
+            status = registry_entry.publication_status
+            reason_code = registry_entry.reason_code
+            if status == PublicationStatus.PLAYABLE:
+                result = await self._project_registry_entry(registry_entry)
+                if result.status != ManifestReadStatus.AVAILABLE:
+                    status = PublicationStatus.INVALID
+                    reason_code = result.reason_code or "CANONICAL_PROJECTION_INVALID"
+
+            entries.append(
+                ManifestCatalogEntry(
+                    slug=registry_entry.slug,
+                    rulesetId=registry_entry.ruleset_id,
+                    moduleId=registry_entry.binding.module_id,
+                    moduleVersionRange=registry_entry.binding.module_version_range,
+                    status=status,
+                    reasonCode=reason_code,
+                    manifestPath=self._manifest_path(registry_entry.slug, registry_entry.ruleset_id),
+                )
+            )
+
+        revision_payload = [entry.model_dump(mode="json", by_alias=True) for entry in entries]
+        revision = hashlib.sha256(
+            json.dumps(revision_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+        return ManifestCatalog(catalogRevision=revision, entries=entries)
+
+    async def get_manifest(self, slug: str, ruleset_id: str) -> ManifestReadResponse:
+        registry = self.load_registry()
+        entry = next(
+            (
+                candidate
+                for candidate in registry.entries
+                if candidate.slug == slug and candidate.ruleset_id == ruleset_id
+            ),
+            None,
+        )
+        if entry is None:
+            return ManifestReadResponse(
+                status=ManifestReadStatus.NOT_REGISTERED,
+                slug=slug,
+                rulesetId=ruleset_id,
+                reasonCode="MODULE_BINDING_NOT_REGISTERED",
+            )
+        if entry.publication_status != PublicationStatus.PLAYABLE:
+            return ManifestReadResponse(
+                status=_STATUS_TO_READ_STATUS[entry.publication_status],
+                slug=slug,
+                rulesetId=ruleset_id,
+                reasonCode=entry.reason_code,
+            )
+        return await self._project_registry_entry(entry)
+
+    async def _project_registry_entry(self, entry: BindingRegistryEntry) -> ManifestReadResponse:
+        try:
+            game_row = await self.game_service.get_game_by_slug(entry.slug)
+            if not game_row:
+                return self._invalid(entry, "CANONICAL_GAME_NOT_FOUND")
+            game = GameDetail.model_validate(game_row)
+
+            rulesets = await self.ruleset_service.get_by_slug(entry.slug)
+            if rulesets is None or rulesets.status != "available":
+                return self._invalid(entry, "RULESETS_NOT_AVAILABLE")
+            ruleset = next(
+                (candidate for candidate in rulesets.rulesets if candidate.ruleset_id == entry.ruleset_id),
+                None,
+            )
+            if ruleset is None:
+                return self._invalid(entry, "RULESET_NOT_FOUND")
+
+            rule_graph = await self.rule_graph_service.get_by_slug(entry.slug, rule_set_id=entry.ruleset_id)
+            if rule_graph is None or rule_graph.status != "available":
+                return self._invalid(entry, "RULE_GRAPH_NOT_AVAILABLE")
+
+            component_catalog = await self._component_catalog(entry)
+            manifest = project_board_game_module_manifest(
+                game=game,
+                ruleset=ruleset,
+                rule_graph=rule_graph,
+                component_catalog=component_catalog,
+                binding=entry.binding,
+                generated_at=entry.snapshot_at,
+            )
+        except (ValueError, TypeError, KeyError) as exc:
+            logger.warning(
+                "VRChat manifest projection rejected %s/%s: %s",
+                entry.slug,
+                entry.ruleset_id,
+                exc,
+            )
+            return self._invalid(entry, "CANONICAL_PROJECTION_INVALID")
+
+        return ManifestReadResponse(
+            status=ManifestReadStatus.AVAILABLE,
+            slug=entry.slug,
+            rulesetId=entry.ruleset_id,
+            manifest=manifest,
+        )
+
+    async def _component_catalog(self, entry: BindingRegistryEntry) -> ComponentCatalog | None:
+        response = await self.component_catalog_service.get_sets(entry.slug, entry.ruleset_id)
+        if response is None or response.status != "available":
+            return None
+        return ComponentCatalog(
+            ruleset_id=entry.ruleset_id,
+            component_sets=response.component_sets,
+            property_definitions=response.property_definitions,
+        )
+
+    @staticmethod
+    def _invalid(entry: BindingRegistryEntry, reason_code: str) -> ManifestReadResponse:
+        return ManifestReadResponse(
+            status=ManifestReadStatus.INVALID,
+            slug=entry.slug,
+            rulesetId=entry.ruleset_id,
+            reasonCode=reason_code,
+        )
+
+    @staticmethod
+    def _manifest_path(slug: str, ruleset_id: str) -> str:
+        return f"/api/vrchat/v1/manifests/{quote(slug, safe='')}/{quote(ruleset_id, safe='')}"

--- a/backend/tests/test_vrchat_catalog.py
+++ b/backend/tests/test_vrchat_catalog.py
@@ -1,5 +1,6 @@
 import json
 from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
@@ -159,9 +160,8 @@ def _client(service: VrchatManifestCatalogService) -> TestClient:
 
 
 def test_production_registry_is_valid_and_starts_fail_closed():
-    registry = BindingRegistryFile.model_validate_json(
-        (vrchat.Path(__file__).parents[2] / "data" / "vrchat" / "module-bindings-v1.json").read_text(encoding="utf-8")
-    )
+    registry_path = Path(__file__).parents[2] / "data" / "vrchat" / "module-bindings-v1.json"
+    registry = BindingRegistryFile.model_validate_json(registry_path.read_text(encoding="utf-8"))
     assert registry.entries == []
 
 

--- a/backend/tests/test_vrchat_catalog.py
+++ b/backend/tests/test_vrchat_catalog.py
@@ -1,0 +1,257 @@
+import json
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models import GameDetail
+from app.models.component_catalog import ComponentKind, ComponentSet, ComponentSetListResponse
+from app.models.rule_graph import RuleGraphReadResponse, RuleNode, RuleNodeType
+from app.models.ruleset import RuleSet, RuleSetListResponse
+from app.models.vrchat_catalog import BindingRegistryFile, ManifestReadStatus, PublicationStatus
+from app.routers import vrchat
+from app.services.vrchat_manifest_catalog import VrchatManifestCatalogService
+
+SNAPSHOT_AT = datetime(2026, 8, 14, tzinfo=UTC)
+
+
+def _registry_payload(*, status: str = "playable", reason_code: str | None = None) -> dict:
+    entry = {
+        "slug": "example-game",
+        "rulesetId": "ruleset-ja-v1",
+        "binding": {
+            "moduleId": "vrmine.example-game",
+            "moduleVersionRange": ">=1.0.0,<2.0.0",
+            "supportedPlatforms": ["vrchat-pc"],
+            "interactionProfile": "desktop-and-vr",
+            "capabilities": {
+                "turn-based": "supported",
+                "deck": "supported",
+                "score": "supported",
+            },
+        },
+        "publicationStatus": status,
+        "snapshotAt": SNAPSHOT_AT.isoformat().replace("+00:00", "Z"),
+    }
+    if reason_code is not None:
+        entry["reasonCode"] = reason_code
+    return {"schemaVersion": "1.0", "entries": [entry]}
+
+
+def _write_registry(tmp_path, *, status: str = "playable", reason_code: str | None = None):
+    path = tmp_path / "module-bindings-v1.json"
+    path.write_text(
+        json.dumps(_registry_payload(status=status, reason_code=reason_code)),
+        encoding="utf-8",
+    )
+    return path
+
+
+class FakeGameService:
+    async def get_game_by_slug(self, slug: str):
+        if slug != "example-game":
+            return None
+        return GameDetail(
+            id="game-1",
+            slug=slug,
+            title="Example Game",
+            min_players=2,
+            max_players=4,
+        ).model_dump(mode="json")
+
+
+class FakeRuleSetService:
+    async def get_by_slug(self, slug: str):
+        return RuleSetListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            rulesets=[
+                RuleSet(
+                    ruleset_id="ruleset-ja-v1",
+                    game_id="game-1",
+                    language_code="ja",
+                    source_revision="publisher-v1",
+                    source_ids=["source.publisher"],
+                    verification_status="verified",
+                    status="active",
+                )
+            ],
+        )
+
+
+class FakeRuleGraphService:
+    def __init__(self, *, available: bool = True):
+        self.available = available
+
+    async def get_by_slug(self, slug: str, *, rule_set_id: str | None = None, **_kwargs):
+        if not self.available:
+            return RuleGraphReadResponse(status="not_available", game_id="game-1", slug=slug)
+        return RuleGraphReadResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            rule_set_id=rule_set_id,
+            language_code="ja",
+            source_revision="publisher-v1",
+            nodes=[
+                RuleNode(
+                    rule_id="setup.start",
+                    node_type=RuleNodeType.SETUP,
+                    normalized_statement="Set up the game.",
+                    verification_status="verified",
+                    source_claim_ref="claim.setup",
+                    evidence_ref="evidence.setup",
+                ),
+                RuleNode(
+                    rule_id="end.game",
+                    node_type=RuleNodeType.GAME_END,
+                    normalized_statement="End the game.",
+                    verification_status="verified",
+                    source_claim_ref="claim.end",
+                    evidence_ref="evidence.end",
+                ),
+            ],
+        )
+
+
+class FakeComponentCatalogService:
+    async def get_sets(self, slug: str, rule_set_id: str):
+        return ComponentSetListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            ruleset_id=rule_set_id,
+            component_sets=[
+                ComponentSet(
+                    component_set_id="set.cards",
+                    ruleset_id=rule_set_id,
+                    canonical_name="Cards",
+                    kind=ComponentKind.CARD,
+                    source_ids=["source.components"],
+                )
+            ],
+        )
+
+
+class ExplodingService:
+    def __getattr__(self, name):
+        raise AssertionError(f"canonical service must not be read for blocked entry: {name}")
+
+
+def _service(tmp_path, *, status: str = "playable", reason_code: str | None = None, graph_available: bool = True):
+    registry_path = _write_registry(tmp_path, status=status, reason_code=reason_code)
+    return VrchatManifestCatalogService(
+        registry_path=registry_path,
+        game_service=FakeGameService(),
+        ruleset_service=FakeRuleSetService(),
+        rule_graph_service=FakeRuleGraphService(available=graph_available),
+        component_catalog_service=FakeComponentCatalogService(),
+    )
+
+
+def _client(service: VrchatManifestCatalogService) -> TestClient:
+    app = FastAPI()
+    app.include_router(vrchat.router, prefix="/api/vrchat/v1")
+    app.dependency_overrides[vrchat.get_vrchat_manifest_catalog_service] = lambda: service
+    return TestClient(app)
+
+
+def test_production_registry_is_valid_and_starts_fail_closed():
+    registry = BindingRegistryFile.model_validate_json(
+        (vrchat.Path(__file__).parents[2] / "data" / "vrchat" / "module-bindings-v1.json").read_text(encoding="utf-8")
+    )
+    assert registry.entries == []
+
+
+@pytest.mark.asyncio
+async def test_playable_entry_projects_one_selected_manifest(tmp_path):
+    result = await _service(tmp_path).get_manifest("example-game", "ruleset-ja-v1")
+
+    assert result.status == ManifestReadStatus.AVAILABLE
+    assert result.manifest is not None
+    assert result.manifest.schema_version == "1.0"
+    assert result.manifest.game_id == "game-1"
+    assert result.manifest.ruleset_id == "ruleset-ja-v1"
+    assert result.manifest.module_id == "vrmine.example-game"
+    assert result.manifest.component_set_refs == ["set.cards"]
+    assert result.manifest.generated_at == SNAPSHOT_AT
+
+
+@pytest.mark.asyncio
+async def test_unregistered_manifest_is_explicit_and_has_no_payload(tmp_path):
+    result = await _service(tmp_path).get_manifest("other-game", "ruleset-other")
+
+    assert result.status == ManifestReadStatus.NOT_REGISTERED
+    assert result.reason_code == "MODULE_BINDING_NOT_REGISTERED"
+    assert result.manifest is None
+
+
+@pytest.mark.asyncio
+async def test_known_unsupported_entry_never_reads_canonical_services(tmp_path):
+    registry_path = _write_registry(tmp_path, status="unsupported", reason_code="DEXTERITY_UNSUPPORTED")
+    exploding = ExplodingService()
+    service = VrchatManifestCatalogService(
+        registry_path=registry_path,
+        game_service=exploding,
+        ruleset_service=exploding,
+        rule_graph_service=exploding,
+        component_catalog_service=exploding,
+    )
+
+    result = await service.get_manifest("example-game", "ruleset-ja-v1")
+
+    assert result.status == ManifestReadStatus.UNSUPPORTED
+    assert result.reason_code == "DEXTERITY_UNSUPPORTED"
+    assert result.manifest is None
+
+
+@pytest.mark.asyncio
+async def test_playable_registry_entry_is_downgraded_when_canonical_projection_is_invalid(tmp_path):
+    service = _service(tmp_path, graph_available=False)
+
+    result = await service.get_manifest("example-game", "ruleset-ja-v1")
+    catalog = await service.get_catalog()
+
+    assert result.status == ManifestReadStatus.INVALID
+    assert result.reason_code == "RULE_GRAPH_NOT_AVAILABLE"
+    assert result.manifest is None
+    assert catalog.entries[0].status == PublicationStatus.INVALID
+    assert catalog.entries[0].reason_code == "RULE_GRAPH_NOT_AVAILABLE"
+
+
+def test_catalog_and_manifest_routes_are_read_only():
+    assert all(route.methods <= {"GET", "HEAD"} for route in vrchat.router.routes)
+
+
+def test_catalog_api_is_cacheable_and_supports_conditional_get(tmp_path):
+    client = _client(_service(tmp_path))
+
+    first = client.get("/api/vrchat/v1/catalog")
+    assert first.status_code == 200
+    assert first.headers["cache-control"] == "public, max-age=300, stale-while-revalidate=3600"
+    etag = first.headers["etag"]
+    payload = first.json()
+    assert payload["schemaVersion"] == "1.0"
+    assert payload["manifestSchemaVersion"] == "1.0"
+    assert len(payload["catalogRevision"]) == 64
+    assert payload["entries"][0]["status"] == "playable"
+
+    second = client.get("/api/vrchat/v1/catalog", headers={"If-None-Match": etag})
+    assert second.status_code == 304
+    assert second.content == b""
+    assert second.headers["etag"] == etag
+
+
+def test_selected_manifest_api_returns_valid_manifest_in_one_fetch(tmp_path):
+    client = _client(_service(tmp_path))
+
+    response = client.get("/api/vrchat/v1/manifests/example-game/ruleset-ja-v1")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "available"
+    assert payload["manifest"]["schemaVersion"] == "1.0"
+    assert payload["manifest"]["moduleId"] == "vrmine.example-game"
+    assert payload["manifest"]["componentSetRefs"] == ["set.cards"]
+    assert response.headers["etag"].startswith('"')

--- a/backend/tests/test_vrchat_catalog.py
+++ b/backend/tests/test_vrchat_catalog.py
@@ -3,9 +3,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
 from app.models import GameDetail
 from app.models.component_catalog import ComponentKind, ComponentSet, ComponentSetListResponse
 from app.models.rule_graph import RuleGraphReadResponse, RuleNode, RuleNodeType
@@ -13,7 +10,12 @@ from app.models.ruleset import RuleSet, RuleSetListResponse
 from app.models.vrchat_catalog import BindingRegistryFile, ManifestReadStatus, PublicationStatus
 from app.routers import vrchat
 from app.services.vrchat_manifest_catalog import VrchatManifestCatalogService
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
+HTTP_OK = 200
+HTTP_NOT_MODIFIED = 304
+SHA256_HEX_LENGTH = 64
 SNAPSHOT_AT = datetime(2026, 8, 14, tzinfo=UTC)
 
 
@@ -229,17 +231,17 @@ def test_catalog_api_is_cacheable_and_supports_conditional_get(tmp_path):
     client = _client(_service(tmp_path))
 
     first = client.get("/api/vrchat/v1/catalog")
-    assert first.status_code == 200
+    assert first.status_code == HTTP_OK
     assert first.headers["cache-control"] == "public, max-age=300, stale-while-revalidate=3600"
     etag = first.headers["etag"]
     payload = first.json()
     assert payload["schemaVersion"] == "1.0"
     assert payload["manifestSchemaVersion"] == "1.0"
-    assert len(payload["catalogRevision"]) == 64
+    assert len(payload["catalogRevision"]) == SHA256_HEX_LENGTH
     assert payload["entries"][0]["status"] == "playable"
 
     second = client.get("/api/vrchat/v1/catalog", headers={"If-None-Match": etag})
-    assert second.status_code == 304
+    assert second.status_code == HTTP_NOT_MODIFIED
     assert second.content == b""
     assert second.headers["etag"] == etag
 
@@ -248,7 +250,7 @@ def test_selected_manifest_api_returns_valid_manifest_in_one_fetch(tmp_path):
     client = _client(_service(tmp_path))
 
     response = client.get("/api/vrchat/v1/manifests/example-game/ruleset-ja-v1")
-    assert response.status_code == 200
+    assert response.status_code == HTTP_OK
     payload = response.json()
     assert payload["status"] == "available"
     assert payload["manifest"]["schemaVersion"] == "1.0"

--- a/data/vrchat/module-bindings-v1.json
+++ b/data/vrchat/module-bindings-v1.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0",
+  "entries": []
+}

--- a/docs/VRCHAT_MANIFEST_CATALOG_V1.md
+++ b/docs/VRCHAT_MANIFEST_CATALOG_V1.md
@@ -1,0 +1,100 @@
+# VRChat Manifest Catalog v1
+
+Issue: https://github.com/KAFKA2306/rule-scribe-games/issues/184
+
+## Public read contract
+
+RuleScribe exposes two read-only endpoints:
+
+- `GET /api/vrchat/v1/catalog`
+- `GET /api/vrchat/v1/manifests/{slug}/{ruleset_id}`
+
+Both responses are JSON, include `ETag`, and advertise:
+
+`Cache-Control: public, max-age=300, stale-while-revalidate=3600`
+
+Clients should cache the catalog and selected manifest instead of fetching on every interaction.
+If the client sends the current `If-None-Match`, the API returns `304 Not Modified` with no body.
+
+## Publication registry
+
+`data/vrchat/module-bindings-v1.json` is the only production publication registry.
+It is deployment metadata, not a second source of board-game rules.
+
+Each entry binds one canonical `(slug, rulesetId)` to the explicit `ModuleBinding` introduced by
+BoardGameModule Manifest v1 and declares one publication state:
+
+- `playable`
+- `unavailable`
+- `unsupported`
+- `retired`
+
+Non-playable records require a machine-readable `reasonCode`.
+
+The initial production registry is intentionally empty. Issue #185 owns full-catalog readiness,
+rights, and blocker auditing and may only promote audited games into this registry. VRMine #32 owns
+runtime module compatibility.
+
+## Fail-closed behavior
+
+A registry entry marked `playable` is still not trusted blindly. Before it is returned as playable,
+the service reloads and validates:
+
+1. canonical `GameDetail`;
+2. the exact canonical `RuleSet`;
+3. the exact Rule Graph for that RuleSet;
+4. the available Component Set/Property Definition catalog;
+5. the deterministic #183 manifest projection.
+
+If any required identity or Rule Graph is missing, mismatched, or invalid, the manifest response is
+`invalid` and the catalog entry is downgraded to `invalid`. The API never substitutes another
+edition, language, platform, or RuleSet.
+
+Known `unavailable`, `unsupported`, and `retired` entries are returned as such without reading the
+canonical services. An unknown `(slug, rulesetId)` returns `not_registered`.
+
+## Manifest response states
+
+`GET /api/vrchat/v1/manifests/{slug}/{ruleset_id}` returns one envelope with:
+
+- `available` — `manifest` contains one BoardGameModule Manifest v1;
+- `not_registered` — no publication binding exists;
+- `unavailable` — binding exists but is not publishable yet;
+- `unsupported` — current runtime contract cannot support the game;
+- `retired` — binding was intentionally retired;
+- `invalid` — a binding claimed playable but canonical projection validation failed.
+
+Only `available` contains a manifest payload.
+
+## Revisions and compatibility
+
+The catalog contains:
+
+- `schemaVersion` — catalog transport schema version;
+- `manifestSchemaVersion` — expected BoardGameModule Manifest version;
+- `catalogRevision` — SHA-256 of the validated public catalog entries;
+- per-entry `moduleId`, `moduleVersionRange`, status, reason, and manifest path.
+
+The manifest itself carries its canonical RuleSet revision and explicit `generatedAt` snapshot.
+A changed catalog or manifest payload produces a different HTTP ETag.
+
+## Security boundary
+
+This API has no POST/PATCH/PUT/DELETE route, accepts no credentials or service-role secret, and
+cannot mutate canonical game data. Runtime module binding is server-side versioned metadata; a
+client cannot supply an arbitrary `moduleId` or capability declaration to make a game playable.
+
+## Verification
+
+`backend/tests/test_vrchat_catalog.py` verifies:
+
+- production registry schema and empty fail-closed baseline;
+- one-fetch selected manifest projection;
+- `not_registered` and `unsupported` states;
+- downgrade from claimed `playable` to `invalid` when canonical Rule Graph is unavailable;
+- GET-only route surface;
+- catalog revision, cache headers, ETag, and conditional `304`;
+- manifest schema version and component-set references.
+
+The dedicated CI gate also runs the #183 manifest contract tests so transport changes cannot drift
+from the versioned BoardGameModule Manifest JSON Schema.


### PR DESCRIPTION
## Summary
- expose read-only `/api/vrchat/v1/catalog` and `/api/vrchat/v1/manifests/{slug}/{ruleset_id}`
- add versioned server-side module binding registry with an intentionally empty production baseline
- require explicit publication state and reason codes for non-playable entries
- revalidate canonical Game/RuleSet/RuleGraph/ComponentCatalog before any claimed playable entry is published
- downgrade broken playable bindings to `invalid` instead of substituting another ruleset or inferred data
- add stable catalog SHA-256 revision, ETag, Cache-Control, and conditional 304 support
- keep mutation/auth/secrets outside the public transport surface
- add focused API/service tests and rerun the #183 manifest contract tests in CI

## Publication boundary
#185 owns readiness/rights auditing and population of real production bindings. This PR only provides the transport and fail-closed publication contract; it does not mark any unaudited game playable.

## Verification
Dedicated workflow: `VRChat manifest catalog`
- compile catalog model/router/service
- Ruff catalog code/tests
- `pytest -q backend/tests/test_vrchat_manifest.py backend/tests/test_vrchat_catalog.py`

Closes #184