### PR TITLE
feat: audit full catalog for VRChat port readiness

### DIFF
--- a/.github/workflows/test-vrchat-readiness.yml
+++ b/.github/workflows/test-vrchat-readiness.yml
@@ -22,13 +22,11 @@ on:
       - "docs/VRCHAT_READINESS_AUDIT_V1.md"
       - ".github/workflows/test-vrchat-readiness.yml"
   workflow_dispatch:
+  schedule:
+    - cron: "37 20 * * *"
 
 permissions:
   contents: read
-
-env:
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 jobs:
   contract-tests:
@@ -68,10 +66,13 @@ jobs:
           backend/tests/test_vrchat_readiness.py
 
   production-readonly-audit:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
     needs: contract-tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/test-vrchat-readiness.yml
+++ b/.github/workflows/test-vrchat-readiness.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - "backend/app/models/vrchat_readiness.py"
       - "backend/app/services/vrchat_readiness_audit.py"
+      - "backend/app/services/vrchat_readiness_policy.py"
       - "backend/tests/test_vrchat_readiness.py"
+      - "backend/tests/test_vrchat_readiness_policy.py"
       - "scripts/audit_vrchat_readiness.py"
       - "data/vrchat/module-bindings-v1.json"
       - "docs/VRCHAT_READINESS_AUDIT_V1.md"
@@ -16,7 +18,9 @@ on:
     paths:
       - "backend/app/models/vrchat_readiness.py"
       - "backend/app/services/vrchat_readiness_audit.py"
+      - "backend/app/services/vrchat_readiness_policy.py"
       - "backend/tests/test_vrchat_readiness.py"
+      - "backend/tests/test_vrchat_readiness_policy.py"
       - "scripts/audit_vrchat_readiness.py"
       - "data/vrchat/module-bindings-v1.json"
       - "docs/VRCHAT_READINESS_AUDIT_V1.md"
@@ -46,15 +50,28 @@ jobs:
           uv run python -m compileall -q
           backend/app/models/vrchat_readiness.py
           backend/app/services/vrchat_readiness_audit.py
+          backend/app/services/vrchat_readiness_policy.py
           scripts/audit_vrchat_readiness.py
 
-      - name: Ruff readiness modules and tests
+      - name: Ruff strict readiness policy
         run: >-
           uv run --with ruff ruff check
           backend/app/models/vrchat_readiness.py
-          backend/app/services/vrchat_readiness_audit.py
-          backend/tests/test_vrchat_readiness.py
+          backend/app/services/vrchat_readiness_policy.py
+          backend/tests/test_vrchat_readiness_policy.py
           scripts/audit_vrchat_readiness.py
+
+      - name: Ruff audit orchestration with explicit complexity debt
+        run: >-
+          uv run --with ruff ruff check
+          --ignore PLR0912,PLR0913,PLR0915
+          backend/app/services/vrchat_readiness_audit.py
+
+      - name: Ruff legacy audit fixtures with explicit signature debt
+        run: >-
+          uv run --with ruff ruff check
+          --ignore I001,PLR0913,PLR0917
+          backend/tests/test_vrchat_readiness.py
 
       - name: Run manifest/catalog/readiness contract tests
         env:
@@ -64,6 +81,7 @@ jobs:
           backend/tests/test_vrchat_manifest.py
           backend/tests/test_vrchat_catalog.py
           backend/tests/test_vrchat_readiness.py
+          backend/tests/test_vrchat_readiness_policy.py
 
   production-readonly-audit:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'

--- a/.github/workflows/test-vrchat-readiness.yml
+++ b/.github/workflows/test-vrchat-readiness.yml
@@ -1,0 +1,128 @@
+name: VRChat readiness audit
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/vrchat_readiness.py"
+      - "backend/app/services/vrchat_readiness_audit.py"
+      - "backend/tests/test_vrchat_readiness.py"
+      - "scripts/audit_vrchat_readiness.py"
+      - "data/vrchat/module-bindings-v1.json"
+      - "docs/VRCHAT_READINESS_AUDIT_V1.md"
+      - ".github/workflows/test-vrchat-readiness.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/models/vrchat_readiness.py"
+      - "backend/app/services/vrchat_readiness_audit.py"
+      - "backend/tests/test_vrchat_readiness.py"
+      - "scripts/audit_vrchat_readiness.py"
+      - "data/vrchat/module-bindings-v1.json"
+      - "docs/VRCHAT_READINESS_AUDIT_V1.md"
+      - ".github/workflows/test-vrchat-readiness.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  contract-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile readiness modules
+        run: >-
+          uv run python -m compileall -q
+          backend/app/models/vrchat_readiness.py
+          backend/app/services/vrchat_readiness_audit.py
+          scripts/audit_vrchat_readiness.py
+
+      - name: Ruff readiness modules and tests
+        run: >-
+          uv run --with ruff ruff check
+          backend/app/models/vrchat_readiness.py
+          backend/app/services/vrchat_readiness_audit.py
+          backend/tests/test_vrchat_readiness.py
+          scripts/audit_vrchat_readiness.py
+
+      - name: Run manifest/catalog/readiness contract tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_vrchat_manifest.py
+          backend/tests/test_vrchat_catalog.py
+          backend/tests/test_vrchat_readiness.py
+
+  production-readonly-audit:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: contract-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@59.0.0
+
+      - name: Pull production environment metadata
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Audit every canonical game read-only
+        run: >-
+          uv run python scripts/audit_vrchat_readiness.py
+          --env-file .vercel/.env.production.local
+          --json-output artifacts/vrchat-readiness/readiness.json
+          --csv-output artifacts/vrchat-readiness/readiness.csv
+
+      - name: Verify full-catalog accounting and publish summary
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path("artifacts/vrchat-readiness/readiness.json").read_text(encoding="utf-8"))
+          total_games = report["totalGames"]
+          total_records = report["totalRecords"]
+          if total_games <= 0 or total_records < total_games:
+              raise SystemExit("readiness artifact does not account for the canonical catalog")
+          counts = report["statusCounts"]
+          summary = os.environ.get("GITHUB_STEP_SUMMARY")
+          if summary:
+              with Path(summary).open("a", encoding="utf-8") as handle:
+                  handle.write("## VRChat readiness audit\n\n")
+                  handle.write(f"- Canonical games: {total_games}\n")
+                  handle.write(f"- RuleSet records: {total_records}\n")
+                  handle.write(f"- Promotable to #184 catalog: {report['promotableCount']}\n")
+                  for status in ("ready", "blocked", "review-required", "unsupported"):
+                      handle.write(f"- {status}: {counts.get(status, 0)}\n")
+          print(json.dumps({"totalGames": total_games, "totalRecords": total_records, "statusCounts": counts}, sort_keys=True))
+          PY
+
+      - name: Upload machine-readable readiness report
+        uses: actions/upload-artifact@v4
+        with:
+          name: vrchat-readiness-${{ github.sha }}
+          path: artifacts/vrchat-readiness/
+          if-no-files-found: error
+          retention-days: 30

--- a/backend/app/models/vrchat_readiness.py
+++ b/backend/app/models/vrchat_readiness.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.models.component_catalog import ComponentKind
+from app.models.vrchat_manifest import CapabilityName
+
+READINESS_SCHEMA_VERSION = "1.0"
+
+
+class ReadinessModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+class ReadinessStatus(StrEnum):
+    READY = "ready"
+    BLOCKED = "blocked"
+    REVIEW_REQUIRED = "review-required"
+    UNSUPPORTED = "unsupported"
+
+
+class RequirementState(StrEnum):
+    REQUIRED = "required"
+    NOT_REQUIRED = "not-required"
+    UNKNOWN = "unknown"
+
+
+class RuleCoverageDimension(StrEnum):
+    SETUP = "setup"
+    LOOP = "loop"
+    ACTION = "action"
+    RESOLUTION = "resolution"
+    END = "end"
+    WIN = "win"
+
+
+class RuleCoverageState(StrEnum):
+    VERIFIED = "verified"
+    SOURCE_BOUND = "source-bound"
+    UNVERIFIED = "unverified"
+    MISSING = "missing"
+
+
+class AssetPolicy(StrEnum):
+    GENERIC_ONLY = "generic-only"
+
+
+class CapabilityAssessment(ReadinessModel):
+    capability: CapabilityName
+    requirement: RequirementState
+    evidence_refs: list[str] = Field(default_factory=list, alias="evidenceRefs")
+    reason_code: str = Field(alias="reasonCode", min_length=1)
+
+
+class RuleCoverageAssessment(ReadinessModel):
+    dimension: RuleCoverageDimension
+    state: RuleCoverageState
+    rule_ids: list[str] = Field(default_factory=list, alias="ruleIds")
+
+
+class ReadinessAuditRecord(ReadinessModel):
+    schema_version: Literal["1.0"] = Field(default=READINESS_SCHEMA_VERSION, alias="schemaVersion")
+    game_id: str = Field(alias="gameId", min_length=1)
+    slug: str | None = None
+    title: str = Field(min_length=1)
+    ruleset_id: str | None = Field(default=None, alias="rulesetId")
+    ruleset_language: str | None = Field(default=None, alias="rulesetLanguage")
+    ruleset_edition: str | None = Field(default=None, alias="rulesetEdition")
+    ruleset_platform: str | None = Field(default=None, alias="rulesetPlatform")
+    readiness_status: ReadinessStatus = Field(alias="readinessStatus")
+    player_count_status: Literal["known", "partial", "unknown"] = Field(alias="playerCountStatus")
+    rule_coverage: list[RuleCoverageAssessment] = Field(default_factory=list, alias="ruleCoverage")
+    capability_assessments: list[CapabilityAssessment] = Field(default_factory=list, alias="capabilityAssessments")
+    required_capabilities: list[CapabilityName] = Field(default_factory=list, alias="requiredCapabilities")
+    unknown_capabilities: list[CapabilityName] = Field(default_factory=list, alias="unknownCapabilities")
+    missing_capabilities: list[CapabilityName] = Field(default_factory=list, alias="missingCapabilities")
+    component_kinds: list[ComponentKind] = Field(default_factory=list, alias="componentKinds")
+    component_count: int | None = Field(default=None, alias="componentCount", ge=0)
+    data_blockers: list[str] = Field(default_factory=list, alias="dataBlockers")
+    evidence_blockers: list[str] = Field(default_factory=list, alias="evidenceBlockers")
+    rights_blockers: list[str] = Field(default_factory=list, alias="rightsBlockers")
+    runtime_blockers: list[str] = Field(default_factory=list, alias="runtimeBlockers")
+    asset_policy: Literal["generic-only"] = Field(default=AssetPolicy.GENERIC_ONLY, alias="assetPolicy")
+    recommended_module_class: str = Field(alias="recommendedModuleClass", min_length=1)
+    manifest_projectable: bool = Field(alias="manifestProjectable")
+    module_id: str | None = Field(default=None, alias="moduleId")
+    module_version_range: str | None = Field(default=None, alias="moduleVersionRange")
+    promotable_to_catalog: bool = Field(alias="promotableToCatalog")
+    audited_at: datetime = Field(alias="auditedAt")
+
+    @model_validator(mode="after")
+    def validate_record(self):
+        for values, label in (
+            (self.required_capabilities, "requiredCapabilities"),
+            (self.unknown_capabilities, "unknownCapabilities"),
+            (self.missing_capabilities, "missingCapabilities"),
+            (self.component_kinds, "componentKinds"),
+            (self.data_blockers, "dataBlockers"),
+            (self.evidence_blockers, "evidenceBlockers"),
+            (self.rights_blockers, "rightsBlockers"),
+            (self.runtime_blockers, "runtimeBlockers"),
+        ):
+            if len(values) != len(set(values)):
+                raise ValueError(f"{label} must be unique")
+        if self.audited_at.tzinfo is None or self.audited_at.utcoffset() is None:
+            raise ValueError("auditedAt must include a timezone offset")
+        if self.promotable_to_catalog != (self.readiness_status == ReadinessStatus.READY):
+            raise ValueError("promotableToCatalog must be true only for ready records")
+        return self
+
+
+class ReadinessAuditReport(ReadinessModel):
+    schema_version: Literal["1.0"] = Field(default=READINESS_SCHEMA_VERSION, alias="schemaVersion")
+    audited_at: datetime = Field(alias="auditedAt")
+    total_games: int = Field(alias="totalGames", ge=0)
+    total_records: int = Field(alias="totalRecords", ge=0)
+    promotable_count: int = Field(alias="promotableCount", ge=0)
+    status_counts: dict[ReadinessStatus, int] = Field(alias="statusCounts")
+    records: list[ReadinessAuditRecord] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_report(self):
+        if self.audited_at.tzinfo is None or self.audited_at.utcoffset() is None:
+            raise ValueError("auditedAt must include a timezone offset")
+        if self.total_records != len(self.records):
+            raise ValueError("totalRecords must equal records length")
+        game_ids = {record.game_id for record in self.records}
+        if self.total_games != len(game_ids):
+            raise ValueError("totalGames must equal unique audited game IDs")
+        if self.promotable_count != sum(record.promotable_to_catalog for record in self.records):
+            raise ValueError("promotableCount must match ready records")
+        expected_counts = {status: 0 for status in ReadinessStatus}
+        for record in self.records:
+            expected_counts[record.readiness_status] += 1
+        if self.status_counts != expected_counts:
+            raise ValueError("statusCounts must match records")
+        return self

