### PR TITLE
fix: add VRChat catalog response schemas

### DIFF
--- a/.github/workflows/test-vrchat-catalog.yml
+++ b/.github/workflows/test-vrchat-catalog.yml
@@ -12,7 +12,11 @@ on:
       - "backend/tests/test_vrchat_catalog.py"
       - "backend/tests/test_vrchat_manifest.py"
       - "data/vrchat/module-bindings-v1.json"
+      - "evaluation/vrchat/manifest-v1-fixtures.json"
       - "schemas/vrchat/board-game-module-manifest-v1.schema.json"
+      - "schemas/vrchat/manifest-catalog-v1.schema.json"
+      - "schemas/vrchat/manifest-read-response-v1.schema.json"
+      - "scripts/validate_vrchat_catalog_schemas.py"
       - "docs/VRCHAT_MANIFEST_CATALOG_V1.md"
       - ".github/workflows/test-vrchat-catalog.yml"
   push:
@@ -28,7 +32,11 @@ on:
       - "backend/tests/test_vrchat_catalog.py"
       - "backend/tests/test_vrchat_manifest.py"
       - "data/vrchat/module-bindings-v1.json"
+      - "evaluation/vrchat/manifest-v1-fixtures.json"
       - "schemas/vrchat/board-game-module-manifest-v1.schema.json"
+      - "schemas/vrchat/manifest-catalog-v1.schema.json"
+      - "schemas/vrchat/manifest-read-response-v1.schema.json"
+      - "scripts/validate_vrchat_catalog_schemas.py"
       - "docs/VRCHAT_MANIFEST_CATALOG_V1.md"
       - ".github/workflows/test-vrchat-catalog.yml"
 
@@ -54,6 +62,7 @@ jobs:
           backend/app/models/vrchat_catalog.py
           backend/app/routers/vrchat.py
           backend/app/services/vrchat_manifest_catalog.py
+          scripts/validate_vrchat_catalog_schemas.py
 
       - name: Ruff VRChat catalog modules and tests
         run: >-
@@ -62,6 +71,12 @@ jobs:
           backend/app/routers/vrchat.py
           backend/app/services/vrchat_manifest_catalog.py
           backend/tests/test_vrchat_catalog.py
+          scripts/validate_vrchat_catalog_schemas.py
+
+      - name: Validate external JSON Schema contracts
+        run: >-
+          uv run --with jsonschema
+          python scripts/validate_vrchat_catalog_schemas.py
 
       - name: Run manifest and catalog contract tests
         env:

--- a/backend/tests/test_vrchat_catalog.py
+++ b/backend/tests/test_vrchat_catalog.py
@@ -3,6 +3,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from app.models import GameDetail
 from app.models.component_catalog import ComponentKind, ComponentSet, ComponentSetListResponse
 from app.models.rule_graph import RuleGraphReadResponse, RuleNode, RuleNodeType
@@ -10,8 +13,6 @@ from app.models.ruleset import RuleSet, RuleSetListResponse
 from app.models.vrchat_catalog import BindingRegistryFile, ManifestReadStatus, PublicationStatus
 from app.routers import vrchat
 from app.services.vrchat_manifest_catalog import VrchatManifestCatalogService
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 HTTP_OK = 200
 HTTP_NOT_MODIFIED = 304

--- a/docs/VRCHAT_MANIFEST_CATALOG_V1.md
+++ b/docs/VRCHAT_MANIFEST_CATALOG_V1.md
@@ -16,6 +16,28 @@ Both responses are JSON, include `ETag`, and advertise:
 Clients should cache the catalog and selected manifest instead of fetching on every interaction.
 If the client sends the current `If-None-Match`, the API returns `304 Not Modified` with no body.
 