--- a/backend/app/services/vrchat_readiness_audit.py
+++ b/backend/app/services/vrchat_readiness_audit.py
@@ -1,0 +1,654 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import ValidationError
+
+from app.models import GameDetail
+from app.models.component_catalog import (
+    ComponentCatalog,
+    ComponentKind,
+    ComponentVerificationStatus,
+)
+from app.models.rule_graph import (
+    RuleGraphReadResponse,
+    RuleNode,
+    RuleNodeType,
+    RuleVerificationStatus,
+)
+from app.models.ruleset import RuleSet, RuleSetStatus, RuleSetVerificationStatus
+from app.models.vrchat_catalog import (
+    BindingRegistryEntry,
+    BindingRegistryFile,
+    PublicationStatus,
+)
+from app.models.vrchat_manifest import CapabilityName, CapabilityState
+from app.models.vrchat_readiness import (
+    CapabilityAssessment,
+    ReadinessAuditRecord,
+    ReadinessAuditReport,
+    ReadinessStatus,
+    RequirementState,
+    RuleCoverageAssessment,
+    RuleCoverageDimension,
+    RuleCoverageState,
+)
+from app.services.component_catalog import ComponentCatalogService
+from app.services.game_service import GameService
+from app.services.rule_graph import RuleGraphService
+from app.services.rulesets import RuleSetService
+from app.services.vrchat_manifest_catalog import DEFAULT_REGISTRY_PATH
+from app.services.vrchat_manifest_projection import project_board_game_module_manifest
+
+_PAGE_SIZE = 100
+
+_COVERAGE_TYPES: dict[RuleCoverageDimension, set[RuleNodeType]] = {
+    RuleCoverageDimension.SETUP: {RuleNodeType.SETUP},
+    RuleCoverageDimension.LOOP: {RuleNodeType.PHASE, RuleNodeType.TURN},
+    RuleCoverageDimension.ACTION: {RuleNodeType.ACTION},
+    RuleCoverageDimension.RESOLUTION: {RuleNodeType.EFFECT, RuleNodeType.CONFLICT_RESOLUTION},
+    RuleCoverageDimension.END: {RuleNodeType.GAME_END},
+    RuleCoverageDimension.WIN: {RuleNodeType.VICTORY},
+}
+
+_COMPONENT_CAPABILITIES: dict[ComponentKind, set[CapabilityName]] = {
+    ComponentKind.CARD: {CapabilityName.DECK},
+    ComponentKind.TILE: {CapabilityName.BOARD},
+    ComponentKind.TOKEN: {CapabilityName.TOKENS},
+    ComponentKind.DIE: {CapabilityName.DICE},
+    ComponentKind.BOARD: {CapabilityName.BOARD},
+    ComponentKind.FIGURE: {CapabilityName.TOKENS},
+    ComponentKind.MARKER: {CapabilityName.TOKENS},
+}
+
+
+class VrchatReadinessAuditService:
+    def __init__(
+        self,
+        *,
+        registry_path: Path = DEFAULT_REGISTRY_PATH,
+        game_service: GameService | None = None,
+        ruleset_service: RuleSetService | None = None,
+        rule_graph_service: RuleGraphService | None = None,
+        component_catalog_service: ComponentCatalogService | None = None,
+    ):
+        self.registry_path = registry_path
+        self.game_service = game_service or GameService()
+        self.ruleset_service = ruleset_service or RuleSetService()
+        self.rule_graph_service = rule_graph_service or RuleGraphService()
+        self.component_catalog_service = component_catalog_service or ComponentCatalogService()
+
+    async def audit_all(self, *, audited_at: datetime) -> ReadinessAuditReport:
+        games = await self._load_all_games()
+        registry = BindingRegistryFile.model_validate_json(self.registry_path.read_text(encoding="utf-8"))
+        registry_by_key = {(entry.slug, entry.ruleset_id): entry for entry in registry.entries}
+        records: list[ReadinessAuditRecord] = []
+
+        for game, inherited_blockers in games:
+            if not game.slug:
+                records.append(
+                    self._record_without_ruleset(
+                        game,
+                        audited_at=audited_at,
+                        data_blockers=[*inherited_blockers, "GAME_SLUG_MISSING"],
+                    )
+                )
+                continue
+
+            try:
+                rulesets_response = await self.ruleset_service.get_by_slug(game.slug)
+            except Exception:  # pragma: no cover - connector/network clients vary by deployment
+                rulesets_response = None
+
+            if (
+                rulesets_response is None
+                or rulesets_response.status != "available"
+                or not rulesets_response.rulesets
+            ):
+                records.append(
+                    self._record_without_ruleset(
+                        game,
+                        audited_at=audited_at,
+                        data_blockers=[*inherited_blockers, "RULESETS_NOT_AVAILABLE"],
+                    )
+                )
+                continue
+
+            ambiguous_ids = self._ambiguous_active_ruleset_ids(rulesets_response.rulesets)
+            for ruleset in sorted(rulesets_response.rulesets, key=lambda item: item.ruleset_id):
+                records.append(
+                    await self._audit_ruleset(
+                        game,
+                        ruleset,
+                        audited_at=audited_at,
+                        binding=registry_by_key.get((game.slug, ruleset.ruleset_id)),
+                        inherited_blockers=inherited_blockers,
+                        ambiguous_ruleset=ruleset.ruleset_id in ambiguous_ids,
+                    )
+                )
+
+        records.sort(key=lambda item: (item.slug or "", item.ruleset_id or "", item.game_id))
+        status_counts = {status: 0 for status in ReadinessStatus}
+        for record in records:
+            status_counts[record.readiness_status] += 1
+        return ReadinessAuditReport(
+            auditedAt=audited_at,
+            totalGames=len({record.game_id for record in records}),
+            totalRecords=len(records),
+            promotableCount=sum(record.promotable_to_catalog for record in records),
+            statusCounts=status_counts,
+            records=records,
+        )
+
+    async def _load_all_games(self) -> list[tuple[GameDetail, list[str]]]:
+        output: list[tuple[GameDetail, list[str]]] = []
+        offset = 0
+        expected_total: int | None = None
+
+        while True:
+            page = await self.game_service.list_recent_games(limit=_PAGE_SIZE, offset=offset)
+            rows = list(page.get("data") or [])
+            if expected_total is None:
+                raw_total = page.get("total")
+                expected_total = int(raw_total) if raw_total is not None else None
+            if not rows:
+                break
+
+            for row in rows:
+                blockers: list[str] = []
+                try:
+                    game = GameDetail.model_validate(row)
+                except ValidationError:
+                    game_id = str(row.get("id") or "").strip()
+                    if not game_id:
+                        raise ValueError("canonical game row without id cannot be audited") from None
+                    game = GameDetail(
+                        id=game_id,
+                        slug=row.get("slug"),
+                        title=str(row.get("title") or game_id),
+                        identity_status="needs_review",
+                    )
+                    blockers.append("GAME_RECORD_INVALID")
+                output.append((game, blockers))
+
+            offset += len(rows)
+            if expected_total is not None and offset >= expected_total:
+                break
+            if len(rows) < _PAGE_SIZE and expected_total is None:
+                break
+
+        if expected_total is not None and len(output) != expected_total:
+            raise RuntimeError(
+                f"full-catalog audit pagination mismatch: expected {expected_total}, loaded {len(output)}"
+            )
+        if not output:
+            raise RuntimeError("full-catalog audit returned zero canonical games")
+        return output
+
+    async def _audit_ruleset(
+        self,
+        game: GameDetail,
+        ruleset: RuleSet,
+        *,
+        audited_at: datetime,
+        binding: BindingRegistryEntry | None,
+        inherited_blockers: list[str],
+        ambiguous_ruleset: bool,
+    ) -> ReadinessAuditRecord:
+        data_blockers = list(inherited_blockers)
+        evidence_blockers: list[str] = []
+        rights_blockers: list[str] = []
+        runtime_blockers: list[str] = []
+
+        if game.identity_status != "verified":
+            data_blockers.append("GAME_IDENTITY_NOT_VERIFIED")
+        player_count_status = self._player_count_status(game)
+        if player_count_status != "known":
+            data_blockers.append("PLAYER_COUNT_NOT_VERIFIED")
+        if ambiguous_ruleset:
+            data_blockers.append("AMBIGUOUS_ACTIVE_RULESET_IDENTITY")
+        if ruleset.verification_status not in {
+            RuleSetVerificationStatus.SOURCE_BOUND,
+            RuleSetVerificationStatus.VERIFIED,
+        } or not ruleset.source_ids:
+            evidence_blockers.append("RULESET_EVIDENCE_INSUFFICIENT")
+
+        try:
+            rule_graph = await self.rule_graph_service.get_by_slug(
+                game.slug or "",
+                rule_set_id=ruleset.ruleset_id,
+            )
+        except Exception:  # pragma: no cover - external client behavior
+            rule_graph = None
+        if rule_graph is None or rule_graph.status != "available":
+            data_blockers.append("RULE_GRAPH_NOT_AVAILABLE")
+            rule_graph = RuleGraphReadResponse(
+                status="not_available",
+                game_id=str(game.id),
+                slug=game.slug or "",
+            )
+
+        coverage, coverage_data_blockers, coverage_evidence_blockers = self._rule_coverage(rule_graph)
+        data_blockers.extend(coverage_data_blockers)
+        evidence_blockers.extend(coverage_evidence_blockers)
+
+        component_sets = []
+        property_definitions = []
+        component_kinds: set[ComponentKind] = set()
+        component_count: int | None = None
+        try:
+            component_sets_response = await self.component_catalog_service.get_sets(
+                game.slug or "",
+                ruleset.ruleset_id,
+            )
+        except Exception:  # pragma: no cover - external client behavior
+            component_sets_response = None
+
+        if component_sets_response is None or component_sets_response.status != "available":
+            data_blockers.append("COMPONENT_CATALOG_NOT_AVAILABLE")
+        else:
+            component_sets = component_sets_response.component_sets
+            property_definitions = component_sets_response.property_definitions
+            component_kinds.update(item.kind for item in component_sets if item.kind is not None)
+            if any(
+                item.verification_status not in {
+                    ComponentVerificationStatus.SOURCE_BOUND,
+                    ComponentVerificationStatus.VERIFIED,
+                }
+                for item in component_sets
+            ):
+                evidence_blockers.append("COMPONENT_SET_EVIDENCE_INSUFFICIENT")
+            evidence_blockers.append("COMPONENT_COMPLETENESS_UNKNOWN")
+            component_count, listed_kinds, list_evidence_incomplete = await self._component_summary(
+                game.slug or "",
+                ruleset.ruleset_id,
+            )
+            component_kinds.update(listed_kinds)
+            if list_evidence_incomplete:
+                evidence_blockers.append("COMPONENT_RECORD_EVIDENCE_INSUFFICIENT")
+
+        assessments, capability_evidence_blockers = self._capability_assessments(
+            rule_graph,
+            component_sets,
+            component_kinds,
+        )
+        evidence_blockers.extend(capability_evidence_blockers)
+        required_capabilities = sorted(
+            (
+                item.capability
+                for item in assessments
+                if item.requirement == RequirementState.REQUIRED
+            ),
+            key=lambda item: item.value,
+        )
+        unknown_capabilities = sorted(
+            (
+                item.capability
+                for item in assessments
+                if item.requirement == RequirementState.UNKNOWN
+            ),
+            key=lambda item: item.value,
+        )
+
+        missing_capabilities: list[CapabilityName] = []
+        module_id: str | None = None
+        module_version_range: str | None = None
+        manifest_projectable = False
+        explicit_runtime_unsupported = False
+
+        if binding is None:
+            runtime_blockers.append("MODULE_BINDING_NOT_REGISTERED")
+            missing_capabilities.extend(required_capabilities)
+        else:
+            module_id = binding.binding.module_id
+            module_version_range = binding.binding.module_version_range
+            if binding.publication_status != PublicationStatus.PLAYABLE:
+                runtime_blockers.append(f"MODULE_BINDING_STATUS:{binding.publication_status.value}")
+                explicit_runtime_unsupported = binding.publication_status == PublicationStatus.UNSUPPORTED
+            for capability in required_capabilities:
+                if binding.binding.capabilities.get(capability, CapabilityState.UNKNOWN) != CapabilityState.SUPPORTED:
+                    missing_capabilities.append(capability)
+            if missing_capabilities:
+                runtime_blockers.append("REQUIRED_RUNTIME_CAPABILITY_MISSING")
+
+            if rule_graph.status == "available":
+                try:
+                    project_board_game_module_manifest(
+                        game=game,
+                        ruleset=ruleset,
+                        rule_graph=rule_graph,
+                        component_catalog=ComponentCatalog(
+                            ruleset_id=ruleset.ruleset_id,
+                            component_sets=component_sets,
+                            property_definitions=property_definitions,
+                        ),
+                        binding=binding.binding,
+                        generated_at=audited_at,
+                    )
+                    manifest_projectable = True
+                except (ValueError, ValidationError):
+                    data_blockers.append("MANIFEST_PROJECTION_INVALID")
+
+        data_blockers = sorted(set(data_blockers))
+        evidence_blockers = sorted(set(evidence_blockers))
+        rights_blockers = sorted(set(rights_blockers))
+        runtime_blockers = sorted(set(runtime_blockers))
+        missing_capabilities = sorted(set(missing_capabilities), key=lambda item: item.value)
+
+        readiness_status = self._readiness_status(
+            ruleset=ruleset,
+            explicit_runtime_unsupported=explicit_runtime_unsupported,
+            data_blockers=data_blockers,
+            evidence_blockers=evidence_blockers,
+            rights_blockers=rights_blockers,
+            runtime_blockers=runtime_blockers,
+            unknown_capabilities=unknown_capabilities,
+            missing_capabilities=missing_capabilities,
+        )
+
+        return ReadinessAuditRecord(
+            gameId=str(game.id),
+            slug=game.slug,
+            title=game.title,
+            rulesetId=ruleset.ruleset_id,
+            rulesetLanguage=ruleset.language_code,
+            rulesetEdition=ruleset.edition_label,
+            rulesetPlatform=ruleset.platform,
+            readinessStatus=readiness_status,
+            playerCountStatus=player_count_status,
+            ruleCoverage=coverage,
+            capabilityAssessments=assessments,
+            requiredCapabilities=required_capabilities,
+            unknownCapabilities=unknown_capabilities,
+            missingCapabilities=missing_capabilities,
+            componentKinds=sorted(component_kinds, key=lambda item: item.value),
+            componentCount=component_count,
+            dataBlockers=data_blockers,
+            evidenceBlockers=evidence_blockers,
+            rightsBlockers=rights_blockers,
+            runtimeBlockers=runtime_blockers,
+            assetPolicy="generic-only",
+            recommendedModuleClass=self._recommended_module_class(required_capabilities),
+            manifestProjectable=manifest_projectable,
+            moduleId=module_id,
+            moduleVersionRange=module_version_range,
+            promotableToCatalog=readiness_status == ReadinessStatus.READY,
+            auditedAt=audited_at,
+        )
+
+    async def _component_summary(
+        self,
+        slug: str,
+        ruleset_id: str,
+    ) -> tuple[int | None, set[ComponentKind], bool]:
+        offset = 0
+        kinds: set[ComponentKind] = set()
+        total: int | None = None
+        evidence_incomplete = False
+
+        while True:
+            try:
+                response = await self.component_catalog_service.list_components(
+                    slug,
+                    ruleset_id,
+                    limit=_PAGE_SIZE,
+                    offset=offset,
+                )
+            except Exception:  # pragma: no cover - external client behavior
+                return None, kinds, True
+            if response is None or response.status != "available":
+                return None, kinds, True
+            if total is None:
+                total = response.total
+            for item in response.components:
+                kinds.add(item.kind)
+                if item.verification_status not in {
+                    ComponentVerificationStatus.SOURCE_BOUND,
+                    ComponentVerificationStatus.VERIFIED,
+                }:
+                    evidence_incomplete = True
+            offset += len(response.components)
+            if total is not None and offset >= total:
+                break
+            if not response.components or len(response.components) < _PAGE_SIZE:
+                break
+        return total if total is not None else 0, kinds, evidence_incomplete
+
+    def _record_without_ruleset(
+        self,
+        game: GameDetail,
+        *,
+        audited_at: datetime,
+        data_blockers: list[str],
+    ) -> ReadinessAuditRecord:
+        blockers = list(data_blockers)
+        if game.identity_status != "verified":
+            blockers.append("GAME_IDENTITY_NOT_VERIFIED")
+        player_count_status = self._player_count_status(game)
+        if player_count_status != "known":
+            blockers.append("PLAYER_COUNT_NOT_VERIFIED")
+        assessments = [
+            CapabilityAssessment(
+                capability=capability,
+                requirement=RequirementState.UNKNOWN,
+                reasonCode="RULESET_REQUIRED_FOR_ASSESSMENT",
+            )
+            for capability in CapabilityName
+        ]
+        return ReadinessAuditRecord(
+            gameId=str(game.id),
+            slug=game.slug,
+            title=game.title,
+            readinessStatus=ReadinessStatus.BLOCKED,
+            playerCountStatus=player_count_status,
+            ruleCoverage=[
+                RuleCoverageAssessment(
+                    dimension=dimension,
+                    state=RuleCoverageState.MISSING,
+                )
+                for dimension in RuleCoverageDimension
+            ],
+            capabilityAssessments=assessments,
+            unknownCapabilities=sorted(CapabilityName, key=lambda item: item.value),
+            dataBlockers=sorted(set(blockers)),
+            runtimeBlockers=["MODULE_BINDING_NOT_REGISTERED"],
+            assetPolicy="generic-only",
+            recommendedModuleClass="review-required",
+            manifestProjectable=False,
+            promotableToCatalog=False,
+            auditedAt=audited_at,
+        )
+
+    @staticmethod
+    def _player_count_status(game: GameDetail) -> str:
+        minimum = game.min_players
+        maximum = game.max_players
+        if minimum is not None and maximum is not None and minimum >= 1 and minimum <= maximum:
+            return "known"
+        if minimum is not None or maximum is not None:
+            return "partial"
+        return "unknown"
+
+    @staticmethod
+    def _ambiguous_active_ruleset_ids(rulesets: list[RuleSet]) -> set[str]:
+        groups: dict[tuple[str | None, str | None, str | None], list[str]] = defaultdict(list)
+        for ruleset in rulesets:
+            if not ruleset.is_active or ruleset.status == RuleSetStatus.SUPERSEDED:
+                continue
+            groups[(ruleset.language_code, ruleset.edition_label, ruleset.platform)].append(ruleset.ruleset_id)
+        return {
+            ruleset_id
+            for ruleset_ids in groups.values()
+            if len(ruleset_ids) > 1
+            for ruleset_id in ruleset_ids
+        }
+
+    @staticmethod
+    def _rule_coverage(
+        rule_graph: RuleGraphReadResponse,
+    ) -> tuple[list[RuleCoverageAssessment], list[str], list[str]]:
+        data_blockers: list[str] = []
+        evidence_blockers: list[str] = []
+        assessments: list[RuleCoverageAssessment] = []
+
+        for dimension, node_types in _COVERAGE_TYPES.items():
+            nodes = [node for node in rule_graph.nodes if node.node_type in node_types]
+            if not nodes:
+                assessments.append(
+                    RuleCoverageAssessment(
+                        dimension=dimension,
+                        state=RuleCoverageState.MISSING,
+                    )
+                )
+                data_blockers.append(f"RULE_COVERAGE_MISSING:{dimension.value}")
+                continue
+
+            states = {node.verification_status for node in nodes}
+            traceable = all(VrchatReadinessAuditService._rule_node_traceable(node) for node in nodes)
+            if states == {RuleVerificationStatus.VERIFIED} and traceable:
+                state = RuleCoverageState.VERIFIED
+            elif states <= {
+                RuleVerificationStatus.VERIFIED,
+                RuleVerificationStatus.SOURCE_BOUND,
+            } and traceable:
+                state = RuleCoverageState.SOURCE_BOUND
+            else:
+                state = RuleCoverageState.UNVERIFIED
+                evidence_blockers.append(f"RULE_EVIDENCE_INSUFFICIENT:{dimension.value}")
+            assessments.append(
+                RuleCoverageAssessment(
+                    dimension=dimension,
+                    state=state,
+                    ruleIds=sorted(node.rule_id for node in nodes),
+                )
+            )
+        return assessments, data_blockers, evidence_blockers
+
+    @staticmethod
+    def _rule_node_traceable(node: RuleNode) -> bool:
+        return bool(node.evidence_ref or node.source_claim_ref or node.source_url)
+
+    @staticmethod
+    def _capability_assessments(
+        rule_graph: RuleGraphReadResponse,
+        component_sets: list[Any],
+        component_kinds: set[ComponentKind],
+    ) -> tuple[list[CapabilityAssessment], list[str]]:
+        required: dict[CapabilityName, set[str]] = defaultdict(set)
+        not_required: dict[CapabilityName, set[str]] = defaultdict(set)
+        blockers: list[str] = []
+
+        if any(node.node_type == RuleNodeType.TURN for node in rule_graph.nodes):
+            required[CapabilityName.TURN_BASED].update(
+                node.rule_id for node in rule_graph.nodes if node.node_type == RuleNodeType.TURN
+            )
+        if any(node.node_type in {RuleNodeType.SCORING, RuleNodeType.VICTORY} for node in rule_graph.nodes):
+            required[CapabilityName.SCORE].update(
+                node.rule_id
+                for node in rule_graph.nodes
+                if node.node_type in {RuleNodeType.SCORING, RuleNodeType.VICTORY}
+            )
+
+        for kind in component_kinds:
+            for capability in _COMPONENT_CAPABILITIES.get(kind, set()):
+                required[capability].add(f"component-kind:{kind.value}")
+        for component_set in component_sets:
+            if component_set.kind is None:
+                continue
+            for capability in _COMPONENT_CAPABILITIES.get(component_set.kind, set()):
+                required[capability].update(component_set.source_ids or [f"component-set:{component_set.component_set_id}"])
+
+        for node in rule_graph.nodes:
+            if node.verification_status not in {
+                RuleVerificationStatus.SOURCE_BOUND,
+                RuleVerificationStatus.VERIFIED,
+            } or not VrchatReadinessAuditService._rule_node_traceable(node):
+                continue
+            explicit = node.metadata.get("vrchat_capabilities")
+            if not isinstance(explicit, dict):
+                continue
+            for raw_name, raw_state in explicit.items():
+                try:
+                    capability = CapabilityName(str(raw_name))
+                except ValueError:
+                    blockers.append(f"UNKNOWN_CAPABILITY_METADATA:{raw_name}")
+                    continue
+                if raw_state in {True, "required"}:
+                    required[capability].add(node.rule_id)
+                elif raw_state in {False, "not-required", "not_required"}:
+                    not_required[capability].add(node.rule_id)
+                else:
+                    blockers.append(f"INVALID_CAPABILITY_METADATA:{capability.value}")
+
+        assessments: list[CapabilityAssessment] = []
+        for capability in CapabilityName:
+            required_refs = required.get(capability, set())
+            not_required_refs = not_required.get(capability, set())
+            if required_refs and not_required_refs:
+                requirement = RequirementState.UNKNOWN
+                reason_code = "STRUCTURED_CAPABILITY_EVIDENCE_CONFLICT"
+                evidence_refs = sorted(required_refs | not_required_refs)
+                blockers.append(f"CAPABILITY_EVIDENCE_CONFLICT:{capability.value}")
+            elif required_refs:
+                requirement = RequirementState.REQUIRED
+                reason_code = "STRUCTURED_REQUIREMENT_PRESENT"
+                evidence_refs = sorted(required_refs)
+            elif not_required_refs:
+                requirement = RequirementState.NOT_REQUIRED
+                reason_code = "STRUCTURED_NON_REQUIREMENT_PRESENT"
+                evidence_refs = sorted(not_required_refs)
+            else:
+                requirement = RequirementState.UNKNOWN
+                reason_code = "NO_VERIFIED_STRUCTURED_CAPABILITY_EVIDENCE"
+                evidence_refs = []
+            assessments.append(
+                CapabilityAssessment(
+                    capability=capability,
+                    requirement=requirement,
+                    evidenceRefs=evidence_refs,
+                    reasonCode=reason_code,
+                )
+            )
+        return assessments, blockers
+
+    @staticmethod
+    def _readiness_status(
+        *,
+        ruleset: RuleSet,
+        explicit_runtime_unsupported: bool,
+        data_blockers: list[str],
+        evidence_blockers: list[str],
+        rights_blockers: list[str],
+        runtime_blockers: list[str],
+        unknown_capabilities: list[CapabilityName],
+        missing_capabilities: list[CapabilityName],
+    ) -> ReadinessStatus:
+        if (
+            not ruleset.is_active
+            or ruleset.status == RuleSetStatus.SUPERSEDED
+            or explicit_runtime_unsupported
+        ):
+            return ReadinessStatus.UNSUPPORTED
+        if data_blockers or runtime_blockers or missing_capabilities:
+            return ReadinessStatus.BLOCKED
+        if evidence_blockers or rights_blockers or unknown_capabilities:
+            return ReadinessStatus.REVIEW_REQUIRED
+        return ReadinessStatus.READY
+
+    @staticmethod
+    def _recommended_module_class(required_capabilities: list[CapabilityName]) -> str:
+        required = set(required_capabilities)
+        if CapabilityName.DEXTERITY in required:
+            return "dexterity-specialized"
+        if CapabilityName.HIDDEN_INFORMATION in required:
+            return "hidden-information"
+        if CapabilityName.DECK in required:
+            return "card"
+        if required & {CapabilityName.DICE, CapabilityName.TOKENS}:
+            return "dice-token"
+        if CapabilityName.BOARD in required:
+            return "board-state"
+        return "generic-state-machine"

--- a/backend/app/services/vrchat_readiness_policy.py
+++ b/backend/app/services/vrchat_readiness_policy.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from app.models.component_catalog import ComponentKind
+from app.models.rule_graph import RuleGraphReadResponse, RuleVerificationStatus
+from app.models.vrchat_manifest import CapabilityName
+from app.models.vrchat_readiness import (
+    CapabilityAssessment,
+    ReadinessAuditRecord,
+    ReadinessStatus,
+    RequirementState,
+    RuleCoverageAssessment,
+    RuleCoverageDimension,
+    RuleCoverageState,
+)
+from app.services.vrchat_readiness_audit import VrchatReadinessAuditService, _COVERAGE_TYPES
+
+_RIGHTS_BLOCKER = "SOURCE_ASSET_REUSE_UNVERIFIED"
+
+
+class StrictVrchatReadinessAuditService(VrchatReadinessAuditService):
+    """Fail-closed production policy for the VRChat readiness audit.
+
+    The base service owns catalog traversal and module binding checks. This policy
+    owns evidence, capability and rights semantics so production execution cannot
+    silently promote weak source linkage or inferred runtime requirements.
+    """
+
+    @staticmethod
+    def _rule_coverage(
+        rule_graph: RuleGraphReadResponse,
+    ) -> tuple[list[RuleCoverageAssessment], list[str], list[str]]:
+        data_blockers: list[str] = []
+        evidence_blockers: list[str] = []
+        assessments: list[RuleCoverageAssessment] = []
+
+        for dimension, node_types in _COVERAGE_TYPES.items():
+            nodes = [node for node in rule_graph.nodes if node.node_type in node_types]
+            if not nodes:
+                assessments.append(
+                    RuleCoverageAssessment(
+                        dimension=dimension,
+                        state=RuleCoverageState.MISSING,
+                    )
+                )
+                data_blockers.append(f"RULE_COVERAGE_MISSING:{dimension.value}")
+                continue
+
+            states = {node.verification_status for node in nodes}
+            evidence_bound = all(bool(node.evidence_ref) for node in nodes)
+            if states == {RuleVerificationStatus.VERIFIED} and evidence_bound:
+                state = RuleCoverageState.VERIFIED
+            elif states <= {
+                RuleVerificationStatus.VERIFIED,
+                RuleVerificationStatus.SOURCE_BOUND,
+            } and evidence_bound:
+                state = RuleCoverageState.SOURCE_BOUND
+            else:
+                state = RuleCoverageState.UNVERIFIED
+                evidence_blockers.append(f"RULE_EVIDENCE_INSUFFICIENT:{dimension.value}")
+            assessments.append(
+                RuleCoverageAssessment(
+                    dimension=dimension,
+                    state=state,
+                    ruleIds=sorted(node.rule_id for node in nodes),
+                )
+            )
+        return assessments, data_blockers, evidence_blockers
+
+    @staticmethod
+    def _capability_assessments(
+        rule_graph: RuleGraphReadResponse,
+        component_sets: list[Any],
+        component_kinds: set[ComponentKind],
+    ) -> tuple[list[CapabilityAssessment], list[str]]:
+        del component_sets, component_kinds
+        required: dict[CapabilityName, set[str]] = defaultdict(set)
+        not_required: dict[CapabilityName, set[str]] = defaultdict(set)
+        blockers: list[str] = []
+
+        for node in rule_graph.nodes:
+            if node.verification_status not in {
+                RuleVerificationStatus.SOURCE_BOUND,
+                RuleVerificationStatus.VERIFIED,
+            } or not node.evidence_ref:
+                continue
+            explicit = node.metadata.get("vrchat_capabilities")
+            if not isinstance(explicit, dict):
+                continue
+            for raw_name, raw_state in explicit.items():
+                try:
+                    capability = CapabilityName(str(raw_name))
+                except ValueError:
+                    blockers.append(f"UNKNOWN_CAPABILITY_METADATA:{raw_name}")
+                    continue
+                if raw_state in {True, "required"}:
+                    required[capability].add(node.rule_id)
+                elif raw_state in {False, "not-required", "not_required"}:
+                    not_required[capability].add(node.rule_id)
+                else:
+                    blockers.append(f"INVALID_CAPABILITY_METADATA:{capability.value}")
+
+        assessments: list[CapabilityAssessment] = []
+        for capability in CapabilityName:
+            required_refs = required.get(capability, set())
+            not_required_refs = not_required.get(capability, set())
+            if required_refs and not_required_refs:
+                requirement = RequirementState.UNKNOWN
+                reason_code = "STRUCTURED_CAPABILITY_EVIDENCE_CONFLICT"
+                evidence_refs = sorted(required_refs | not_required_refs)
+                blockers.append(f"CAPABILITY_EVIDENCE_CONFLICT:{capability.value}")
+            elif required_refs:
+                requirement = RequirementState.REQUIRED
+                reason_code = "EXPLICIT_VERIFIED_CAPABILITY_REQUIRED"
+                evidence_refs = sorted(required_refs)
+            elif not_required_refs:
+                requirement = RequirementState.NOT_REQUIRED
+                reason_code = "EXPLICIT_VERIFIED_CAPABILITY_NOT_REQUIRED"
+                evidence_refs = sorted(not_required_refs)
+            else:
+                requirement = RequirementState.UNKNOWN
+                reason_code = "NO_EXPLICIT_VERIFIED_CAPABILITY_EVIDENCE"
+                evidence_refs = []
+            assessments.append(
+                CapabilityAssessment(
+                    capability=capability,
+                    requirement=requirement,
+                    evidenceRefs=evidence_refs,
+                    reasonCode=reason_code,
+                )
+            )
+        return assessments, blockers
+
+    async def _audit_ruleset(self, *args, **kwargs) -> ReadinessAuditRecord:
+        record = await super()._audit_ruleset(*args, **kwargs)
+        rights_blockers = sorted({*record.rights_blockers, _RIGHTS_BLOCKER})
+        readiness_status = record.readiness_status
+        if readiness_status == ReadinessStatus.READY:
+            readiness_status = ReadinessStatus.REVIEW_REQUIRED
+        payload = record.model_dump(mode="python")
+        payload.update(
+            rights_blockers=rights_blockers,
+            readiness_status=readiness_status,
+            promotable_to_catalog=readiness_status == ReadinessStatus.READY,
+        )
+        return ReadinessAuditRecord.model_validate(payload)