+## Versioned external schemas
+
+The transport boundary is published as checked-in JSON Schema Draft 2020-12 documents:
+
+- `schemas/vrchat/manifest-catalog-v1.schema.json`
+- `schemas/vrchat/manifest-read-response-v1.schema.json`
+- nested manifest: `schemas/vrchat/board-game-module-manifest-v1.schema.json`
+
+The read-response schema references the #183 BoardGameModule schema rather than copying its fields.
+This keeps the API envelope and the game manifest as separate versioned contracts.
+
+The schema gate validates both positive and fail-closed cases. It rejects, among other things:
+
+- malformed catalog SHA-256 revisions;
+- a non-playable catalog entry without `reasonCode`;
+- an `available` read response without a manifest;
+- a non-available read response that leaks a manifest payload.
+
+`scripts/validate_vrchat_catalog_schemas.py` validates the checked-in schemas themselves and exercises
+those cases using the existing #183 card-centric manifest fixture. CI installs `jsonschema` only for
+this contract step, so the application dependency/lockfile surface is unchanged.
+
 ## Publication registry
 
 `data/vrchat/module-bindings-v1.json` is the only production publication registry.
@@ -64,7 +86,8 @@ canonical services. An unknown `(slug, rulesetId)` returns `not_registered`.
 - `retired` — binding was intentionally retired;
 - `invalid` — a binding claimed playable but canonical projection validation failed.
 
-Only `available` contains a manifest payload.
+Only `available` contains a manifest payload. The external read-response JSON Schema enforces this
+rather than relying on client convention.
 
 ## Revisions and compatibility
 
@@ -96,14 +119,21 @@ client cannot supply an arbitrary `moduleId` or capability declaration to make a
 - catalog revision, cache headers, ETag, and conditional `304`;
 - manifest schema version and component-set references.
 
-The dedicated CI gate also runs the #183 manifest contract tests so transport changes cannot drift
-from the versioned BoardGameModule Manifest JSON Schema.
+The dedicated CI gate also:
+
+- runs the #183 manifest contract tests so transport changes cannot drift from the versioned
+  BoardGameModule Manifest JSON Schema;
+- validates the catalog/read-response Draft 2020-12 schemas as actual external-consumer contracts;
+- exercises positive and negative envelope fixtures without network access.
 
 ## Production verification state
 
 The merge commit for PR #195 (`3458ccfe8e2c64aee67b3c3965a9b61781237de4`) passed the production
 Vercel build and environment checks on 2026-08-14. The repository's deployment-budget gate reported
 `quota_saturated`, so the canonical Vercel Git production deployment verification was deliberately
-skipped and no deployment was created by GitHub Actions. Issue #184 therefore remains open: its
-remaining acceptance condition is a successful canonical production deployment followed by a live
-catalog schema/cache smoke check. This quota state does not change the local/CI contract above.
+skipped and no deployment was created by GitHub Actions.
+
+Issue #184 therefore remains open until a canonical production deployment is available and both live
+endpoints pass a schema/cache smoke check. The checked-in catalog/read-response JSON Schema CI gate
+is independent of that deployment quota and is required before the transport contract is considered
+complete in source control.