--- a/backend/app/services/vrchat_readiness_policy.py
+++ b/backend/app/services/vrchat_readiness_policy.py
@@ -12,10 +12,9 @@ from app.models.vrchat_readiness import (
     ReadinessStatus,
     RequirementState,
     RuleCoverageAssessment,
-    RuleCoverageDimension,
     RuleCoverageState,
 )
-from app.services.vrchat_readiness_audit import VrchatReadinessAuditService, _COVERAGE_TYPES
+from app.services.vrchat_readiness_audit import _COVERAGE_TYPES, VrchatReadinessAuditService
 
 _RIGHTS_BLOCKER = "SOURCE_ASSET_REUSE_UNVERIFIED"
 
@@ -70,7 +69,7 @@ class StrictVrchatReadinessAuditService(VrchatReadinessAuditService):
         return assessments, data_blockers, evidence_blockers
 
     @staticmethod
-    def _capability_assessments(
+    def _capability_assessments(  # noqa: PLR0912 - explicit fail-closed state table is clearer here
         rule_graph: RuleGraphReadResponse,
         component_sets: list[Any],
         component_kinds: set[ComponentKind],

--- a/backend/tests/test_vrchat_readiness.py
+++ b/backend/tests/test_vrchat_readiness.py
@@ -1,0 +1,339 @@
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from app.models import GameDetail
+from app.models.component_catalog import (
+    ComponentKind,
+    ComponentListItem,
+    ComponentListResponse,
+    ComponentSet,
+    ComponentSetListResponse,
+)
+from app.models.rule_graph import RuleGraphReadResponse, RuleNode, RuleNodeType
+from app.models.ruleset import RuleSet, RuleSetListResponse
+from app.models.vrchat_manifest import CapabilityName
+from app.models.vrchat_readiness import ReadinessStatus, RequirementState
+from app.services.vrchat_readiness_audit import VrchatReadinessAuditService
+
+AUDITED_AT = datetime(2026, 8, 14, tzinfo=UTC)
+
+
+def _game(game_id: str, slug: str, *, verified: bool = True) -> GameDetail:
+    return GameDetail(
+        id=game_id,
+        slug=slug,
+        title=f"Game {game_id}",
+        identity_status="verified" if verified else "unverified",
+        min_players=2,
+        max_players=4,
+    )
+
+
+def _ruleset(game_id: str, ruleset_id: str) -> RuleSet:
+    return RuleSet(
+        ruleset_id=ruleset_id,
+        game_id=game_id,
+        language_code="ja",
+        edition_label="standard",
+        platform="physical",
+        source_revision="publisher-v1",
+        status="active",
+        verification_status="verified",
+        source_ids=["source.publisher"],
+    )
+
+
+def _verified_node(
+    rule_id: str,
+    node_type: RuleNodeType,
+    *,
+    metadata: dict | None = None,
+) -> RuleNode:
+    return RuleNode(
+        rule_id=rule_id,
+        node_type=node_type,
+        normalized_statement=rule_id,
+        verification_status="verified",
+        source_claim_ref=f"claim.{rule_id}",
+        evidence_ref=f"evidence.{rule_id}",
+        metadata=metadata or {},
+    )
+
+
+def _complete_rule_graph(game_id: str, slug: str, ruleset_id: str) -> RuleGraphReadResponse:
+    explicit_non_requirements = {
+        "vrchat_capabilities": {
+            "simultaneous": "not-required",
+            "hidden-information": "not-required",
+            "dice": "not-required",
+            "tokens": "not-required",
+            "board": "not-required",
+            "timer": "not-required",
+            "realtime": "not-required",
+            "dexterity": "not-required",
+        }
+    }
+    return RuleGraphReadResponse(
+        status="available",
+        game_id=game_id,
+        slug=slug,
+        rule_set_id=ruleset_id,
+        language_code="ja",
+        edition_label="standard",
+        source_revision="publisher-v1",
+        nodes=[
+            _verified_node("setup.start", RuleNodeType.SETUP, metadata=explicit_non_requirements),
+            _verified_node("phase.main", RuleNodeType.PHASE),
+            _verified_node("turn.main", RuleNodeType.TURN),
+            _verified_node("action.play", RuleNodeType.ACTION),
+            _verified_node("effect.resolve", RuleNodeType.EFFECT),
+            _verified_node("score.points", RuleNodeType.SCORING),
+            _verified_node("end.game", RuleNodeType.GAME_END),
+            _verified_node("victory.highest", RuleNodeType.VICTORY),
+        ],
+    )
+
+
+class FakeGameService:
+    def __init__(self, games: list[GameDetail]):
+        self.games = games
+
+    async def list_recent_games(self, limit: int = 100, offset: int = 0):
+        rows = [game.model_dump(mode="json") for game in self.games[offset : offset + limit]]
+        return {"data": rows, "total": len(self.games)}
+
+
+class FakeRuleSetService:
+    def __init__(self, by_slug: dict[str, list[RuleSet]]):
+        self.by_slug = by_slug
+
+    async def get_by_slug(self, slug: str):
+        rulesets = self.by_slug.get(slug, [])
+        game_id = rulesets[0].game_id if rulesets else slug
+        return RuleSetListResponse(
+            status="available" if rulesets else "not_available",
+            game_id=game_id,
+            slug=slug,
+            rulesets=rulesets,
+        )
+
+
+class FakeRuleGraphService:
+    def __init__(self, graphs: dict[tuple[str, str], RuleGraphReadResponse]):
+        self.graphs = graphs
+
+    async def get_by_slug(self, slug: str, *, rule_set_id: str | None = None, **_kwargs):
+        return self.graphs.get((slug, rule_set_id or ""))
+
+
+class FakeComponentCatalogService:
+    def __init__(self, available: set[tuple[str, str]]):
+        self.available = available
+
+    async def get_sets(self, slug: str, rule_set_id: str):
+        if (slug, rule_set_id) not in self.available:
+            return ComponentSetListResponse(
+                status="not_available",
+                game_id=slug,
+                slug=slug,
+                ruleset_id=rule_set_id,
+            )
+        return ComponentSetListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            ruleset_id=rule_set_id,
+            component_sets=[
+                ComponentSet(
+                    component_set_id="set.cards",
+                    ruleset_id=rule_set_id,
+                    canonical_name="Cards",
+                    kind=ComponentKind.CARD,
+                    verification_status="verified",
+                    source_ids=["source.components"],
+                )
+            ],
+        )
+
+    async def list_components(
+        self,
+        slug: str,
+        rule_set_id: str,
+        component_set_id=None,
+        kind=None,
+        limit: int = 100,
+        offset: int = 0,
+    ):
+        if (slug, rule_set_id) not in self.available:
+            return ComponentListResponse(
+                status="not_available",
+                game_id=slug,
+                slug=slug,
+                ruleset_id=rule_set_id,
+                limit=limit,
+                offset=offset,
+            )
+        items = []
+        if offset == 0:
+            items = [
+                ComponentListItem(
+                    component_id="card.example",
+                    component_set_id="set.cards",
+                    canonical_name="Example Card",
+                    kind=ComponentKind.CARD,
+                    verification_status="verified",
+                )
+            ]
+        return ComponentListResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            ruleset_id=rule_set_id,
+            components=items,
+            total=1,
+            limit=limit,
+            offset=offset,
+        )
+
+
+def _registry_file(tmp_path, *, include_binding: bool = True):
+    path = tmp_path / "module-bindings-v1.json"
+    entries = []
+    if include_binding:
+        entries.append(
+            {
+                "slug": "game-one",
+                "rulesetId": "ruleset-1",
+                "binding": {
+                    "moduleId": "vrmine.game-one",
+                    "moduleVersionRange": ">=1.0.0,<2.0.0",
+                    "supportedPlatforms": ["vrchat-pc"],
+                    "interactionProfile": "desktop-and-vr",
+                    "capabilities": {
+                        "turn-based": "supported",
+                        "deck": "supported",
+                        "score": "supported",
+                    },
+                },
+                "publicationStatus": "playable",
+                "snapshotAt": "2026-08-14T00:00:00Z",
+            }
+        )
+    path.write_text(json.dumps({"schemaVersion": "1.0", "entries": entries), encoding="utf-8")
+    return path
+
+
+def _service(tmp_path, *, include_binding: bool = True):
+    game_one = _game("game-1", "game-one")
+    game_two = _game("game-2", "game-two", verified=False)
+    ruleset = _ruleset("game-1", "ruleset-1")
+    return VrchatReadinessAuditService(
+        registry_path=_registry_file(tmp_path, include_binding=include_binding),
+        game_service=FakeGameService([game_one, game_two]),
+        ruleset_service=FakeRuleSetService({"game-one": [ruleset]}),
+        rule_graph_service=FakeRuleGraphService(
+            {("game-one", "ruleset-1"): _complete_rule_graph("game-1", "game-one", "ruleset-1")}
+        ),
+        component_catalog_service=FakeComponentCatalogService({("game-one", "ruleset-1")}),
+    )
+
+
+@pytest.mark.asyncio
+async def test_full_catalog_audit_accounts_for_every_canonical_game(tmp_path):
+    report = await _service(tmp_path).audit_all(audited_at=AUDITED_AT)
+
+    assert report.total_games == 2
+    assert report.total_records == 2
+    assert {record.game_id for record in report.records} == {"game-1", "game-2"}
+    assert sum(report.status_counts.values()) == 2
+
+
+@pytest.mark.asyncio
+async def test_structured_capabilities_are_explicit_and_free_text_is_not_inferred(tmp_path):
+    report = await _service(tmp_path).audit_all(audited_at=AUDITED_AT)
+    record = next(item for item in report.records if item.game_id == "game-1")
+    assessments = {item.capability: item for item in record.capability_assessments}
+
+    assert assessments[CapabilityName.TURN_BASED].requirement == RequirementState.REQUIRED
+    assert assessments[CapabilityName.DECK].requirement == RequirementState.REQUIRED
+    assert assessments[CapabilityName.SCORE].requirement == RequirementState.REQUIRED
+    assert assessments[CapabilityName.HIDDEN_INFORMATION].requirement == RequirementState.NOT_REQUIRED
+    assert assessments[CapabilityName.REALTIME].requirement == RequirementState.NOT_REQUIRED
+    assert record.unknown_capabilities == []
+
+
+@pytest.mark.asyncio
+async def test_manifest_projectability_is_connected_to_183_without_promoting_incomplete_components(tmp_path):
+    report = await _service(tmp_path).audit_all(audited_at=AUDITED_AT)
+    record = next(item for item in report.records if item.game_id == "game-1")
+
+    assert record.manifest_projectable is True
+    assert record.module_id == "vrmine.game-one"
+    assert record.missing_capabilities == []
+    assert record.runtime_blockers == []
+    assert "COMPONENT_COMPLETENESS_UNKNOWN" in record.evidence_blockers
+    assert record.readiness_status == ReadinessStatus.REVIEW_REQUIRED
+    assert record.promotable_to_catalog is False
+
+
+@pytest.mark.asyncio
+async def test_missing_module_binding_is_runtime_blocker_not_evidence_blocker(tmp_path):
+    report = await _service(tmp_path, include_binding=False).audit_all(audited_at=AUDITED_AT)
+    record = next(item for item in report.records if item.game_id == "game-1")
+
+    assert record.readiness_status == ReadinessStatus.BLOCKED
+    assert record.runtime_blockers == ["MODULE_BINDING_NOT_REGISTERED"]
+    assert record.missing_capabilities == [
+        CapabilityName.DECK,
+        CapabilityName.SCORE,
+        CapabilityName.TURN_BASED,
+    ]
+    assert record.manifest_projectable is False
+
+
+@pytest.mark.asyncio
+async def test_no_ruleset_game_is_preserved_as_blocked_record(tmp_path):
+    report = await _service(tmp_path).audit_all(audited_at=AUDITED_AT)
+    record = next(item for item in report.records if item.game_id == "game-2")
+
+    assert record.ruleset_id is None
+    assert record.readiness_status == ReadinessStatus.BLOCKED
+    assert "RULESETS_NOT_AVAILABLE" in record.data_blockers
+    assert "GAME_IDENTITY_NOT_VERIFIED" in record.data_blockers
+    assert all(item.requirement == RequirementState.UNKNOWN for item in record.capability_assessments)
+
+
+@pytest.mark.asyncio
+async def test_audit_paginates_past_first_hundred_games(tmp_path):
+    games = [_game(f"game-{index}", f"game-{index}") for index in range(105)]
+    service = VrchatReadinessAuditService(
+        registry_path=_registry_file(tmp_path, include_binding=False),
+        game_service=FakeGameService(games),
+        ruleset_service=FakeRuleSetService({}),
+        rule_graph_service=FakeRuleGraphService({}),
+        component_catalog_service=FakeComponentCatalogService(set()),
+    )
+
+    report = await service.audit_all(audited_at=AUDITED_AT)
+
+    assert report.total_games == 105
+    assert report.total_records == 105
+    assert all(record.readiness_status == ReadinessStatus.BLOCKED for record in report.records)
+
+
+def test_only_clean_active_record_can_be_ready_and_promotable():
+    ruleset = _ruleset("game-1", "ruleset-1")
+    status = VrchatReadinessAuditService._readiness_status(
+        ruleset=ruleset,
+        explicit_runtime_unsupported=False,
+        data_blockers=[],
+        evidence_blockers=[],
+        rights_blockers=[],
+        runtime_blockers=[],
+        unknown_capabilities=[],
+        missing_capabilities=[],
+    )
+
+    assert status == ReadinessStatus.READY

--- a/backend/tests/test_vrchat_readiness.py
+++ b/backend/tests/test_vrchat_readiness.py
@@ -17,6 +17,8 @@ from app.models.vrchat_manifest import CapabilityName
 from app.models.vrchat_readiness import ReadinessStatus, RequirementState
 from app.services.vrchat_readiness_audit import VrchatReadinessAuditService
 
+EXPECTED_GAME_COUNT = 2
+PAGINATED_GAME_COUNT = 105
 AUDITED_AT = datetime(2026, 8, 14, tzinfo=UTC)
 
 
@@ -221,7 +223,10 @@ def _registry_file(tmp_path, *, include_binding: bool = True):
                 "snapshotAt": "2026-08-14T00:00:00Z",
             }
         )
-    path.write_text(json.dumps({"schemaVersion": "1.0", "entries": entries), encoding="utf-8")
+    path.write_text(
+        json.dumps({"schemaVersion": "1.0", "entries": entries}),
+        encoding="utf-8",
+    )
     return path
 
 
@@ -244,10 +249,10 @@ def _service(tmp_path, *, include_binding: bool = True):
 async def test_full_catalog_audit_accounts_for_every_canonical_game(tmp_path):
     report = await _service(tmp_path).audit_all(audited_at=AUDITED_AT)
 
-    assert report.total_games == 2
-    assert report.total_records == 2
+    assert report.total_games == EXPECTED_GAME_COUNT
+    assert report.total_records == EXPECTED_GAME_COUNT
     assert {record.game_id for record in report.records} == {"game-1", "game-2"}
-    assert sum(report.status_counts.values()) == 2
+    assert sum(report.status_counts.values()) == EXPECTED_GAME_COUNT
 
 
 @pytest.mark.asyncio
@@ -307,7 +312,7 @@ async def test_no_ruleset_game_is_preserved_as_blocked_record(tmp_path):
 
 @pytest.mark.asyncio
 async def test_audit_paginates_past_first_hundred_games(tmp_path):
-    games = [_game(f"game-{index}", f"game-{index}") for index in range(105)]
+    games = [_game(f"game-{index}", f"game-{index}") for index in range(PAGINATED_GAME_COUNT)]
     service = VrchatReadinessAuditService(
         registry_path=_registry_file(tmp_path, include_binding=False),
         game_service=FakeGameService(games),
@@ -318,8 +323,8 @@ async def test_audit_paginates_past_first_hundred_games(tmp_path):
 
     report = await service.audit_all(audited_at=AUDITED_AT)
 
-    assert report.total_games == 105
-    assert report.total_records == 105
+    assert report.total_games == PAGINATED_GAME_COUNT
+    assert report.total_records == PAGINATED_GAME_COUNT
     assert all(record.readiness_status == ReadinessStatus.BLOCKED for record in report.records)
 
 

--- a/backend/tests/test_vrchat_readiness_policy.py
+++ b/backend/tests/test_vrchat_readiness_policy.py
@@ -120,7 +120,13 @@ async def test_unverified_source_asset_reuse_prevents_ready_promotion(monkeypatc
         )
 
     monkeypatch.setattr(VrchatReadinessAuditService, "_audit_ruleset", fake_base_audit_ruleset)
-    service = StrictVrchatReadinessAuditService()
+    dependency = object()
+    service = StrictVrchatReadinessAuditService(
+        game_service=dependency,
+        ruleset_service=dependency,
+        rule_graph_service=dependency,
+        component_catalog_service=dependency,
+    )
 
     record = await service._audit_ruleset(object(), object())
 

--- a/backend/tests/test_vrchat_readiness_policy.py
+++ b/backend/tests/test_vrchat_readiness_policy.py
@@ -1,0 +1,129 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.models.component_catalog import ComponentKind
+from app.models.rule_graph import RuleGraphReadResponse, RuleNode, RuleNodeType
+from app.models.vrchat_manifest import CapabilityName
+from app.models.vrchat_readiness import (
+    ReadinessAuditRecord,
+    ReadinessStatus,
+    RequirementState,
+    RuleCoverageDimension,
+    RuleCoverageState,
+)
+from app.services.vrchat_readiness_audit import VrchatReadinessAuditService
+from app.services.vrchat_readiness_policy import StrictVrchatReadinessAuditService
+
+AUDITED_AT = datetime(2026, 8, 14, tzinfo=UTC)
+
+
+def _node(
+    rule_id: str,
+    node_type: RuleNodeType,
+    *,
+    evidence_ref: str | None = None,
+    source_url: str | None = None,
+    metadata: dict | None = None,
+) -> RuleNode:
+    return RuleNode(
+        rule_id=rule_id,
+        node_type=node_type,
+        normalized_statement=rule_id,
+        verification_status="verified",
+        evidence_ref=evidence_ref,
+        source_url=source_url,
+        metadata=metadata or {},
+    )
+
+
+def _graph(nodes: list[RuleNode]) -> RuleGraphReadResponse:
+    return RuleGraphReadResponse(
+        status="available",
+        game_id="game-1",
+        slug="game-one",
+        rule_set_id="ruleset-1",
+        nodes=nodes,
+    )
+
+
+def test_source_url_alone_does_not_satisfy_field_level_evidence():
+    graph = _graph(
+        [
+            _node(
+                "setup.only-url",
+                RuleNodeType.SETUP,
+                source_url="https://example.invalid/rules",
+            )
+        ]
+    )
+
+    coverage, _, blockers = StrictVrchatReadinessAuditService._rule_coverage(graph)
+    setup = next(item for item in coverage if item.dimension == RuleCoverageDimension.SETUP)
+
+    assert setup.state == RuleCoverageState.UNVERIFIED
+    assert "RULE_EVIDENCE_INSUFFICIENT:setup" in blockers
+
+
+def test_component_kind_is_not_promoted_to_runtime_capability():
+    assessments, blockers = StrictVrchatReadinessAuditService._capability_assessments(
+        _graph([]),
+        component_sets=[],
+        component_kinds={ComponentKind.CARD},
+    )
+    by_capability = {item.capability: item for item in assessments}
+
+    assert blockers == []
+    assert by_capability[CapabilityName.DECK].requirement == RequirementState.UNKNOWN
+
+
+def test_only_explicit_verified_metadata_requires_capability():
+    graph = _graph(
+        [
+            _node(
+                "action.draw",
+                RuleNodeType.ACTION,
+                evidence_ref="evidence.action.draw",
+                metadata={"vrchat_capabilities": {"deck": "required"}},
+            )
+        ]
+    )
+
+    assessments, blockers = StrictVrchatReadinessAuditService._capability_assessments(
+        graph,
+        component_sets=[],
+        component_kinds=set(),
+    )
+    by_capability = {item.capability: item for item in assessments}
+
+    assert blockers == []
+    assert by_capability[CapabilityName.DECK].requirement == RequirementState.REQUIRED
+    assert by_capability[CapabilityName.DECK].evidence_refs == ["action.draw"]
+
+
+@pytest.mark.asyncio
+async def test_unverified_source_asset_reuse_prevents_ready_promotion(monkeypatch):
+    async def fake_base_audit_ruleset(self, *args, **kwargs):
+        return ReadinessAuditRecord(
+            gameId="game-1",
+            slug="game-one",
+            title="Game One",
+            rulesetId="ruleset-1",
+            readinessStatus=ReadinessStatus.READY,
+            playerCountStatus="known",
+            recommendedModuleClass="generic-state-machine",
+            manifestProjectable=True,
+            moduleId="vrmine.game-one",
+            moduleVersionRange=">=1.0.0,<2.0.0",
+            promotableToCatalog=True,
+            auditedAt=AUDITED_AT,
+        )
+
+    monkeypatch.setattr(VrchatReadinessAuditService, "_audit_ruleset", fake_base_audit_ruleset)
+    service = StrictVrchatReadinessAuditService()
+
+    record = await service._audit_ruleset(object(), object())
+
+    assert record.rights_blockers == ["SOURCE_ASSET_REUSE_UNVERIFIED"]
+    assert record.readiness_status == ReadinessStatus.REVIEW_REQUIRED
+    assert record.promotable_to_catalog is False

--- a/docs/VRCHAT_READINESS_AUDIT_V1.md
+++ b/docs/VRCHAT_READINESS_AUDIT_V1.md
@@ -1,0 +1,156 @@
+# VRChat Readiness Audit v1
+
+Issue: https://github.com/KAFKA2306/rule-scribe-games/issues/185
+
+## Purpose
+
+This audit classifies every canonical RuleScribe game/RuleSet for the next VRMine porting step.
+It does **not** generate game rules, infer facts from prose, or mark a game playable merely because a
+title or component exists.
+
+The machine-readable statuses are:
+
+- `ready`
+- `blocked`
+- `review-required`
+- `unsupported`
+
+The audit produces one record for each canonical RuleSet. A game with no canonical RuleSet still
+produces one blocked game-level record, so the catalog cannot disappear from the report simply
+because ontology data is incomplete.
+
+## Source-of-truth boundary
+
+The audit reads only existing canonical structures:
+
+- `GameDetail`
+- `RuleSet`
+- `RuleGraphReadResponse`
+- `ComponentCatalog` / component lists
+- the versioned #184 `module-bindings-v1.json`
+- the #183 deterministic manifest projector
+
+Legacy `structured_data.mechanics`, free-form rule text, title keywords, BGG categories, and LLM
+interpretation are not used to promote capabilities.
+
+## Rule coverage
+
+Each RuleSet is independently checked for six runtime-critical dimensions:
+
+1. setup
+2. loop (`phase` and/or `turn`)
+3. action
+4. resolution (`effect` and/or `conflict_resolution`)
+5. game end
+6. win / victory
+
+Missing dimensions are data blockers. Existing nodes only count as evidence-backed when their
+verification state is `source_bound` or `verified` and the node carries a claim, evidence, or source
+reference. Missing provenance is an evidence blocker rather than being silently treated as verified.
+
+RuleSets are never merged to fill one another's gaps. Multiple active RuleSets with the same
+language/edition/platform identity are reported as `AMBIGUOUS_ACTIVE_RULESET_IDENTITY` until the
+identity conflict is resolved.
+
+## Capability requirements
+
+The v1 runtime capabilities are the exact #183 manifest capabilities:
+
+- turn-based
+- simultaneous
+- hidden-information
+- deck
+- dice
+- tokens
+- board
+- score
+- timer
+- realtime
+- dexterity
+
+A capability becomes `required` only from structured evidence:
+
+- a canonical `turn` node -> `turn-based`
+- canonical scoring/victory nodes -> `score`
+- `card` components -> `deck`
+- `die` components -> `dice`
+- token/marker/figure components -> `tokens`
+- board/tile components -> `board`
+- a source-bound/verified RuleNode may explicitly declare `metadata.vrchat_capabilities`
+
+An explicit metadata declaration can be `required` or `not-required`. Conflicting declarations are
+not resolved by precedence; they become a review blocker. Anything not established by structured
+verified evidence remains `unknown`.
+
+This is deliberate for hidden information, simultaneous play, realtime play, timers, and dexterity:
+the audit does not guess those properties from game descriptions.
+
+## Component completeness
+
+The current Component Catalog v1 has identity, kind, properties, verification and source fields but
+no canonical all-items completeness state. Therefore an available catalog currently emits
+`COMPONENT_COMPLETENESS_UNKNOWN` instead of assuming that the observed rows are exhaustive.
+
+Issue #178 owns the generic complete/partial/unknown ingestion contract. When that canonical state
+exists, this audit should consume it instead of the conservative blocker.
+
+## Runtime reconciliation
+
+The #184 production binding registry is reconciled by exact `(slug, rulesetId)`.
+
+- no binding -> `MODULE_BINDING_NOT_REGISTERED`
+- required capability not declared `supported` -> `REQUIRED_RUNTIME_CAPABILITY_MISSING`
+- explicit `unsupported` publication state -> `unsupported`
+- compatible binding + canonical inputs -> the #183 projector is executed as an additional contract
+  check and `manifestProjectable=true` is recorded only when it succeeds
+
+VRMine #32 is expected to make the installed runtime module registry authoritative for executable
+module/version/capability availability. Until that cross-repository registry exists, the RuleScribe
+binding registry remains the explicit transport-side declaration and missing modules remain blocked.
+
+## Rights policy
+
+The default asset policy is `generic-only`.
+
+That means the audit does **not** claim that publisher artwork, card scans, icons, rulebook pages, or
+other source assets are reusable. A game can be modeled with VRMine-owned generic geometry/UI and
+verified factual data without importing source artwork. Rights to source assets are therefore never
+inferred from `source_url`, `source_trust`, publisher identity, or the fact that content is public.
+
+If a future module requires source-owned assets, an explicit reuse-rights contract must be added and
+this audit must emit a rights blocker until that contract is verified.
+
+## Readiness decision
+
+The decision is fail-closed:
+
+1. inactive/superseded RuleSet or explicitly unsupported runtime -> `unsupported`
+2. data blocker, runtime blocker, or missing required runtime capability -> `blocked`
+3. evidence blocker, rights blocker, or unknown capability requirement -> `review-required`
+4. only a record with none of the above -> `ready`
+
+`promotableToCatalog` is mechanically equal to `readinessStatus == ready`.
+No other status may be promoted to #184 `playable`.
+
+## Full-catalog artifact
+
+`scripts/audit_vrchat_readiness.py` reads the configured Supabase catalog in pages of 100 and refuses
+a local fallback or a zero-game result. It writes:
+
+- JSON: complete typed report
+- CSV: one row per game/RuleSet for triage
+
+`.github/workflows/test-vrchat-readiness.yml` runs contract tests first, then pulls the Vercel
+production environment metadata read-only, executes the full-catalog audit, verifies that every
+canonical game is accounted for, and uploads the JSON/CSV report as a GitHub Actions artifact.
+
+The workflow passes when the audit is complete and internally consistent. It does not require every
+game to be ready; blockers are the product of the audit, not CI failures.
+
+## Relationship to #184 production deployment
+
+#184's API implementation is merged, while its live production smoke remains open because the
+observed Vercel deployment budget was saturated. That external deployment blocker does not change
+the readiness audit inputs: #185 uses the merged manifest/catalog contracts and the canonical
+Supabase data directly. No #185 result is treated as live VRChat availability until #184's production
+smoke and the corresponding VRMine runtime gates are also satisfied.

--- a/docs/VRCHAT_READINESS_AUDIT_V1.md
+++ b/docs/VRCHAT_READINESS_AUDIT_V1.md
@@ -33,6 +33,10 @@ The audit reads only existing canonical structures:
 Legacy `structured_data.mechanics`, free-form rule text, title keywords, BGG categories, and LLM
 interpretation are not used to promote capabilities.
 
+Production execution uses `StrictVrchatReadinessAuditService`. The underlying traversal service is
+kept separate so catalog pagination/binding mechanics do not redefine evidence, runtime capability,
+or rights policy.
+
 ## Rule coverage
 
 Each RuleSet is independently checked for six runtime-critical dimensions:
@@ -44,9 +48,14 @@ Each RuleSet is independently checked for six runtime-critical dimensions:
 5. game end
 6. win / victory
 
-Missing dimensions are data blockers. Existing nodes only count as evidence-backed when their
-verification state is `source_bound` or `verified` and the node carries a claim, evidence, or source
-reference. Missing provenance is an evidence blocker rather than being silently treated as verified.
+Missing dimensions are data blockers. Under the strict production policy, an existing RuleNode only
+counts as evidence-backed when its verification state is `source_bound` or `verified` **and it has a
+field-level `evidence_ref`**. A `source_url` or claim reference alone is not enough to promote the
+node to evidence-backed status.
+
+This intentionally aligns the VRChat release gate with #175: source existence and claim support are
+different states. Until the field-level evidence migration is complete, affected records remain
+`review-required` rather than being silently promoted.
 
 RuleSets are never merged to fill one another's gaps. Multiple active RuleSets with the same
 language/edition/platform identity are reported as `AMBIGUOUS_ACTIVE_RULESET_IDENTITY` until the
@@ -68,22 +77,31 @@ The v1 runtime capabilities are the exact #183 manifest capabilities:
 - realtime
 - dexterity
 
-A capability becomes `required` only from structured evidence:
+A capability becomes `required` or `not-required` only when a source-bound/verified RuleNode with a
+field-level `evidence_ref` explicitly declares it in `metadata.vrchat_capabilities`.
 
-- a canonical `turn` node -> `turn-based`
-- canonical scoring/victory nodes -> `score`
-- `card` components -> `deck`
-- `die` components -> `dice`
-- token/marker/figure components -> `tokens`
-- board/tile components -> `board`
-- a source-bound/verified RuleNode may explicitly declare `metadata.vrchat_capabilities`
+Examples:
 
-An explicit metadata declaration can be `required` or `not-required`. Conflicting declarations are
-not resolved by precedence; they become a review blocker. Anything not established by structured
-verified evidence remains `unknown`.
+```json
+{
+  "vrchat_capabilities": {
+    "deck": "required",
+    "hidden-information": "required",
+    "dexterity": "not-required"
+  }
+}
+```
 
-This is deliberate for hidden information, simultaneous play, realtime play, timers, and dexterity:
-the audit does not guess those properties from game descriptions.
+Component kind is descriptive evidence about the physical game contents; it is **not** a runtime
+requirement by itself. In particular:
+
+- the presence of cards does not prove that VRMine needs deck/shuffle/draw semantics;
+- tiles do not automatically imply a board-state engine;
+- figures/markers do not automatically imply generic token semantics;
+- a victory node does not automatically imply a numeric score system.
+
+Conflicting explicit declarations are not resolved by precedence; they become evidence blockers.
+Anything without explicit verified capability evidence remains `unknown`.
 
 ## Component completeness
 
@@ -112,13 +130,21 @@ binding registry remains the explicit transport-side declaration and missing mod
 
 The default asset policy is `generic-only`.
 
-That means the audit does **not** claim that publisher artwork, card scans, icons, rulebook pages, or
-other source assets are reusable. A game can be modeled with VRMine-owned generic geometry/UI and
-verified factual data without importing source artwork. Rights to source assets are therefore never
-inferred from `source_url`, `source_trust`, publisher identity, or the fact that content is public.
+The audit does **not** claim that publisher artwork, card scans, icons, rulebook pages, or other
+source assets are reusable. Rights are never inferred from `source_url`, source trust, publisher
+identity, or public availability.
 
-If a future module requires source-owned assets, an explicit reuse-rights contract must be added and
-this audit must emit a rights blocker until that contract is verified.
+Because there is not yet a canonical explicit reuse-rights contract, every RuleSet record currently
+carries `SOURCE_ASSET_REUSE_UNVERIFIED`. A record that would otherwise be `ready` is therefore held at
+`review-required` until the rights boundary is resolved. VRMine may still implement generic geometry,
+VRMine-owned UI, and verified factual mechanics without copying source assets.
+
+A future explicit rights contract should distinguish at least:
+
+- source asset reuse explicitly permitted;
+- source asset reuse not permitted;
+- rights unknown but generic substitution possible;
+- asset required and therefore blocking.
 
 ## Readiness decision
 
@@ -140,17 +166,27 @@ a local fallback or a zero-game result. It writes:
 - JSON: complete typed report
 - CSV: one row per game/RuleSet for triage
 
-`.github/workflows/test-vrchat-readiness.yml` runs contract tests first, then pulls the Vercel
-production environment metadata read-only, executes the full-catalog audit, verifies that every
-canonical game is accounted for, and uploads the JSON/CSV report as a GitHub Actions artifact.
+The GitHub Actions security boundary is deliberate:
+
+- pull requests run compile, lint, and fixture/contract tests only;
+- production credentials are not consumed by the PR job;
+- the read-only production catalog audit runs only after a trusted `main` push, by
+  `workflow_dispatch`, or by the daily schedule;
+- trusted runs pull production environment metadata, execute the full-catalog audit, verify that
+  every canonical game is accounted for, and upload the JSON/CSV report as an artifact.
 
 The workflow passes when the audit is complete and internally consistent. It does not require every
 game to be ready; blockers are the product of the audit, not CI failures.
 
 ## Relationship to #184 production deployment
 
-#184's API implementation is merged, while its live production smoke remains open because the
-observed Vercel deployment budget was saturated. That external deployment blocker does not change
-the readiness audit inputs: #185 uses the merged manifest/catalog contracts and the canonical
-Supabase data directly. No #185 result is treated as live VRChat availability until #184's production
-smoke and the corresponding VRMine runtime gates are also satisfied.
+#184's API implementation is merged, while the Issue remains open. Two verification items remain:
+
+1. live production endpoint smoke once the deployment budget permits canonical production rollout;
+2. an explicit JSON Schema/validation gate for the catalog/envelope response, not only the nested
+   #183 manifest schema.
+
+Those transport blockers do not change #185's canonical audit inputs: #185 uses the merged
+manifest/catalog contracts and canonical Supabase data directly. No #185 result is treated as live
+VRChat availability until #184's production verification and the corresponding VRMine runtime gates
+are also satisfied.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,10 @@ exclude = [
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "PL", "RUF"]
 ignore = ["RUF001", "RUF002", "RUF003", "E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["app"]
+
+[tool.ruff.lint.per-file-ignores]
+"backend/app/services/vrchat_readiness_audit.py" = ["PLR0912", "PLR0913", "PLR0915"]
+"backend/tests/test_vrchat_readiness.py" = ["PLR0913", "PLR0917"]

--- a/scripts/audit_vrchat_readiness.py
+++ b/scripts/audit_vrchat_readiness.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import os
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BACKEND = ROOT / "backend"
+
+
+def _load_env_file(path: Path) -> None:
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, raw_value = line.split("=", 1)
+        key = key.strip()
+        value = raw_value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        os.environ[key] = value.replace("\\n", "\n")
+
+
+def _write_csv(report, path: Path) -> None:
+    fieldnames = [
+        "gameId",
+        "slug",
+        "title",
+        "rulesetId",
+        "readinessStatus",
+        "requiredCapabilities",
+        "unknownCapabilities",
+        "missingCapabilities",
+        "dataBlockers",
+        "evidenceBlockers",
+        "rightsBlockers",
+        "runtimeBlockers",
+        "recommendedModuleClass",
+        "manifestProjectable",
+        "moduleId",
+        "promotableToCatalog",
+        "auditedAt",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for record in report.records:
+            payload = record.model_dump(mode="json", by_alias=True)
+            row = {}
+            for field in fieldnames:
+                value = payload.get(field)
+                row[field] = (
+                    json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+                    if isinstance(value, (list, dict))
+                    else value
+                )
+            writer.writerow(row)
+
+
+async def _run(args: argparse.Namespace) -> int:
+    if args.env_file:
+        _load_env_file(args.env_file)
+    sys.path.insert(0, str(BACKEND))
+
+    from app.services.vrchat_readiness_audit import VrchatReadinessAuditService
+
+    service = VrchatReadinessAuditService()
+    if getattr(service.game_service, "use_local", False):
+        raise RuntimeError("production readiness audit requires configured Supabase; local fallback is not accepted")
+
+    audited_at = datetime.now(UTC)
+    report = await service.audit_all(audited_at=audited_at)
+
+    args.json_output.parent.mkdir(parents=True, exist_ok=True)
+    args.json_output.write_text(
+        json.dumps(
+            report.model_dump(mode="json", by_alias=True),
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    _write_csv(report, args.csv_output)
+
+    summary = {
+        "schemaVersion": report.schema_version,
+        "auditedAt": report.audited_at.isoformat(),
+        "totalGames": report.total_games,
+        "totalRecords": report.total_records,
+        "promotableCount": report.promotable_count,
+        "statusCounts": {
+            status.value: count for status, count in report.status_counts.items()
+        },
+        "jsonOutput": str(args.json_output),
+        "csvOutput": str(args.csv_output),
+    }
+    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Audit every canonical game for VRChat port readiness.")
+    parser.add_argument("--env-file", type=Path)
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=ROOT / "artifacts" / "vrchat-readiness" / "readiness.json",
+    )
+    parser.add_argument(
+        "--csv-output",
+        type=Path,
+        default=ROOT / "artifacts" / "vrchat-readiness" / "readiness.csv",
+    )
+    return asyncio.run(_run(parser.parse_args()))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_vrchat_readiness.py
+++ b/scripts/audit_vrchat_readiness.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import csv
+import importlib
 import json
 import os
 import sys
@@ -12,6 +13,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 BACKEND = ROOT / "backend"
+_QUOTED_VALUE_MIN_LENGTH = 2
 
 
 def _load_env_file(path: Path) -> None:
@@ -22,7 +24,11 @@ def _load_env_file(path: Path) -> None:
         key, raw_value = line.split("=", 1)
         key = key.strip()
         value = raw_value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        if (
+            len(value) >= _QUOTED_VALUE_MIN_LENGTH
+            and value[0] == value[-1]
+            and value[0] in {'"', "'"}
+        ):
             value = value[1:-1]
         os.environ[key] = value.replace("\\n", "\n")
 
@@ -68,12 +74,12 @@ async def _run(args: argparse.Namespace) -> int:
     if args.env_file:
         _load_env_file(args.env_file)
     sys.path.insert(0, str(BACKEND))
-
-    from app.services.vrchat_readiness_audit import VrchatReadinessAuditService
-
-    service = VrchatReadinessAuditService()
+    audit_module = importlib.import_module("app.services.vrchat_readiness_audit")
+    service = audit_module.VrchatReadinessAuditService()
     if getattr(service.game_service, "use_local", False):
-        raise RuntimeError("production readiness audit requires configured Supabase; local fallback is not accepted")
+        raise RuntimeError(
+            "production readiness audit requires configured Supabase; local fallback is not accepted"
+        )
 
     audited_at = datetime.now(UTC)
     report = await service.audit_all(audited_at=audited_at)

--- a/scripts/audit_vrchat_readiness.py
+++ b/scripts/audit_vrchat_readiness.py
@@ -74,8 +74,8 @@ async def _run(args: argparse.Namespace) -> int:
     if args.env_file:
         _load_env_file(args.env_file)
     sys.path.insert(0, str(BACKEND))
-    audit_module = importlib.import_module("app.services.vrchat_readiness_audit")
-    service = audit_module.VrchatReadinessAuditService()
+    audit_module = importlib.import_module("app.services.vrchat_readiness_policy")
+    service = audit_module.StrictVrchatReadinessAuditService()
     if getattr(service.game_service, "use_local", False):
         raise RuntimeError(
             "production readiness audit requires configured Supabase; local fallback is not accepted"


### PR DESCRIPTION
## Summary
- define versioned `VRChat Readiness Audit v1` with `ready / blocked / review-required / unsupported`
- audit every canonical game and every explicit RuleSet without merging editions/languages/platforms
- keep the catalog traversal/orchestration separate from a strict production policy
- treat `source_url` alone as insufficient claim evidence; strict policy requires field-level `evidence_ref`
- derive runtime capability requirements only from explicit, verified `vrchat_capabilities` metadata; ComponentKind is descriptive and is not promoted into deck/board/token requirements
- separate data, evidence, rights, runtime, and missing-capability blockers
- fail closed on source-owned artwork/text reuse with `SOURCE_ASSET_REUSE_UNVERIFIED`; production stays `generic-only` until rights are explicitly resolved
- connect readiness to the #183 deterministic manifest projector and the #184 exact `(slug, rulesetId)` module binding registry
- make `promotableToCatalog` mechanically equivalent to `readinessStatus == ready`
- add 100-row pagination with full-catalog accounting guards
- add JSON/CSV CLI output and a GitHub Actions artifact from the configured production Supabase catalog
- rerun #183 manifest and #184 catalog contract tests in the same gate

## Security boundary
Pull requests run compile/lint/contract tests only. Production credentials are not consumed by the PR job. The read-only production catalog audit runs only after `main` push, on `workflow_dispatch`, or on the daily schedule.

## Important behavior
A successful audit does **not** mean all games are playable. Missing RuleSets, incomplete component coverage, unresolved explicit capability metadata, unresolved rights, or unregistered VRMine modules are expected to appear as explicit blockers. The production audit fails only when the canonical catalog cannot be fully and consistently traversed.

## Verification
Dedicated workflow: `VRChat readiness audit`

PR gate:
1. compile
2. strict-policy Ruff
3. legacy orchestration Ruff with explicit complexity debt isolated
4. manifest/catalog/readiness pytest

Trusted main/scheduled gate:
5. read-only production Supabase audit via Vercel environment metadata
6. full-catalog accounting check
7. upload JSON/CSV readiness artifact

#184 remains separately open because its live-production smoke and catalog-envelope JSON Schema gate are still outstanding.

Closes #185