--- a/schemas/vrchat/manifest-catalog-v1.schema.json
+++ b/schemas/vrchat/manifest-catalog-v1.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/rule-scribe-games/schemas/vrchat/manifest-catalog-v1.schema.json",
+  "title": "VRChat Manifest Catalog v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "catalogRevision",
+    "manifestSchemaVersion",
+    "entries"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0"
+    },
+    "catalogRevision": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "manifestSchemaVersion": {
+      "const": "1.0"
+    },
+    "entries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ManifestCatalogEntry"
+      }
+    }
+  },
+  "$defs": {
+    "ManifestCatalogEntry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "rulesetId",
+        "moduleId",
+        "moduleVersionRange",
+        "status",
+        "reasonCode",
+        "manifestPath",
+        "manifestSchemaVersion"
+      ],
+      "properties": {
+        "slug": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rulesetId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "moduleId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "moduleVersionRange": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": [
+            "playable",
+            "unavailable",
+            "unsupported",
+            "retired",
+            "invalid"
+          ]
+        },
+        "reasonCode": {
+          "anyOf": [
+            {
+              "type": "string",
+              "minLength": 1
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "manifestPath": {
+          "type": "string",
+          "pattern": "^/api/vrchat/v1/manifests/[^/]+/[^/]+$"
+        },
+        "manifestSchemaVersion": {
+          "const": "1.0"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "playable"
+              }
+            },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "reasonCode": {
+                "type": "null"
+              }
+            }
+          },
+          "else": {
+            "properties": {
+              "reasonCode": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/vrchat/manifest-read-response-v1.schema.json
+++ b/schemas/vrchat/manifest-read-response-v1.schema.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/rule-scribe-games/schemas/vrchat/manifest-read-response-v1.schema.json",
+  "title": "VRChat Manifest Read Response v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "status",
+    "slug",
+    "rulesetId",
+    "reasonCode",
+    "manifest"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "1.0"
+    },
+    "status": {
+      "enum": [
+        "available",
+        "not_registered",
+        "unavailable",
+        "unsupported",
+        "retired",
+        "invalid"
+      ]
+    },
+    "slug": {
+      "type": "string",
+      "minLength": 1
+    },
+    "rulesetId": {
+      "type": "string",
+      "minLength": 1
+    },
+    "reasonCode": {
+      "anyOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "manifest": {
+      "anyOf": [
+        {
+          "$ref": "board-game-module-manifest-v1.schema.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "available"
+          }
+        },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "reasonCode": {
+            "type": "null"
+          },
+          "manifest": {
+            "$ref": "board-game-module-manifest-v1.schema.json"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "reasonCode": {
+            "type": "string",
+            "minLength": 1
+          },
+          "manifest": {
+            "type": "null"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/validate_vrchat_catalog_schemas.py
+++ b/scripts/validate_vrchat_catalog_schemas.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, FormatChecker, ValidationError
+from referencing import Registry, Resource
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas" / "vrchat"
+MANIFEST_SCHEMA_PATH = SCHEMA_DIR / "board-game-module-manifest-v1.schema.json"
+CATALOG_SCHEMA_PATH = SCHEMA_DIR / "manifest-catalog-v1.schema.json"
+READ_SCHEMA_PATH = SCHEMA_DIR / "manifest-read-response-v1.schema.json"
+MANIFEST_FIXTURES_PATH = ROOT / "evaluation" / "vrchat" / "manifest-v1-fixtures.json"
+REVISION = "a" * 64
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _validator(schema: dict, manifest_schema: dict) -> Draft202012Validator:
+    registry = Registry().with_resource(
+        manifest_schema["$id"],
+        Resource.from_contents(manifest_schema),
+    )
+    return Draft202012Validator(
+        schema,
+        registry=registry,
+        format_checker=FormatChecker(),
+    )
+
+
+def _expect_invalid(validator: Draft202012Validator, payload: dict, label: str) -> None:
+    try:
+        validator.validate(payload)
+    except ValidationError:
+        return
+    raise AssertionError(f"expected schema rejection: {label}")
+
+
+def main() -> int:
+    manifest_schema = _load(MANIFEST_SCHEMA_PATH)
+    catalog_schema = _load(CATALOG_SCHEMA_PATH)
+    read_schema = _load(READ_SCHEMA_PATH)
+
+    Draft202012Validator.check_schema(manifest_schema)
+    Draft202012Validator.check_schema(catalog_schema)
+    Draft202012Validator.check_schema(read_schema)
+
+    fixtures = _load(MANIFEST_FIXTURES_PATH)
+    manifest = fixtures["cases"][0]["manifest"]
+
+    catalog_validator = _validator(catalog_schema, manifest_schema)
+    read_validator = _validator(read_schema, manifest_schema)
+
+    catalog = {
+        "schemaVersion": "1.0",
+        "catalogRevision": REVISION,
+        "manifestSchemaVersion": "1.0",
+        "entries": [
+            {
+                "slug": manifest["slug"],
+                "rulesetId": manifest["rulesetId"],
+                "moduleId": manifest["moduleId"],
+                "moduleVersionRange": manifest["moduleVersionRange"],
+                "status": "playable",
+                "reasonCode": None,
+                "manifestPath": (
+                    f"/api/vrchat/v1/manifests/{manifest['slug']}/{manifest['rulesetId']}"
+                ),
+                "manifestSchemaVersion": "1.0",
+            },
+            {
+                "slug": "unsupported-example",
+                "rulesetId": "ruleset-unsupported",
+                "moduleId": "vrmine.unsupported-example",
+                "moduleVersionRange": ">=1.0.0,<2.0.0",
+                "status": "unsupported",
+                "reasonCode": "DEXTERITY_UNSUPPORTED",
+                "manifestPath": (
+                    "/api/vrchat/v1/manifests/unsupported-example/ruleset-unsupported"
+                ),
+                "manifestSchemaVersion": "1.0",
+            },
+        ],
+    }
+    catalog_validator.validate(catalog)
+
+    available = {
+        "schemaVersion": "1.0",
+        "status": "available",
+        "slug": manifest["slug"],
+        "rulesetId": manifest["rulesetId"],
+        "reasonCode": None,
+        "manifest": manifest,
+    }
+    unavailable = {
+        "schemaVersion": "1.0",
+        "status": "not_registered",
+        "slug": "missing-example",
+        "rulesetId": "ruleset-missing",
+        "reasonCode": "MODULE_BINDING_NOT_REGISTERED",
+        "manifest": None,
+    }
+    read_validator.validate(available)
+    read_validator.validate(unavailable)
+
+    bad_revision = copy.deepcopy(catalog)
+    bad_revision["catalogRevision"] = "not-a-sha256"
+    _expect_invalid(catalog_validator, bad_revision, "catalog revision")
+
+    bad_catalog_reason = copy.deepcopy(catalog)
+    bad_catalog_reason["entries"][1]["reasonCode"] = None
+    _expect_invalid(catalog_validator, bad_catalog_reason, "blocked catalog reasonCode")
+
+    missing_manifest = copy.deepcopy(available)
+    missing_manifest["manifest"] = None
+    _expect_invalid(read_validator, missing_manifest, "available response without manifest")
+
+    leaked_manifest = copy.deepcopy(unavailable)
+    leaked_manifest["manifest"] = manifest
+    _expect_invalid(read_validator, leaked_manifest, "blocked response with manifest")
+
+    print("VRChat catalog/read-response Draft 2020-12 schemas: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- publish checked-in Draft 2020-12 JSON Schemas for the public VRChat catalog and selected-manifest response envelopes
- keep the nested BoardGameModule contract as a `$ref` to the existing #183 manifest schema instead of duplicating it
- validate catalog revision shape, publication states, `reasonCode`, manifest path, and manifest schema version
- enforce at the external schema boundary that `available` responses contain a manifest and non-available responses do not
- add positive and negative schema-contract checks using the existing #183 manifest fixture
- run the schema gate in the dedicated VRChat catalog workflow without changing the application lockfile
- document the external-consumer schema paths and the remaining production smoke blocker

## Verification
Dedicated `VRChat manifest catalog` gate:
1. compile catalog modules + schema validation script
2. Ruff catalog code/tests/script
3. `uv run --with jsonschema python scripts/validate_vrchat_catalog_schemas.py`
4. existing #183/#184 pytest contracts

## Scope / completion
This resolves the source-control JSON Schema acceptance gap found in the #184 audit. It does **not** close #184: the canonical live-production endpoint/schema/cache smoke remains a separate fixed point until Vercel production deployment is current.

Refs #184