### PR TITLE
Add schema-driven Components UI

### DIFF
--- a/.github/workflows/test-components-ui.yml
+++ b/.github/workflows/test-components-ui.yml
@@ -1,0 +1,112 @@
+name: Components UI contract
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/component_catalog_view.py"
+      - "backend/app/services/component_catalog_view.py"
+      - "backend/app/routers/component_catalog_view.py"
+      - "backend/app/main.py"
+      - "backend/tests/test_component_catalog_view.py"
+      - "frontend/src/lib/componentCatalog.js"
+      - "frontend/src/components/game/ComponentsPanel.jsx"
+      - "frontend/src/components/game/components-panel.css"
+      - "frontend/src/pages/GamePage.jsx"
+      - "frontend/tests/componentCatalog.test.mjs"
+      - "frontend/tests/components_ui.spec.js"
+      - ".github/workflows/test-components-ui.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/app/models/component_catalog_view.py"
+      - "backend/app/services/component_catalog_view.py"
+      - "backend/app/routers/component_catalog_view.py"
+      - "backend/app/main.py"
+      - "backend/tests/test_component_catalog_view.py"
+      - "frontend/src/lib/componentCatalog.js"
+      - "frontend/src/components/game/ComponentsPanel.jsx"
+      - "frontend/src/components/game/components-panel.css"
+      - "frontend/src/pages/GamePage.jsx"
+      - "frontend/tests/componentCatalog.test.mjs"
+      - "frontend/tests/components_ui.spec.js"
+      - ".github/workflows/test-components-ui.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  backend-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+      - name: Compile component UI projection modules
+        run: >-
+          uv run python -m compileall -q
+          backend/app/models/component_catalog_view.py
+          backend/app/services/component_catalog_view.py
+          backend/app/routers/component_catalog_view.py
+          backend/app/main.py
+      - name: Run component view and canonical dependency tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_component_catalog_view.py
+          backend/tests/test_component_catalog.py
+          backend/tests/test_claim_evidence.py
+          backend/tests/test_ruleset_identity.py
+
+  frontend-contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      VITE_SUPABASE_URL: https://example.supabase.co
+      VITE_SUPABASE_ANON_KEY: sb_publishable_test
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Run schema-driven filter unit tests
+        working-directory: frontend
+        run: node --test tests/componentCatalog.test.mjs
+      - name: Lint Components UI surfaces
+        working-directory: frontend
+        run: >-
+          npx eslint
+          src/lib/componentCatalog.js
+          src/components/game/ComponentsPanel.jsx
+          src/pages/GamePage.jsx
+          tests/components_ui.spec.js
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+      - name: Gate Components UI at 375 768 and 1440 widths
+        working-directory: frontend
+        run: >-
+          npx playwright test tests/components_ui.spec.js
+          --project=ux-mobile
+          --project=ux-tablet
+          --project=ux-desktop
+      - name: Upload Components UI screenshots and traces
+        if: ${{ success() || failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: components-ui-evidence
+          path: frontend/test-results/**/*
+          if-no-files-found: ignore
+          retention-days: 14

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.responses import HTMLResponse
 
 from app.core.logger import setup_logging
 from app.middleware.validation import ValidationMiddleware
-from app.routers import auth, games, lists, presentation, vrchat
+from app.routers import auth, component_catalog_view, games, lists, presentation, vrchat
 from app.services.seo_renderer import generate_seo_html
 from app.services.sitemap import get_sitemap_xml
 
@@ -23,6 +23,7 @@ app.add_middleware(
 
 app.include_router(games.router, prefix="/api", tags=["games"])
 app.include_router(presentation.router, prefix="/api", tags=["presentation"])
+app.include_router(component_catalog_view.router, prefix="/api", tags=["components"])
 app.include_router(auth.router, prefix="/api/auth", tags=["auth"])
 app.include_router(lists.router, prefix="/api", tags=["lists"])
 app.include_router(vrchat.router, prefix="/api/vrchat/v1", tags=["vrchat"])

--- a/backend/app/models/component_catalog_view.py
+++ b/backend/app/models/component_catalog_view.py
@@ -1,0 +1,50 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.component_catalog import Component, ComponentSet, PropertyDefinition
+
+COMPONENT_CATALOG_VIEW_SCHEMA_VERSION = "1.0"
+
+
+class ComponentCatalogViewModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ComponentCatalogAvailabilityResponse(ComponentCatalogViewModel):
+    schema_version: Literal["1.0"] = COMPONENT_CATALOG_VIEW_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    rule_set_ids: list[str] = Field(default_factory=list)
+
+
+class FieldEvidenceSummary(ComponentCatalogViewModel):
+    status: Literal["verified", "unknown", "contested"] = "unknown"
+    claim_ids: list[str] = Field(default_factory=list)
+    source_ids: list[str] = Field(default_factory=list)
+
+
+class AbilityEvidenceSummary(ComponentCatalogViewModel):
+    printed_text: FieldEvidenceSummary = Field(default_factory=FieldEvidenceSummary)
+    normalized: FieldEvidenceSummary = Field(default_factory=FieldEvidenceSummary)
+
+
+class ComponentCatalogPageItem(ComponentCatalogViewModel):
+    component: Component
+    property_evidence: dict[str, FieldEvidenceSummary] = Field(default_factory=dict)
+    ability_evidence: dict[str, AbilityEvidenceSummary] = Field(default_factory=dict)
+
+
+class ComponentCatalogPageResponse(ComponentCatalogViewModel):
+    schema_version: Literal["1.0"] = COMPONENT_CATALOG_VIEW_SCHEMA_VERSION
+    status: Literal["available", "not_available"]
+    game_id: str
+    slug: str
+    rule_set_id: str
+    component_sets: list[ComponentSet] = Field(default_factory=list)
+    property_definitions: list[PropertyDefinition] = Field(default_factory=list)
+    items: list[ComponentCatalogPageItem] = Field(default_factory=list)
+    total: int = Field(default=0, ge=0)
+    limit: int = Field(default=50, ge=1, le=100)
+    offset: int = Field(default=0, ge=0)

--- a/backend/app/routers/component_catalog_view.py
+++ b/backend/app/routers/component_catalog_view.py
@@ -1,0 +1,54 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.models.component_catalog import ComponentKind
+from app.models.component_catalog_view import (
+    ComponentCatalogAvailabilityResponse,
+    ComponentCatalogPageResponse,
+)
+from app.services.component_catalog_view import ComponentCatalogViewService
+
+router = APIRouter()
+
+
+def get_component_catalog_view_service():
+    return ComponentCatalogViewService()
+
+
+@router.get(
+    "/games/{slug}/component-catalog-availability",
+    response_model=ComponentCatalogAvailabilityResponse,
+)
+async def get_component_catalog_availability(
+    slug: str,
+    service: ComponentCatalogViewService = Depends(get_component_catalog_view_service),
+):
+    result = await service.get_availability(slug)
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return result
+
+
+@router.get(
+    "/games/{slug}/component-catalog",
+    response_model=ComponentCatalogPageResponse,
+)
+async def get_component_catalog_page(
+    slug: str,
+    rule_set_id: str = Query(..., min_length=1),
+    component_set_id: str | None = Query(default=None),
+    kind: ComponentKind | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    service: ComponentCatalogViewService = Depends(get_component_catalog_view_service),
+):
+    result = await service.get_page(
+        slug,
+        rule_set_id,
+        component_set_id=component_set_id,
+        kind=kind.value if kind else None,
+        limit=limit,
+        offset=offset,
+    )
+    if result is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    return result

--- a/backend/app/services/component_catalog_view.py
+++ b/backend/app/services/component_catalog_view.py
@@ -1,0 +1,443 @@
+import logging
+from collections import defaultdict
+
+import anyio
+
+from app.core import supabase
+from app.models.component_catalog import Ability, Component, ComponentProperty
+from app.models.component_catalog_view import (
+    AbilityEvidenceSummary,
+    ComponentCatalogAvailabilityResponse,
+    ComponentCatalogPageItem,
+    ComponentCatalogPageResponse,
+    FieldEvidenceSummary,
+)
+from app.services.component_catalog import ComponentCatalogService
+
+logger = logging.getLogger("services.component_catalog_view")
+
+
+class ComponentCatalogViewReadError(RuntimeError):
+    """Raised when canonical component catalog data cannot be read safely."""
+
+
+def _raw_property_value(row: dict):
+    value_type = row["value_type"]
+    column = {
+        "text": "text_value",
+        "integer": "integer_value",
+        "number": "number_value",
+        "boolean": "boolean_value",
+        "enum": "enum_value",
+        "concept_ref": "concept_ref_id",
+        "component_ref": "component_ref_id",
+    }.get(value_type)
+    if column is None:
+        return None
+    return row.get(column)
+
+
+def _claim_relations(claim: dict, bindings_by_claim: dict[str, list[dict]]) -> set[str]:
+    return {row.get("relation") for row in bindings_by_claim.get(claim["claim_id"], [])}
+
+
+def summarize_property_evidence(
+    rows: list[dict],
+    claims: list[dict],
+    bindings_by_claim: dict[str, list[dict]],
+) -> FieldEvidenceSummary:
+    """Verify a property only when every current ordinal has accepted supporting evidence."""
+    if not rows:
+        return FieldEvidenceSummary()
+
+    claim_ids: set[str] = set()
+    source_ids: set[str] = set()
+    all_verified = True
+    any_contested = False
+
+    for row in rows:
+        current_value = _raw_property_value(row)
+        ordinal = row["ordinal"]
+        matching = [
+            claim
+            for claim in claims
+            if claim.get("lifecycle_status") == "accepted"
+            and claim.get("ordinal") == ordinal
+            and (claim.get("normalized_payload") or {}).get("value") == current_value
+        ]
+        ordinal_verified = False
+        for claim in matching:
+            relations = _claim_relations(claim, bindings_by_claim)
+            claim_ids.add(claim["claim_id"])
+            if "contradicts" in relations:
+                any_contested = True
+            if "supports" in relations and "contradicts" not in relations:
+                ordinal_verified = True
+                source_ids.update(
+                    str(binding["source_id"])
+                    for binding in bindings_by_claim.get(claim["claim_id"], [])
+                    if binding.get("relation") == "supports"
+                )
+        if not ordinal_verified:
+            all_verified = False
+
+    status = "contested" if any_contested else "verified" if all_verified else "unknown"
+    return FieldEvidenceSummary(
+        status=status,
+        claim_ids=sorted(claim_ids),
+        source_ids=sorted(source_ids),
+    )
+
+
+def summarize_ability_evidence(
+    ability: dict,
+    claims: list[dict],
+    bindings_by_claim: dict[str, list[dict]],
+) -> AbilityEvidenceSummary:
+    def summary_for(target_type: str, expected_text: str | None) -> FieldEvidenceSummary:
+        relevant = [
+            claim
+            for claim in claims
+            if claim.get("target_type") == target_type and claim.get("lifecycle_status") == "accepted"
+        ]
+        if target_type == "ability_printed_text" and expected_text is not None:
+            relevant = [
+                claim for claim in relevant if (claim.get("normalized_payload") or {}).get("text") == expected_text
+            ]
+        claim_ids: set[str] = set()
+        source_ids: set[str] = set()
+        has_support = False
+        has_contradiction = False
+        for claim in relevant:
+            relations = _claim_relations(claim, bindings_by_claim)
+            claim_ids.add(claim["claim_id"])
+            has_support = has_support or "supports" in relations
+            has_contradiction = has_contradiction or "contradicts" in relations
+            source_ids.update(
+                str(binding["source_id"])
+                for binding in bindings_by_claim.get(claim["claim_id"], [])
+                if binding.get("relation") == "supports"
+            )
+        status = "contested" if has_contradiction else "verified" if has_support else "unknown"
+        return FieldEvidenceSummary(status=status, claim_ids=sorted(claim_ids), source_ids=sorted(source_ids))
+
+    return AbilityEvidenceSummary(
+        printed_text=summary_for("ability_printed_text", ability.get("printed_text")),
+        normalized=summary_for("ability_normalized", ability.get("normalized_label")),
+    )
+
+
+class ComponentCatalogViewService:
+    async def get_availability(self, slug: str) -> ComponentCatalogAvailabilityResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        base = {"game_id": str(game["id"]), "slug": str(game["slug"])}
+        if supabase.is_local():
+            return ComponentCatalogAvailabilityResponse(status="not_available", **base)
+        try:
+            return await anyio.to_thread.run_sync(self._load_availability, game, base)
+        except Exception as exc:
+            logger.exception("Component catalog availability read failed for %s", slug)
+            raise ComponentCatalogViewReadError(f"component catalog availability backend failure for {slug}") from exc
+
+    async def get_page(
+        self,
+        slug: str,
+        rule_set_id: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        component_set_id: str | None = None,
+        kind: str | None = None,
+    ) -> ComponentCatalogPageResponse | None:
+        game = await supabase.get_by_slug(slug)
+        if not game:
+            return None
+        base = {"game_id": str(game["id"]), "slug": str(game["slug"]), "rule_set_id": rule_set_id}
+        if supabase.is_local():
+            return ComponentCatalogPageResponse(status="not_available", limit=limit, offset=offset, **base)
+        try:
+            return await anyio.to_thread.run_sync(
+                self._load_page,
+                game,
+                rule_set_id,
+                limit,
+                offset,
+                component_set_id,
+                kind,
+                base,
+            )
+        except Exception as exc:
+            logger.exception("Component catalog page read failed for %s/%s", slug, rule_set_id)
+            raise ComponentCatalogViewReadError(f"component catalog page backend failure for {slug}/{rule_set_id}") from exc
+
+    @staticmethod
+    def _load_availability(game: dict, base: dict) -> ComponentCatalogAvailabilityResponse:
+        client = supabase._get_client()
+        rule_sets = client.table("rule_sets").select("id").eq("game_id", game["id"]).execute().data
+        rule_set_ids = [str(row["id"]) for row in rule_sets]
+        if not rule_set_ids:
+            return ComponentCatalogAvailabilityResponse(status="not_available", **base)
+        catalogs = (
+            client.table("component_catalogs")
+            .select("rule_set_id")
+            .in_("rule_set_id", rule_set_ids)
+            .execute()
+            .data
+        )
+        available = sorted({str(row["rule_set_id"]) for row in catalogs})
+        return ComponentCatalogAvailabilityResponse(
+            status="available" if available else "not_available",
+            rule_set_ids=available,
+            **base,
+        )
+
+    @classmethod
+    def _load_page(
+        cls,
+        game: dict,
+        rule_set_id: str,
+        limit: int,
+        offset: int,
+        component_set_id: str | None,
+        kind: str | None,
+        base: dict,
+    ) -> ComponentCatalogPageResponse:
+        client = supabase._get_client()
+        context = ComponentCatalogService._context(client, game, rule_set_id)
+        if context is None:
+            return ComponentCatalogPageResponse(status="not_available", limit=limit, offset=offset, **base)
+
+        sets = ComponentCatalogService._load_sets(game, rule_set_id, base)
+        definitions = {item.property_key: item for item in sets.property_definitions}
+
+        query = client.table("components").select("*", count="exact").eq("rule_set_id", rule_set_id)
+        if component_set_id:
+            query = query.eq("component_set_id", component_set_id)
+        if kind:
+            query = query.eq("kind", kind)
+        response = query.order("canonical_name").range(offset, offset + limit - 1).execute()
+        component_rows = response.data
+        component_ids = [row["component_id"] for row in component_rows]
+        if not component_ids:
+            return ComponentCatalogPageResponse(
+                status="available",
+                component_sets=sets.component_sets,
+                property_definitions=sets.property_definitions,
+                total=response.count or 0,
+                limit=limit,
+                offset=offset,
+                **base,
+            )
+
+        property_rows = (
+            client.table("component_properties")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .in_("component_id", component_ids)
+            .order("component_id")
+            .order("property_key")
+            .order("ordinal")
+            .execute()
+            .data
+        )
+        ability_rows = (
+            client.table("component_abilities")
+            .select("*")
+            .eq("rule_set_id", rule_set_id)
+            .in_("component_id", component_ids)
+            .order("component_id")
+            .order("ability_id")
+            .execute()
+            .data
+        )
+        concept_rows = (
+            client.table("component_concepts")
+            .select("component_id,concept_id")
+            .eq("rule_set_id", rule_set_id)
+            .in_("component_id", component_ids)
+            .execute()
+            .data
+        )
+        rule_rows = (
+            client.table("component_rule_nodes")
+            .select("component_id,rule_id")
+            .eq("rule_set_id", rule_set_id)
+            .in_("component_id", component_ids)
+            .execute()
+            .data
+        )
+
+        ability_ids = [row["ability_id"] for row in ability_rows]
+        ability_concept_rows = []
+        ability_rule_rows = []
+        ability_claim_rows = []
+        if ability_ids:
+            ability_concept_rows = (
+                client.table("component_ability_concepts")
+                .select("ability_id,concept_id")
+                .eq("rule_set_id", rule_set_id)
+                .in_("ability_id", ability_ids)
+                .execute()
+                .data
+            )
+            ability_rule_rows = (
+                client.table("component_ability_rule_nodes")
+                .select("ability_id,rule_id")
+                .eq("rule_set_id", rule_set_id)
+                .in_("ability_id", ability_ids)
+                .execute()
+                .data
+            )
+            ability_claim_rows = (
+                client.table("claims")
+                .select("claim_id,ability_id,target_type,normalized_payload,lifecycle_status")
+                .eq("rule_set_id", rule_set_id)
+                .in_("ability_id", ability_ids)
+                .execute()
+                .data
+            )
+
+        property_claim_rows = (
+            client.table("claims")
+            .select("claim_id,component_id,property_key,ordinal,target_type,normalized_payload,lifecycle_status")
+            .eq("rule_set_id", rule_set_id)
+            .eq("target_type", "component_property")
+            .in_("component_id", component_ids)
+            .execute()
+            .data
+        )
+        all_claim_rows = property_claim_rows + ability_claim_rows
+        claim_ids = [row["claim_id"] for row in all_claim_rows]
+        binding_rows = []
+        if claim_ids:
+            binding_rows = (
+                client.table("evidence_bindings")
+                .select("claim_id,source_id,relation")
+                .in_("claim_id", claim_ids)
+                .execute()
+                .data
+            )
+
+        properties_by_component: dict[str, list[dict]] = defaultdict(list)
+        property_rows_by_identity: dict[tuple[str, str], list[dict]] = defaultdict(list)
+        for row in property_rows:
+            properties_by_component[row["component_id"]].append(row)
+            property_rows_by_identity[(row["component_id"], row["property_key"])].append(row)
+
+        abilities_by_component: dict[str, list[dict]] = defaultdict(list)
+        for row in ability_rows:
+            abilities_by_component[row["component_id"]].append(row)
+
+        concepts_by_component: dict[str, set[str]] = defaultdict(set)
+        for row in concept_rows:
+            concepts_by_component[row["component_id"]].add(row["concept_id"])
+        rules_by_component: dict[str, set[str]] = defaultdict(set)
+        for row in rule_rows:
+            rules_by_component[row["component_id"]].add(row["rule_id"])
+
+        concepts_by_ability: dict[str, set[str]] = defaultdict(set)
+        for row in ability_concept_rows:
+            concepts_by_ability[row["ability_id"]].add(row["concept_id"])
+        rules_by_ability: dict[str, set[str]] = defaultdict(set)
+        for row in ability_rule_rows:
+            rules_by_ability[row["ability_id"]].add(row["rule_id"])
+
+        property_claims_by_identity: dict[tuple[str, str], list[dict]] = defaultdict(list)
+        for row in property_claim_rows:
+            property_claims_by_identity[(row["component_id"], row["property_key"])].append(row)
+        ability_claims_by_id: dict[str, list[dict]] = defaultdict(list)
+        for row in ability_claim_rows:
+            ability_claims_by_id[row["ability_id"]].append(row)
+        bindings_by_claim: dict[str, list[dict]] = defaultdict(list)
+        for row in binding_rows:
+            bindings_by_claim[row["claim_id"]].append(row)
+
+        items: list[ComponentCatalogPageItem] = []
+        for component_row in component_rows:
+            component_id = component_row["component_id"]
+            grouped_properties: dict[str, list[dict]] = defaultdict(list)
+            for row in properties_by_component[component_id]:
+                grouped_properties[row["property_key"]].append(row)
+
+            component_properties: list[ComponentProperty] = []
+            property_evidence: dict[str, FieldEvidenceSummary] = {}
+            for property_key, rows in grouped_properties.items():
+                definition = definitions.get(property_key)
+                if definition is None:
+                    raise ValueError(f"missing property definition for {property_key}")
+                typed_values = [ComponentCatalogService._property_value(row) for row in rows]
+                if definition.cardinality.value == "one" and len(typed_values) != 1:
+                    raise ValueError(f"invalid cardinality for {property_key}")
+                if any(value.value_type != definition.value_type.value for value in typed_values):
+                    raise ValueError(f"invalid property type for {property_key}")
+                statuses = {row.get("verification_status", "unknown") for row in rows}
+                source_ids = sorted({source for row in rows for source in (row.get("source_ids") or [])})
+                component_properties.append(
+                    ComponentProperty(
+                        property_key=property_key,
+                        values=typed_values,
+                        verification_status=statuses.pop() if len(statuses) == 1 else "unknown",
+                        source_ids=source_ids,
+                    )
+                )
+                property_evidence[property_key] = summarize_property_evidence(
+                    property_rows_by_identity[(component_id, property_key)],
+                    property_claims_by_identity[(component_id, property_key)],
+                    bindings_by_claim,
+                )
+
+            component_abilities: list[Ability] = []
+            ability_evidence: dict[str, AbilityEvidenceSummary] = {}
+            for row in abilities_by_component[component_id]:
+                ability_id = row["ability_id"]
+                component_abilities.append(
+                    Ability(
+                        ability_id=ability_id,
+                        printed_text=row.get("printed_text"),
+                        normalized_label=row.get("normalized_label"),
+                        concept_ids=sorted(concepts_by_ability[ability_id]),
+                        rule_ids=sorted(rules_by_ability[ability_id]),
+                        verification_status=row.get("verification_status", "unknown"),
+                        source_ids=row.get("source_ids") or [],
+                    )
+                )
+                ability_evidence[ability_id] = summarize_ability_evidence(
+                    row,
+                    ability_claims_by_id[ability_id],
+                    bindings_by_claim,
+                )
+
+            component = Component(
+                component_id=component_id,
+                ruleset_id=rule_set_id,
+                component_set_id=component_row.get("component_set_id"),
+                canonical_name=component_row["canonical_name"],
+                kind=component_row["kind"],
+                quantity=component_row.get("quantity"),
+                properties=component_properties,
+                abilities=component_abilities,
+                concept_ids=sorted(concepts_by_component[component_id]),
+                rule_ids=sorted(rules_by_component[component_id]),
+                verification_status=component_row.get("verification_status", "unknown"),
+                source_ids=component_row.get("source_ids") or [],
+            )
+            items.append(
+                ComponentCatalogPageItem(
+                    component=component,
+                    property_evidence=property_evidence,
+                    ability_evidence=ability_evidence,
+                )
+            )
+
+        return ComponentCatalogPageResponse(
+            status="available",
+            component_sets=sets.component_sets,
+            property_definitions=sets.property_definitions,
+            items=items,
+            total=response.count if response.count is not None else len(items),
+            limit=limit,
+            offset=offset,
+            **base,
+        )

--- a/backend/tests/test_component_catalog_view.py
+++ b/backend/tests/test_component_catalog_view.py
@@ -1,0 +1,190 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.models.component_catalog import (
+    Component,
+    ComponentProperty,
+    ComponentSet,
+    EnumPropertyValue,
+    IntegerPropertyValue,
+    PropertyDefinition,
+)
+from app.models.component_catalog_view import (
+    ComponentCatalogAvailabilityResponse,
+    ComponentCatalogPageItem,
+    ComponentCatalogPageResponse,
+)
+from app.routers import component_catalog_view
+from app.services.component_catalog_view import summarize_property_evidence
+
+
+def test_property_evidence_requires_all_current_ordinals_and_preserves_conflict():
+    rows = [
+        {"ordinal": 0, "value_type": "enum", "enum_value": "sun"},
+        {"ordinal": 1, "value_type": "enum", "enum_value": "moon"},
+    ]
+    claims = [
+        {
+            "claim_id": "claim.0",
+            "ordinal": 0,
+            "lifecycle_status": "accepted",
+            "normalized_payload": {"value": "sun"},
+        },
+        {
+            "claim_id": "claim.1",
+            "ordinal": 1,
+            "lifecycle_status": "accepted",
+            "normalized_payload": {"value": "moon"},
+        },
+    ]
+    bindings = {
+        "claim.0": [{"source_id": "source.rules", "relation": "supports"}],
+        "claim.1": [{"source_id": "source.rules", "relation": "supports"}],
+    }
+    verified = summarize_property_evidence(rows, claims, bindings)
+    assert verified.status == "verified"
+    assert verified.source_ids == ["source.rules"]
+
+    bindings["claim.1"].append({"source_id": "source.errata", "relation": "contradicts"})
+    contested = summarize_property_evidence(rows, claims, bindings)
+    assert contested.status == "contested"
+
+
+def test_property_evidence_rejects_stale_candidate_and_partial_support():
+    rows = [{"ordinal": 0, "value_type": "integer", "integer_value": 3}]
+    claims = [
+        {
+            "claim_id": "claim.stale",
+            "ordinal": 0,
+            "lifecycle_status": "accepted",
+            "normalized_payload": {"value": 2},
+        },
+        {
+            "claim_id": "claim.candidate",
+            "ordinal": 0,
+            "lifecycle_status": "candidate",
+            "normalized_payload": {"value": 3},
+        },
+    ]
+    bindings = {
+        "claim.stale": [{"source_id": "source.old", "relation": "supports"}],
+        "claim.candidate": [{"source_id": "source.current", "relation": "supports"}],
+    }
+    summary = summarize_property_evidence(rows, claims, bindings)
+    assert summary.status == "unknown"
+    assert summary.source_ids == []
+
+
+class FakeComponentCatalogViewService:
+    async def get_availability(self, slug):
+        if slug == "missing":
+            return None
+        if slug == "without-catalog":
+            return ComponentCatalogAvailabilityResponse(
+                status="not_available",
+                game_id="game-1",
+                slug=slug,
+            )
+        return ComponentCatalogAvailabilityResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            rule_set_ids=["ruleset-1"],
+        )
+
+    async def get_page(self, slug, rule_set_id, **kwargs):
+        if slug == "missing":
+            return None
+        component = Component(
+            component_id="card.scout",
+            ruleset_id=rule_set_id,
+            component_set_id="cards",
+            canonical_name="Scout",
+            kind="card",
+            properties=[
+                ComponentProperty(
+                    property_key="faction",
+                    values=[EnumPropertyValue(value="sun")],
+                ),
+                ComponentProperty(
+                    property_key="combat_value",
+                    values=[IntegerPropertyValue(value=3)],
+                ),
+            ],
+        )
+        return ComponentCatalogPageResponse(
+            status="available",
+            game_id="game-1",
+            slug=slug,
+            rule_set_id=rule_set_id,
+            component_sets=[
+                ComponentSet(
+                    component_set_id="cards",
+                    ruleset_id=rule_set_id,
+                    canonical_name="Cards",
+                    kind="card",
+                )
+            ],
+            property_definitions=[
+                PropertyDefinition(
+                    property_key="faction",
+                    labels={"ja": "派閥"},
+                    value_type="enum",
+                    enum_values=["sun", "moon"],
+                    filterable=True,
+                ),
+                PropertyDefinition(
+                    property_key="combat_value",
+                    labels={"ja": "戦力"},
+                    value_type="integer",
+                    sortable=True,
+                ),
+            ],
+            items=[ComponentCatalogPageItem(component=component)],
+            total=1,
+            limit=kwargs.get("limit", 50),
+            offset=kwargs.get("offset", 0),
+        )
+
+
+def _app():
+    app = FastAPI()
+    app.include_router(component_catalog_view.router, prefix="/api")
+    app.dependency_overrides[component_catalog_view.get_component_catalog_view_service] = (
+        lambda: FakeComponentCatalogViewService()
+    )
+    return app
+
+
+def test_availability_is_lightweight_and_missing_catalog_is_explicit():
+    client = TestClient(_app())
+    available = client.get("/api/games/example/component-catalog-availability")
+    unavailable = client.get("/api/games/without-catalog/component-catalog-availability")
+
+    assert available.status_code == 200
+    assert available.json()["rule_set_ids"] == ["ruleset-1"]
+    assert unavailable.status_code == 200
+    assert unavailable.json()["status"] == "not_available"
+    assert unavailable.json()["rule_set_ids"] == []
+
+
+def test_catalog_page_returns_full_generic_component_data_and_requires_ruleset():
+    client = TestClient(_app())
+    response = client.get(
+        "/api/games/example/component-catalog",
+        params={"rule_set_id": "ruleset-1", "limit": 50, "offset": 0},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["component_sets"][0]["kind"] == "card"
+    assert payload["property_definitions"][0]["property_key"] == "faction"
+    assert payload["items"][0]["component"]["properties"][1]["values"][0]["value"] == 3
+
+    missing_identity = client.get("/api/games/example/component-catalog")
+    assert missing_identity.status_code == 422
+
+
+def test_component_catalog_view_keeps_missing_game_distinct():
+    client = TestClient(_app())
+    response = client.get("/api/games/missing/component-catalog-availability")
+    assert response.status_code == 404

--- a/docs/COMPONENTS_UI_V1.md
+++ b/docs/COMPONENTS_UI_V1.md
@@ -1,0 +1,124 @@
+# Components UI v1
+
+## Purpose
+
+#173 Component CatalogをGamePageへ表示する汎用UI契約です。ゲームごとのカード列・タイル列・専用JSXは作らず、`ComponentSet / PropertyDefinition / Component`を入力として同じrendererを利用します。
+
+```text
+Game
+  └─ RuleSet
+       └─ Component Catalog
+            ├─ ComponentSet
+            ├─ PropertyDefinition
+            └─ Component + Claim/Evidence
+                    ↓
+             Components UI
+```
+
+## Availability contract
+
+GamePageは最初に次の軽量APIだけを確認します。
+
+```http
+GET /api/games/{slug}/component-catalog-availability
+```
+
+- catalogが1つ以上存在する場合だけCOMPONENTSタブを表示する。
+- catalogが無い場合はタブを表示せず、full component APIを呼ばない。
+- 複数RuleSetにcatalogがある場合、RuleSetを暗黙選択しない。ComponentsPanelで明示選択する。
+
+COMPONENTSタブを開いた時だけ次を取得します。
+
+```http
+GET /api/games/{slug}/component-catalog?rule_set_id=...&limit=100&offset=...
+```
+
+## Catalog page
+
+1ページで以下を返します。
+
+- ComponentSet
+- PropertyDefinition
+- full Component
+- ComponentProperty
+- Ability
+- Concept / RuleNode references
+- property / ability field-level evidence summary
+- total / limit / offset
+
+detailごとのN+1 requestを避けるため、backendはpage内のproperty / ability / bridge / evidenceをbulk loadします。
+
+frontendは100件単位で全pageを取得し、filter/sortをcatalog全体に適用します。125件fixtureで2 page取得を固定しています。
+
+## Generic rendering
+
+`PropertyDefinition.value_type`により表示・filterを生成します。
+
+| Type | Display | Filter |
+|---|---|---|
+| text | text | substring search |
+| integer | number + unit | min/max |
+| number | number + unit | min/max |
+| boolean | YES / NO | tri-state select |
+| enum | enum value | enum select |
+| concept_ref | stable concept ID | text/ref display |
+| component_ref | stable component ID | text/ref display |
+
+未知の将来型はクラッシュさせず、表示・filter対象からfail-closedで除外します。
+
+Sortはcanonical nameに加え、`PropertyDefinition.sortable=true`のfieldだけを候補にします。
+
+## Evidence semantics
+
+Component entity-levelの`source_ids`だけではverified badgeを出しません。
+
+propertyは#175 Claim/Evidenceをcurrent ordinal/valueと照合し、次で表示します。
+
+- `VERIFIED`: current valueの全ordinalがaccepted + supports + no contradiction
+- `CONTESTED`: current valueにaccepted contradictionがある
+- `UNVERIFIED`: 上記以外
+
+古いvalueを支持するClaim、candidate/unknown/rejected Claimはcurrent fieldをverifiedへ昇格させません。
+
+Abilityはprinted textとnormalized interpretationを別Evidence stateとして保持します。
+
+詳細画面からClaim trace、Concept API、Rule evidence traceへ辿れます。
+
+## UX
+
+- card / tile / token / die等を同じcard rendererで表示
+- ComponentSet group filter
+- global search
+- schema-driven property filters
+- schema-driven sort
+- quantity表示
+- imageは任意。画像無しでも完全に利用可能
+- native button/select/inputを使いkeyboard操作可能
+- detailは`role=dialog`の非modal region
+- 375 / 768 / 1440pxでhorizontal page overflow禁止
+- 100+ componentsをpagination取得して全体filter可能
+
+## Tests
+
+- card / tile / token / die generic renderer helper
+- enum / integer / boolean / text filter
+- sortable property
+- unknown property type fail-closed
+- 100+ page offsets
+- missing catalog -> no tab / no full catalog request
+- 125 components -> 2 page load
+- keyboard open detail
+- field evidence trace link
+- no-image detail
+- 375 / 768 / 1440 responsive geometry
+- CI screenshot artifacts for each responsive project
+
+## Related
+
+- #148 Ontology v2
+- #151 Presentation Projection
+- #173 Component Catalog
+- #174 RuleSet identity
+- #175 Claim/Evidence Binding
+- #176 Components UI
+- #177 YRO pilot

--- a/frontend/src/components/game/ComponentsPanel.jsx
+++ b/frontend/src/components/game/ComponentsPanel.jsx
@@ -1,0 +1,452 @@
+import { useEffect, useMemo, useState } from 'react'
+import { api } from '../../lib/api'
+import {
+  PAGE_SIZE,
+  evidenceLabel,
+  filterAndSortComponentItems,
+  getPropertyLabel,
+  isSupportedDefinition,
+  pageOffsets,
+  propertyDisplayText,
+} from '../../lib/componentCatalog'
+import './components-panel.css'
+
+function rulesetLabel(ruleset) {
+  if (!ruleset) return ''
+  return [
+    ruleset.edition_label,
+    ruleset.platform,
+    ruleset.language_code,
+    ruleset.revision_label,
+  ].filter(Boolean).join(' · ') || ruleset.ruleset_id
+}
+
+function EvidenceBadge({ summary }) {
+  const label = evidenceLabel(summary)
+  return <span className={`component-evidence component-evidence--${summary?.status || 'unknown'}`}>{label}</span>
+}
+
+function PropertyFilter({ definition, value, onChange, languageCode }) {
+  const label = getPropertyLabel(definition, languageCode)
+  if (!definition.filterable || !isSupportedDefinition(definition)) return null
+
+  if (definition.value_type === 'enum') {
+    return (
+      <label className="component-filter">
+        <span>{label}</span>
+        <select value={value || ''} onChange={(event) => onChange(event.target.value)}>
+          <option value="">すべて</option>
+          {definition.enum_values?.map((option) => <option key={option} value={option}>{option}</option>)}
+        </select>
+      </label>
+    )
+  }
+
+  if (definition.value_type === 'boolean') {
+    return (
+      <label className="component-filter">
+        <span>{label}</span>
+        <select value={value || ''} onChange={(event) => onChange(event.target.value)}>
+          <option value="">すべて</option>
+          <option value="true">YES</option>
+          <option value="false">NO</option>
+        </select>
+      </label>
+    )
+  }
+
+  if (definition.value_type === 'integer' || definition.value_type === 'number') {
+    const numeric = value || { min: '', max: '' }
+    return (
+      <fieldset className="component-filter component-filter--range">
+        <legend>{label}</legend>
+        <label>
+          <span className="sr-only">{label} 最小値</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            placeholder="MIN"
+            value={numeric.min ?? ''}
+            onChange={(event) => onChange({ ...numeric, min: event.target.value })}
+          />
+        </label>
+        <span aria-hidden="true">–</span>
+        <label>
+          <span className="sr-only">{label} 最大値</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            placeholder="MAX"
+            value={numeric.max ?? ''}
+            onChange={(event) => onChange({ ...numeric, max: event.target.value })}
+          />
+        </label>
+      </fieldset>
+    )
+  }
+
+  return (
+    <label className="component-filter">
+      <span>{label}</span>
+      <input
+        type="search"
+        value={value || ''}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={`${label}で絞る`}
+      />
+    </label>
+  )
+}
+
+function PropertyRows({ item, definitions, languageCode, slug, ruleSetId }) {
+  const definitionByKey = Object.fromEntries(definitions.map((definition) => [definition.property_key, definition]))
+  return item.component.properties.map((property) => {
+    const definition = definitionByKey[property.property_key]
+    if (!isSupportedDefinition(definition)) return null
+    const text = propertyDisplayText(item.component, definition)
+    if (text == null) return null
+    const evidence = item.property_evidence?.[property.property_key]
+    const claimId = evidence?.claim_ids?.[0]
+    const evidenceHref = claimId
+      ? `/api/games/${encodeURIComponent(slug)}/claims/${encodeURIComponent(claimId)}?rule_set_id=${encodeURIComponent(ruleSetId)}`
+      : null
+    return (
+      <div className="component-detail-property" key={property.property_key}>
+        <dt>{getPropertyLabel(definition, languageCode)}</dt>
+        <dd>
+          <span>{text}</span>
+          <EvidenceBadge summary={evidence} />
+          {evidenceHref && (
+            <a href={evidenceHref} target="_blank" rel="noreferrer" className="component-trace-link">
+              EVIDENCE
+            </a>
+          )}
+        </dd>
+      </div>
+    )
+  })
+}
+
+function ComponentDetail({ item, definitions, componentSets, languageCode, slug, ruleSetId, onClose }) {
+  const component = item.component
+  const setName = componentSets.find((set) => set.component_set_id === component.component_set_id)?.canonical_name
+
+  return (
+    <section className="component-detail" role="dialog" aria-modal="false" aria-labelledby="component-detail-title">
+      <div className="component-detail-header">
+        <div>
+          <div className="component-kicker">{component.kind.toUpperCase()} · {setName || 'UNGROUPED'}</div>
+          <h3 id="component-detail-title">{component.canonical_name}</h3>
+          <code>{component.component_id}</code>
+        </div>
+        <button type="button" className="component-detail-close" onClick={onClose} aria-label="コンポーネント詳細を閉じる">×</button>
+      </div>
+
+      <dl className="component-detail-properties">
+        <PropertyRows
+          item={item}
+          definitions={definitions}
+          languageCode={languageCode}
+          slug={slug}
+          ruleSetId={ruleSetId}
+        />
+      </dl>
+
+      {component.abilities?.length > 0 && (
+        <div className="component-detail-section">
+          <h4>ABILITIES</h4>
+          {component.abilities.map((ability) => {
+            const evidence = item.ability_evidence?.[ability.ability_id]
+            const printedClaimId = evidence?.printed_text?.claim_ids?.[0]
+            const normalizedClaimId = evidence?.normalized?.claim_ids?.[0]
+            return (
+              <article className="component-ability" key={ability.ability_id}>
+                <div className="component-ability-title">
+                  <strong>{ability.normalized_label || ability.ability_id}</strong>
+                  <EvidenceBadge summary={evidence?.normalized} />
+                </div>
+                {ability.printed_text && (
+                  <p>
+                    {ability.printed_text} <EvidenceBadge summary={evidence?.printed_text} />
+                  </p>
+                )}
+                <div className="component-detail-links">
+                  {[printedClaimId, normalizedClaimId].filter(Boolean).map((claimId) => (
+                    <a
+                      key={claimId}
+                      href={`/api/games/${encodeURIComponent(slug)}/claims/${encodeURIComponent(claimId)}?rule_set_id=${encodeURIComponent(ruleSetId)}`}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      EVIDENCE {claimId}
+                    </a>
+                  ))}
+                </div>
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      {component.concept_ids?.length > 0 && (
+        <div className="component-detail-section">
+          <h4>CONCEPTS</h4>
+          <div className="component-detail-links">
+            {component.concept_ids.map((conceptId) => (
+              <a key={conceptId} href={`/api/concepts/${encodeURIComponent(conceptId)}`} target="_blank" rel="noreferrer">
+                {conceptId}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {component.rule_ids?.length > 0 && (
+        <div className="component-detail-section">
+          <h4>RULE REFERENCES</h4>
+          <div className="component-detail-links">
+            {component.rule_ids.map((ruleId) => (
+              <a
+                key={ruleId}
+                href={`/api/games/${encodeURIComponent(slug)}/evidence?rule_set_id=${encodeURIComponent(ruleSetId)}&target_type=rule_node&rule_id=${encodeURIComponent(ruleId)}`}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {ruleId}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function ComponentsPanel({ slug, ruleSetIds, languageCode = 'ja' }) {
+  const [selectedRuleSetId, setSelectedRuleSetId] = useState(ruleSetIds[0] || '')
+  const [rulesets, setRulesets] = useState([])
+  const [componentSets, setComponentSets] = useState([])
+  const [definitions, setDefinitions] = useState([])
+  const [items, setItems] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [search, setSearch] = useState('')
+  const [componentSetId, setComponentSetId] = useState('')
+  const [filters, setFilters] = useState({})
+  const [sortKey, setSortKey] = useState('canonical_name')
+  const [sortDirection, setSortDirection] = useState('asc')
+  const [selectedComponentId, setSelectedComponentId] = useState(null)
+
+  useEffect(() => {
+    setSelectedRuleSetId((current) => ruleSetIds.includes(current) ? current : (ruleSetIds[0] || ''))
+  }, [ruleSetIds])
+
+  useEffect(() => {
+    let cancelled = false
+    if (ruleSetIds.length <= 1) {
+      setRulesets([])
+      return () => { cancelled = true }
+    }
+    api.get(`/api/games/${encodeURIComponent(slug)}/rule-sets`)
+      .then((payload) => {
+        if (!cancelled) setRulesets((payload.rulesets || []).filter((ruleset) => ruleSetIds.includes(ruleset.ruleset_id)))
+      })
+      .catch((err) => {
+        if (!cancelled) console.error('Failed to load component RuleSets:', err)
+      })
+    return () => { cancelled = true }
+  }, [slug, ruleSetIds])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!selectedRuleSetId) {
+      setLoading(false)
+      return () => { cancelled = true }
+    }
+
+    const loadCatalog = async () => {
+      setLoading(true)
+      setError(null)
+      setSelectedComponentId(null)
+      try {
+        const base = `/api/games/${encodeURIComponent(slug)}/component-catalog?rule_set_id=${encodeURIComponent(selectedRuleSetId)}&limit=${PAGE_SIZE}`
+        const first = await api.get(`${base}&offset=0`)
+        if (cancelled) return
+        if (first.status !== 'available') {
+          setItems([])
+          setComponentSets([])
+          setDefinitions([])
+          return
+        }
+        const offsets = pageOffsets(first.total, PAGE_SIZE)
+        const rest = await Promise.all(offsets.map((offset) => api.get(`${base}&offset=${offset}`)))
+        if (cancelled) return
+        setComponentSets(first.component_sets || [])
+        setDefinitions(first.property_definitions || [])
+        setItems([...(first.items || []), ...rest.flatMap((page) => page.items || [])])
+        setComponentSetId('')
+        setFilters({})
+        setSortKey('canonical_name')
+        setSortDirection('asc')
+      } catch (err) {
+        if (!cancelled) {
+          console.error(err)
+          setError('コンポーネント情報の取得に失敗しました')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    loadCatalog()
+    return () => { cancelled = true }
+  }, [slug, selectedRuleSetId])
+
+  const filterableDefinitions = useMemo(
+    () => definitions.filter((definition) => definition.filterable && isSupportedDefinition(definition)),
+    [definitions],
+  )
+  const sortableDefinitions = useMemo(
+    () => definitions.filter((definition) => definition.sortable && isSupportedDefinition(definition)),
+    [definitions],
+  )
+  const visibleItems = useMemo(
+    () => filterAndSortComponentItems(items, definitions, {
+      search,
+      componentSetId,
+      filters,
+      sortKey,
+      sortDirection,
+    }),
+    [items, definitions, search, componentSetId, filters, sortKey, sortDirection],
+  )
+  const selectedItem = items.find((item) => item.component.component_id === selectedComponentId) || null
+
+  if (loading) return <div className="component-panel-state" role="status">COMPONENT CATALOG LOADING...</div>
+  if (error) return <div className="component-panel-state component-panel-state--error" role="alert">{error}</div>
+
+  return (
+    <section className="components-panel" aria-labelledby="components-panel-title">
+      <div className="components-panel-heading">
+        <div>
+          <div className="component-kicker">CANONICAL COMPONENT CATALOG</div>
+          <h2 id="components-panel-title">COMPONENTS</h2>
+          <p>カード・タイル・トークン等を同じschemaから表示します。検証状態はfield-level evidenceに基づきます。</p>
+        </div>
+        <div className="component-count" aria-live="polite">{visibleItems.length} / {items.length}</div>
+      </div>
+
+      {ruleSetIds.length > 1 && (
+        <label className="component-ruleset-select">
+          <span>RULESET</span>
+          <select value={selectedRuleSetId} onChange={(event) => setSelectedRuleSetId(event.target.value)}>
+            {ruleSetIds.map((id) => {
+              const ruleset = rulesets.find((entry) => entry.ruleset_id === id)
+              return <option value={id} key={id}>{rulesetLabel(ruleset) || id}</option>
+            })}
+          </select>
+        </label>
+      )}
+
+      <div className="component-controls" aria-label="コンポーネントの検索と絞り込み">
+        <label className="component-filter component-filter--search">
+          <span>SEARCH</span>
+          <input type="search" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="名前・ID・属性を検索" />
+        </label>
+
+        {componentSets.length > 1 && (
+          <label className="component-filter">
+            <span>GROUP</span>
+            <select value={componentSetId} onChange={(event) => setComponentSetId(event.target.value)}>
+              <option value="">すべて</option>
+              {componentSets.map((set) => <option key={set.component_set_id} value={set.component_set_id}>{set.canonical_name}</option>)}
+            </select>
+          </label>
+        )}
+
+        {filterableDefinitions.map((definition) => (
+          <PropertyFilter
+            key={definition.property_key}
+            definition={definition}
+            value={filters[definition.property_key]}
+            languageCode={languageCode}
+            onChange={(value) => setFilters((current) => ({ ...current, [definition.property_key]: value }))}
+          />
+        ))}
+
+        <label className="component-filter">
+          <span>SORT</span>
+          <select value={sortKey} onChange={(event) => setSortKey(event.target.value)}>
+            <option value="canonical_name">NAME</option>
+            {sortableDefinitions.map((definition) => (
+              <option value={definition.property_key} key={definition.property_key}>{getPropertyLabel(definition, languageCode)}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="component-filter">
+          <span>DIRECTION</span>
+          <select value={sortDirection} onChange={(event) => setSortDirection(event.target.value)}>
+            <option value="asc">ASC</option>
+            <option value="desc">DESC</option>
+          </select>
+        </label>
+      </div>
+
+      {visibleItems.length === 0 ? (
+        <div className="component-panel-state" role="status">条件に一致するコンポーネントはありません。</div>
+      ) : (
+        <div className="component-grid" role="list" aria-label="コンポーネント一覧">
+          {visibleItems.map((item) => {
+            const component = item.component
+            const setName = componentSets.find((set) => set.component_set_id === component.component_set_id)?.canonical_name
+            const previewDefinitions = definitions.filter((definition) => propertyDisplayText(component, definition) != null).slice(0, 3)
+            return (
+              <article className="component-card" role="listitem" key={component.component_id}>
+                <button
+                  type="button"
+                  className="component-card-button"
+                  onClick={() => setSelectedComponentId(component.component_id)}
+                  aria-expanded={selectedComponentId === component.component_id}
+                  aria-controls="component-detail-panel"
+                >
+                  <div className="component-card-meta">
+                    <span>{component.kind.toUpperCase()}</span>
+                    <span>{setName || 'UNGROUPED'}</span>
+                  </div>
+                  <h3>{component.canonical_name}</h3>
+                  <code>{component.component_id}</code>
+                  {component.quantity != null && <div className="component-quantity">QTY {component.quantity}</div>}
+                  <dl className="component-card-properties">
+                    {previewDefinitions.map((definition) => (
+                      <div key={definition.property_key}>
+                        <dt>{getPropertyLabel(definition, languageCode)}</dt>
+                        <dd>
+                          {propertyDisplayText(component, definition)}
+                          <EvidenceBadge summary={item.property_evidence?.[definition.property_key]} />
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </button>
+              </article>
+            )
+          })}
+        </div>
+      )}
+
+      <div id="component-detail-panel">
+        {selectedItem && (
+          <ComponentDetail
+            item={selectedItem}
+            definitions={definitions}
+            componentSets={componentSets}
+            languageCode={languageCode}
+            slug={slug}
+            ruleSetId={selectedRuleSetId}
+            onClose={() => setSelectedComponentId(null)}
+          />
+        )}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/components/game/components-panel.css
+++ b/frontend/src/components/game/components-panel.css
@@ -1,0 +1,319 @@
+.components-panel {
+  display: grid;
+  gap: 1.25rem;
+  min-width: 0;
+}
+
+.components-panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.components-panel-heading h2 {
+  margin: 0.15rem 0 0.4rem;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+}
+
+.components-panel-heading p {
+  margin: 0;
+  max-width: 46rem;
+  color: var(--text-muted);
+  line-height: 1.65;
+}
+
+.component-kicker,
+.component-filter > span,
+.component-ruleset-select > span,
+.component-filter legend {
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+.component-count {
+  flex: 0 0 auto;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 999px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.component-ruleset-select,
+.component-filter {
+  display: grid;
+  gap: 0.35rem;
+  min-width: 0;
+}
+
+.component-ruleset-select select,
+.component-filter input,
+.component-filter select {
+  width: 100%;
+  min-height: 2.6rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 0.55rem;
+  background: var(--surface, rgba(255, 255, 255, 0.04));
+  color: inherit;
+  padding: 0.55rem 0.7rem;
+  font: inherit;
+}
+
+.component-ruleset-select select:focus-visible,
+.component-filter input:focus-visible,
+.component-filter select:focus-visible,
+.component-card-button:focus-visible,
+.component-detail-close:focus-visible,
+.component-detail a:focus-visible {
+  outline: 3px solid var(--accent, currentColor);
+  outline-offset: 2px;
+}
+
+.component-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 11rem), 1fr));
+  gap: 0.8rem;
+  padding: 1rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.25));
+  border-radius: 0.8rem;
+}
+
+.component-filter--search {
+  grid-column: span 2;
+}
+
+.component-filter--range {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: end;
+}
+
+.component-filter--range legend {
+  grid-column: 1 / -1;
+  padding: 0;
+  margin-bottom: 0.35rem;
+}
+
+.component-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 15rem), 1fr));
+  gap: 0.9rem;
+  min-width: 0;
+}
+
+.component-card {
+  min-width: 0;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.28));
+  border-radius: 0.8rem;
+  overflow: clip;
+  background: var(--surface, rgba(255, 255, 255, 0.025));
+}
+
+.component-card-button {
+  display: grid;
+  align-content: start;
+  gap: 0.65rem;
+  width: 100%;
+  min-height: 100%;
+  padding: 1rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.component-card-button:hover {
+  background: rgba(127, 127, 127, 0.08);
+}
+
+.component-card h3,
+.component-detail h3,
+.component-detail h4 {
+  margin: 0;
+}
+
+.component-card code,
+.component-detail code {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.component-card-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.75rem;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.component-quantity {
+  justify-self: start;
+  border-radius: 999px;
+  background: rgba(127, 127, 127, 0.1);
+  padding: 0.25rem 0.45rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.component-card-properties,
+.component-detail-properties {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+}
+
+.component-card-properties > div,
+.component-detail-property {
+  display: grid;
+  grid-template-columns: minmax(5rem, 0.8fr) minmax(0, 1.2fr);
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.component-card-properties dt,
+.component-detail-property dt {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+}
+
+.component-card-properties dd,
+.component-detail-property dd {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+  min-width: 0;
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.component-evidence {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.15rem 0.4rem;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  border: 1px solid currentColor;
+}
+
+.component-evidence--verified {
+  color: var(--success, #2d8a55);
+}
+
+.component-evidence--contested {
+  color: var(--warning, #a76800);
+}
+
+.component-evidence--unknown {
+  color: var(--text-muted);
+}
+
+.component-detail {
+  display: grid;
+  gap: 1.1rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+  border-radius: 0.9rem;
+  padding: clamp(1rem, 3vw, 1.5rem);
+  background: var(--surface, rgba(255, 255, 255, 0.035));
+  scroll-margin-top: 1rem;
+}
+
+.component-detail-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.component-detail-header > div {
+  min-width: 0;
+}
+
+.component-detail-close {
+  flex: 0 0 auto;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: 1px solid var(--border-color, rgba(128, 128, 128, 0.3));
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  font-size: 1.35rem;
+  cursor: pointer;
+}
+
+.component-detail-section {
+  display: grid;
+  gap: 0.75rem;
+  padding-top: 0.8rem;
+  border-top: 1px solid var(--border-color, rgba(128, 128, 128, 0.2));
+}
+
+.component-ability {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.8rem;
+  border-radius: 0.65rem;
+  background: rgba(127, 127, 127, 0.07);
+}
+
+.component-ability p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.component-ability-title,
+.component-detail-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+}
+
+.component-detail-links a,
+.component-trace-link {
+  overflow-wrap: anywhere;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.component-panel-state {
+  border: 1px dashed var(--border-color, rgba(128, 128, 128, 0.35));
+  border-radius: 0.75rem;
+  padding: 1.2rem;
+  color: var(--text-muted);
+}
+
+.component-panel-state--error {
+  color: var(--danger, #a33);
+}
+
+@media (max-width: 600px) {
+  .components-panel-heading {
+    display: grid;
+  }
+
+  .component-count {
+    justify-self: start;
+  }
+
+  .component-filter--search {
+    grid-column: auto;
+  }
+
+  .component-card-properties > div,
+  .component-detail-property {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+}

--- a/frontend/src/lib/componentCatalog.js
+++ b/frontend/src/lib/componentCatalog.js
@@ -1,0 +1,144 @@
+const SUPPORTED_VALUE_TYPES = new Set([
+  'text',
+  'integer',
+  'number',
+  'boolean',
+  'enum',
+  'concept_ref',
+  'component_ref',
+])
+
+export const PAGE_SIZE = 100
+
+export function getPropertyLabel(definition, languageCode = 'ja') {
+  if (!definition) return ''
+  return definition.labels?.[languageCode]
+    || definition.labels?.en
+    || definition.property_key
+}
+
+export function isSupportedDefinition(definition) {
+  return Boolean(definition && SUPPORTED_VALUE_TYPES.has(definition.value_type))
+}
+
+export function getProperty(component, propertyKey) {
+  return component?.properties?.find((property) => property.property_key === propertyKey) || null
+}
+
+export function getPropertyValues(component, propertyKey) {
+  const property = getProperty(component, propertyKey)
+  if (!property) return []
+  return property.values
+    ?.filter((entry) => entry && SUPPORTED_VALUE_TYPES.has(entry.value_type))
+    .map((entry) => entry.value) ?? []
+}
+
+export function formatPropertyValue(value, definition) {
+  if (value == null) return '—'
+  if (!isSupportedDefinition(definition)) return '—'
+  if (definition.value_type === 'boolean') return value ? 'YES' : 'NO'
+  const suffix = definition.unit ? ` ${definition.unit}` : ''
+  return `${String(value)}${suffix}`
+}
+
+export function propertyDisplayText(component, definition) {
+  if (!isSupportedDefinition(definition)) return null
+  const values = getPropertyValues(component, definition.property_key)
+  if (values.length === 0) return null
+  return values.map((value) => formatPropertyValue(value, definition)).join(' / ')
+}
+
+export function pageOffsets(total, pageSize = PAGE_SIZE) {
+  if (!Number.isFinite(total) || total <= pageSize) return []
+  const offsets = []
+  for (let offset = pageSize; offset < total; offset += pageSize) offsets.push(offset)
+  return offsets
+}
+
+function matchesPropertyFilter(component, definition, filterValue) {
+  if (!isSupportedDefinition(definition)) return true
+  if (filterValue == null || filterValue === '') return true
+  const values = getPropertyValues(component, definition.property_key)
+  if (values.length === 0) return false
+
+  if (definition.value_type === 'integer' || definition.value_type === 'number') {
+    const min = filterValue.min === '' || filterValue.min == null ? null : Number(filterValue.min)
+    const max = filterValue.max === '' || filterValue.max == null ? null : Number(filterValue.max)
+    return values.some((value) => {
+      const numeric = Number(value)
+      return Number.isFinite(numeric)
+        && (min == null || numeric >= min)
+        && (max == null || numeric <= max)
+    })
+  }
+
+  if (definition.value_type === 'boolean') {
+    if (filterValue !== 'true' && filterValue !== 'false') return true
+    const expected = filterValue === 'true'
+    return values.some((value) => Boolean(value) === expected)
+  }
+
+  const expected = String(filterValue).toLocaleLowerCase()
+  if (definition.value_type === 'enum') {
+    return values.some((value) => String(value) === String(filterValue))
+  }
+  return values.some((value) => String(value).toLocaleLowerCase().includes(expected))
+}
+
+function comparableValue(item, propertyKey) {
+  if (propertyKey === 'canonical_name') return item.component.canonical_name.toLocaleLowerCase()
+  const values = getPropertyValues(item.component, propertyKey)
+  if (values.length === 0) return null
+  return values[0]
+}
+
+export function filterAndSortComponentItems(
+  items,
+  definitions,
+  {
+    search = '',
+    componentSetId = '',
+    filters = {},
+    sortKey = 'canonical_name',
+    sortDirection = 'asc',
+  } = {},
+) {
+  const definitionByKey = Object.fromEntries(
+    definitions.filter(isSupportedDefinition).map((definition) => [definition.property_key, definition]),
+  )
+  const normalizedSearch = search.trim().toLocaleLowerCase()
+  const filtered = items.filter((item) => {
+    const component = item.component
+    if (componentSetId && component.component_set_id !== componentSetId) return false
+    if (normalizedSearch) {
+      const haystack = [
+        component.canonical_name,
+        component.component_id,
+        component.kind,
+        ...component.properties.flatMap((property) => property.values.map((entry) => entry.value)),
+      ].join(' ').toLocaleLowerCase()
+      if (!haystack.includes(normalizedSearch)) return false
+    }
+    return Object.entries(filters).every(([propertyKey, filterValue]) => {
+      const definition = definitionByKey[propertyKey]
+      return definition ? matchesPropertyFilter(component, definition, filterValue) : true
+    })
+  })
+
+  const direction = sortDirection === 'desc' ? -1 : 1
+  return [...filtered].sort((left, right) => {
+    const a = comparableValue(left, sortKey)
+    const b = comparableValue(right, sortKey)
+    if (a == null && b == null) return left.component.canonical_name.localeCompare(right.component.canonical_name)
+    if (a == null) return 1
+    if (b == null) return -1
+    if (typeof a === 'number' && typeof b === 'number') return (a - b) * direction
+    return String(a).localeCompare(String(b), undefined, { numeric: true }) * direction
+  })
+}
+
+export function evidenceLabel(summary) {
+  if (summary?.status === 'verified') return 'VERIFIED'
+  if (summary?.status === 'contested') return 'CONTESTED'
+  return 'UNVERIFIED'
+}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -11,6 +11,7 @@ import { InfographicsGallery } from '../components/game/InfographicsGallery'
 import { QuickRulesPanel } from '../components/game/QuickRulesPanel'
 import { RuleFlowDiagram } from '../components/game/RuleFlowDiagram'
 import { ConceptGlossary } from '../components/game/ConceptGlossary'
+import { ComponentsPanel } from '../components/game/ComponentsPanel'
 
 const IDENTITY_LABELS = {
   verified: 'IDENTITY VERIFIED',
@@ -42,6 +43,7 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
   const [loading, setLoading] = useState(!initialGame)
   const [error, setError] = useState(null)
   const [activeTab, setActiveTab] = useState('rules')
+  const [componentCatalogAvailability, setComponentCatalogAvailability] = useState(null)
 
   const BASE_URL = 'https://bodoge-no-mikata.vercel.app'
 
@@ -73,6 +75,34 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
     }
     fetchData()
   }, [slug, initialGame, allGames.length])
+
+  useEffect(() => {
+    let cancelled = false
+    setComponentCatalogAvailability(null)
+    setActiveTab('rules')
+
+    api.get(`/api/games/${encodeURIComponent(slug)}/component-catalog-availability`)
+      .then((payload) => {
+        if (!cancelled) setComponentCatalogAvailability(payload)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error('Failed to check component catalog availability:', err)
+          setComponentCatalogAvailability({ status: 'not_available', rule_set_ids: [] })
+        }
+      })
+
+    return () => { cancelled = true }
+  }, [slug])
+
+  const componentRuleSetIds = componentCatalogAvailability?.rule_set_ids || []
+  const hasComponents = componentCatalogAvailability?.status === 'available' && componentRuleSetIds.length > 0
+
+  useEffect(() => {
+    if (componentCatalogAvailability && !hasComponents && activeTab === 'components') {
+      setActiveTab('rules')
+    }
+  }, [componentCatalogAvailability, hasComponents, activeTab])
 
   if (loading) {
     return <div className="page-state page-state--loading" role="status">ARCHIVE LOADING...</div>
@@ -218,6 +248,11 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
             <button role="tab" aria-selected={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>
               セットアップ <span className="sr-only">INST COACH</span>
             </button>
+            {hasComponents && (
+              <button role="tab" aria-selected={activeTab === 'components'} className={activeTab === 'components' ? 'active' : ''} onClick={() => setActiveTab('components')}>
+                コンポーネント <span className="sr-only">COMPONENTS</span>
+              </button>
+            )}
             <button role="tab" aria-selected={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>
               戦略 <span className="sr-only">STRATEGY GUIDE</span>
             </button>
@@ -277,6 +312,10 @@ export default function GamePage({ slug: propSlug, initialGame, allGames: propAl
                   )}
                 </div>
               </div>
+            )}
+
+            {activeTab === 'components' && hasComponents && (
+              <ComponentsPanel slug={slug} ruleSetIds={componentRuleSetIds} />
             )}
 
             {activeTab === 'strategy' && (

--- a/frontend/tests/componentCatalog.test.mjs
+++ b/frontend/tests/componentCatalog.test.mjs
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  evidenceLabel,
+  filterAndSortComponentItems,
+  getPropertyLabel,
+  pageOffsets,
+  propertyDisplayText,
+} from '../src/lib/componentCatalog.js'
+
+const definitions = [
+  {
+    property_key: 'faction',
+    labels: { ja: '派閥', en: 'Faction' },
+    value_type: 'enum',
+    enum_values: ['sun', 'moon'],
+    filterable: true,
+  },
+  {
+    property_key: 'power',
+    labels: { ja: '戦力' },
+    value_type: 'integer',
+    sortable: true,
+    unit: 'VP',
+  },
+  {
+    property_key: 'active',
+    labels: { ja: '有効' },
+    value_type: 'boolean',
+    filterable: true,
+  },
+  {
+    property_key: 'note',
+    labels: { ja: '注記' },
+    value_type: 'text',
+    filterable: true,
+  },
+]
+
+function item(id, name, kind, setId, properties = [], evidence = {}) {
+  return {
+    component: {
+      component_id: id,
+      canonical_name: name,
+      kind,
+      component_set_id: setId,
+      quantity: null,
+      properties,
+      abilities: [],
+      concept_ids: [],
+      rule_ids: [],
+    },
+    property_evidence: evidence,
+    ability_evidence: {},
+  }
+}
+
+function prop(propertyKey, valueType, ...values) {
+  return {
+    property_key: propertyKey,
+    values: values.map((value) => ({ value_type: valueType, value })),
+  }
+}
+
+test('card, tile, token and die use the same generic filter path', () => {
+  const items = [
+    item('card.scout', 'Scout', 'card', 'cards', [prop('faction', 'enum', 'sun'), prop('power', 'integer', 3)]),
+    item('tile.forest', 'Forest', 'tile', 'tiles', [prop('power', 'integer', 1)]),
+    item('token.energy', 'Energy', 'token', 'tokens', [prop('active', 'boolean', true)]),
+    item('die.action', 'Action Die', 'die', 'dice', [prop('note', 'text', 'attack die')]),
+  ]
+
+  assert.deepEqual(
+    filterAndSortComponentItems(items, definitions, { search: 'die' }).map((entry) => entry.component.component_id),
+    ['die.action'],
+  )
+  assert.deepEqual(
+    filterAndSortComponentItems(items, definitions, { componentSetId: 'tiles' }).map((entry) => entry.component.component_id),
+    ['tile.forest'],
+  )
+})
+
+test('enum, numeric, boolean and text filters are schema driven', () => {
+  const items = [
+    item('card.sun', 'Sun', 'card', 'cards', [
+      prop('faction', 'enum', 'sun'),
+      prop('power', 'integer', 4),
+      prop('active', 'boolean', true),
+      prop('note', 'text', 'fast scout'),
+    ]),
+    item('card.moon', 'Moon', 'card', 'cards', [
+      prop('faction', 'enum', 'moon'),
+      prop('power', 'integer', 2),
+      prop('active', 'boolean', false),
+      prop('note', 'text', 'slow guard'),
+    ]),
+  ]
+
+  assert.equal(filterAndSortComponentItems(items, definitions, { filters: { faction: 'sun' } }).length, 1)
+  assert.equal(filterAndSortComponentItems(items, definitions, { filters: { power: { min: 3, max: '' } } }).length, 1)
+  assert.equal(filterAndSortComponentItems(items, definitions, { filters: { active: 'false' } })[0].component.component_id, 'card.moon')
+  assert.equal(filterAndSortComponentItems(items, definitions, { filters: { note: 'scout' } })[0].component.component_id, 'card.sun')
+})
+
+test('sortable property definitions work without game-specific keys', () => {
+  const items = [
+    item('card.a', 'A', 'card', 'cards', [prop('power', 'integer', 9)]),
+    item('card.b', 'B', 'card', 'cards', [prop('power', 'integer', 2)]),
+  ]
+  assert.deepEqual(
+    filterAndSortComponentItems(items, definitions, { sortKey: 'power', sortDirection: 'asc' })
+      .map((entry) => entry.component.component_id),
+    ['card.b', 'card.a'],
+  )
+})
+
+test('unknown future property types fail closed instead of crashing', () => {
+  const unknown = { property_key: 'future', labels: { ja: '将来型' }, value_type: 'matrix' }
+  const component = item('card.future', 'Future', 'card', 'cards', [prop('future', 'matrix', 'x')])
+  assert.equal(propertyDisplayText(component.component, unknown), null)
+  assert.equal(filterAndSortComponentItems([component], [unknown], { filters: { future: 'x' } }).length, 1)
+})
+
+test('labels, evidence badges and 100+ pagination are deterministic', () => {
+  assert.equal(getPropertyLabel(definitions[0], 'ja'), '派閥')
+  assert.equal(propertyDisplayText({ properties: [prop('power', 'integer', 3)] }, definitions[1]), '3 VP')
+  assert.equal(evidenceLabel({ status: 'verified' }), 'VERIFIED')
+  assert.equal(evidenceLabel({ status: 'contested' }), 'CONTESTED')
+  assert.equal(evidenceLabel(), 'UNVERIFIED')
+  assert.deepEqual(pageOffsets(251, 100), [100, 200])
+  assert.deepEqual(pageOffsets(1, 100), [])
+})

--- a/frontend/tests/components_ui.spec.js
+++ b/frontend/tests/components_ui.spec.js
@@ -50,7 +50,7 @@ function buildItems() {
     const name = index === 0 ? 'Scout' : `Component ${String(index + 1).padStart(3, '0')}`
     const componentId = index === 0 ? 'card.scout' : `${kind}.fixture-${index + 1}`
     const faction = index % 2 === 0 ? 'sun' : 'moon'
-    const item = {
+    return {
       component: {
         component_id: componentId,
         ruleset_id: 'ruleset-components',
@@ -95,7 +95,6 @@ function buildItems() {
         },
       } : {},
     }
-    return item
   })
 }
 
@@ -104,8 +103,7 @@ async function mockApi(page, { catalogAvailable = true } = {}) {
   const catalogRequests = []
 
   await page.route('**/api/**', async (route) => {
-    const request = route.request()
-    const url = new URL(request.url())
+    const url = new URL(route.request().url())
     const path = url.pathname
 
     if (path === '/api/games/component-fixture') {
@@ -208,6 +206,7 @@ test('component detail is keyboard reachable and traces field evidence without i
   await page.keyboard.press('Enter')
   await expect(page.getByRole('heading', { name: 'COMPONENTS' })).toBeVisible()
 
+  await page.getByLabel('SEARCH').fill('Scout')
   const firstCard = page.locator('.component-card-button').first()
   await firstCard.focus()
   await page.keyboard.press('Enter')
@@ -220,7 +219,7 @@ test('component detail is keyboard reachable and traces field evidence without i
   await expect(detail.locator('img')).toHaveCount(0)
 })
 
-test('Components UI has no horizontal page overflow at responsive target widths', async ({ page }) => {
+test('Components UI has no horizontal page overflow at responsive target widths', async ({ page }, testInfo) => {
   await mockApi(page)
   await page.goto('/games/component-fixture')
   await page.getByRole('tab', { name: /コンポーネント/ }).click()
@@ -233,4 +232,6 @@ test('Components UI has no horizontal page overflow at responsive target widths'
   }))
   expect(metrics.scrollWidth).toBe(metrics.clientWidth)
   expect(metrics.panelWidth).toBeLessThanOrEqual(metrics.clientWidth)
+
+  await page.screenshot({ path: testInfo.outputPath('components-panel.png'), fullPage: true })
 })

--- a/frontend/tests/components_ui.spec.js
+++ b/frontend/tests/components_ui.spec.js
@@ -1,0 +1,236 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: '11111111-1111-4111-8111-111111111176',
+  slug: 'component-fixture',
+  title: 'Component Fixture',
+  title_ja: 'コンポーネント・フィクスチャ',
+  min_players: 2,
+  max_players: 4,
+  play_time: 30,
+  min_age: 10,
+  published_year: 2026,
+  summary: 'Schema-driven Components UI fixture.',
+  rules_content: '# Fixture Rules\n\nCanonical component UI test fixture.',
+  structured_data: {},
+}
+
+const componentSets = [
+  { component_set_id: 'cards', ruleset_id: 'ruleset-components', canonical_name: 'Cards', kind: 'card' },
+  { component_set_id: 'tiles', ruleset_id: 'ruleset-components', canonical_name: 'Tiles', kind: 'tile' },
+  { component_set_id: 'tokens', ruleset_id: 'ruleset-components', canonical_name: 'Tokens', kind: 'token' },
+  { component_set_id: 'dice', ruleset_id: 'ruleset-components', canonical_name: 'Dice', kind: 'die' },
+]
+
+const definitions = [
+  { property_key: 'faction', labels: { ja: '派閥' }, value_type: 'enum', cardinality: 'one', enum_values: ['sun', 'moon'], filterable: true, sortable: false },
+  { property_key: 'power', labels: { ja: '戦力' }, value_type: 'integer', cardinality: 'one', enum_values: [], unit: 'VP', filterable: true, sortable: true },
+  { property_key: 'active', labels: { ja: '有効' }, value_type: 'boolean', cardinality: 'one', enum_values: [], filterable: true, sortable: false },
+  { property_key: 'note', labels: { ja: '注記' }, value_type: 'text', cardinality: 'one', enum_values: [], filterable: true, sortable: false },
+]
+
+function property(propertyKey, valueType, value) {
+  return {
+    property_key: propertyKey,
+    values: [{ value_type: valueType, value }],
+    verification_status: 'unknown',
+    source_ids: [],
+  }
+}
+
+function buildItems() {
+  const kinds = [
+    ['card', 'cards'],
+    ['tile', 'tiles'],
+    ['token', 'tokens'],
+    ['die', 'dice'],
+  ]
+  return Array.from({ length: 125 }, (_, index) => {
+    const [kind, setId] = kinds[index % kinds.length]
+    const name = index === 0 ? 'Scout' : `Component ${String(index + 1).padStart(3, '0')}`
+    const componentId = index === 0 ? 'card.scout' : `${kind}.fixture-${index + 1}`
+    const faction = index % 2 === 0 ? 'sun' : 'moon'
+    const item = {
+      component: {
+        component_id: componentId,
+        ruleset_id: 'ruleset-components',
+        component_set_id: setId,
+        canonical_name: name,
+        kind,
+        quantity: index % 7 === 0 ? 2 : null,
+        properties: [
+          property('faction', 'enum', faction),
+          property('power', 'integer', (index % 9) + 1),
+          property('active', 'boolean', index % 3 !== 0),
+          property('note', 'text', `${kind} fixture ${index + 1}`),
+        ],
+        abilities: index === 0 ? [{
+          ability_id: 'ability.scout',
+          printed_text: 'Gain 1 gold.',
+          normalized_label: 'Gain gold',
+          rule_ids: ['rule.scout'],
+          concept_ids: ['resource.gold'],
+          verification_status: 'verified',
+          source_ids: ['source.publisher'],
+        }] : [],
+        concept_ids: index === 0 ? ['resource.gold'] : [],
+        rule_ids: index === 0 ? ['rule.scout'] : [],
+        verification_status: 'unknown',
+        source_ids: [],
+      },
+      property_evidence: {
+        faction: {
+          status: index === 0 ? 'verified' : 'unknown',
+          claim_ids: index === 0 ? ['claim.scout.faction'] : [],
+          source_ids: index === 0 ? ['source.publisher'] : [],
+        },
+        power: { status: 'unknown', claim_ids: [], source_ids: [] },
+        active: { status: 'unknown', claim_ids: [], source_ids: [] },
+        note: { status: 'unknown', claim_ids: [], source_ids: [] },
+      },
+      ability_evidence: index === 0 ? {
+        'ability.scout': {
+          printed_text: { status: 'verified', claim_ids: ['claim.scout.printed'], source_ids: ['source.publisher'] },
+          normalized: { status: 'verified', claim_ids: ['claim.scout.normalized'], source_ids: ['source.publisher'] },
+        },
+      } : {},
+    }
+    return item
+  })
+}
+
+async function mockApi(page, { catalogAvailable = true } = {}) {
+  const items = buildItems()
+  const catalogRequests = []
+
+  await page.route('**/api/**', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    const path = url.pathname
+
+    if (path === '/api/games/component-fixture') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(game) })
+      return
+    }
+    if (path === '/api/games/component-fixture/component-catalog-availability') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema_version: '1.0',
+          status: catalogAvailable ? 'available' : 'not_available',
+          game_id: game.id,
+          slug: game.slug,
+          rule_set_ids: catalogAvailable ? ['ruleset-components'] : [],
+        }),
+      })
+      return
+    }
+    if (path === '/api/games/component-fixture/component-catalog') {
+      catalogRequests.push(url.search)
+      const offset = Number(url.searchParams.get('offset') || 0)
+      const limit = Number(url.searchParams.get('limit') || 100)
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema_version: '1.0',
+          status: 'available',
+          game_id: game.id,
+          slug: game.slug,
+          rule_set_id: 'ruleset-components',
+          component_sets: componentSets,
+          property_definitions: definitions,
+          items: items.slice(offset, offset + limit),
+          total: items.length,
+          limit,
+          offset,
+        }),
+      })
+      return
+    }
+    if (path === '/api/games/component-fixture/glossary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ schema_version: '1.0', status: 'not_available', game_id: game.id, slug: game.slug, language_code: 'ja', entries: [] }),
+      })
+      return
+    }
+    if (path === '/api/games') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [], total: 0 }) })
+      return
+    }
+
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'not_available' }) })
+  })
+
+  return { catalogRequests }
+}
+
+test('catalog absence hides the tab and never requests full components', async ({ page }) => {
+  const audit = await mockApi(page, { catalogAvailable: false })
+  await page.goto('/games/component-fixture')
+  await expect(page.getByRole('heading', { name: game.title_ja })).toBeVisible()
+  await expect(page.getByRole('tab', { name: /コンポーネント/ })).toHaveCount(0)
+  expect(audit.catalogRequests).toEqual([])
+})
+
+test('100+ components load in pages and schema-driven filters work globally', async ({ page }) => {
+  const audit = await mockApi(page)
+  await page.goto('/games/component-fixture')
+  await page.getByRole('tab', { name: /コンポーネント/ }).click()
+
+  await expect(page.getByRole('heading', { name: 'COMPONENTS' })).toBeVisible()
+  await expect(page.getByText('125 / 125')).toBeVisible()
+  expect(audit.catalogRequests.length).toBe(2)
+  expect(audit.catalogRequests.some((query) => query.includes('offset=100'))).toBeTruthy()
+
+  await page.getByLabel('SEARCH').fill('Scout')
+  await expect(page.getByText('1 / 125')).toBeVisible()
+  await expect(page.getByRole('heading', { name: 'Scout' })).toBeVisible()
+
+  await page.getByLabel('SEARCH').fill('')
+  await page.getByLabel('派閥').selectOption('sun')
+  await expect(page.getByText(/63 \/ 125/)).toBeVisible()
+
+  await page.getByLabel('派閥').selectOption('')
+  await page.getByLabel('戦力 最小値').fill('8')
+  await expect(page.locator('.component-card')).toHaveCount(27)
+})
+
+test('component detail is keyboard reachable and traces field evidence without images', async ({ page }) => {
+  await mockApi(page)
+  await page.goto('/games/component-fixture')
+
+  const tab = page.getByRole('tab', { name: /コンポーネント/ })
+  await tab.focus()
+  await page.keyboard.press('Enter')
+  await expect(page.getByRole('heading', { name: 'COMPONENTS' })).toBeVisible()
+
+  const firstCard = page.locator('.component-card-button').first()
+  await firstCard.focus()
+  await page.keyboard.press('Enter')
+  const detail = page.getByRole('dialog')
+  await expect(detail).toBeVisible()
+  await expect(detail.getByRole('heading', { name: 'Scout' })).toBeVisible()
+  await expect(detail.getByText('VERIFIED').first()).toBeVisible()
+  await expect(detail.getByRole('link', { name: /EVIDENCE/ }).first()).toHaveAttribute('href', /claim\.scout/)
+  await expect(detail.getByRole('link', { name: 'resource.gold' })).toHaveAttribute('href', '/api/concepts/resource.gold')
+  await expect(detail.locator('img')).toHaveCount(0)
+})
+
+test('Components UI has no horizontal page overflow at responsive target widths', async ({ page }) => {
+  await mockApi(page)
+  await page.goto('/games/component-fixture')
+  await page.getByRole('tab', { name: /コンポーネント/ }).click()
+  await expect(page.getByText('125 / 125')).toBeVisible()
+
+  const metrics = await page.evaluate(() => ({
+    clientWidth: document.documentElement.clientWidth,
+    scrollWidth: document.documentElement.scrollWidth,
+    panelWidth: document.querySelector('.components-panel')?.getBoundingClientRect().width || 0,
+  }))
+  expect(metrics.scrollWidth).toBe(metrics.clientWidth)
+  expect(metrics.panelWidth).toBeLessThanOrEqual(metrics.clientWidth)
+})

--- a/frontend/tests/ui_ux_regression.spec.js
+++ b/frontend/tests/ui_ux_regression.spec.js
@@ -149,6 +149,19 @@ async function mockApi(page, state) {
       return
     }
 
+    const componentAvailabilityMatch = path.match(/^\/api\/games\/([^/]+)\/component-catalog-availability$/)
+    if (componentAvailabilityMatch && method === 'GET') {
+      const game = games.find((candidate) => candidate.slug === decodeURIComponent(componentAvailabilityMatch[1]))
+      await route.fulfill({
+        status: game ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(game
+          ? { schema_version: '1.0', status: 'not_available', game_id: game.id, slug: game.slug, rule_set_ids: [] }
+          : { detail: 'not found' }),
+      })
+      return
+    }
+
     const gameMatch = path.match(/^\/api\/games\/([^/]+)$/)
     if (gameMatch && method === 'GET') {
       await delay(100)


### PR DESCRIPTION
Closes #176

## Changes
- add lightweight `component-catalog-availability` API so GamePage can hide the tab without loading component data
- add paginated full `component-catalog` UI projection API with ComponentSet, PropertyDefinition, full Component, bridges and field-level evidence summaries
- bulk-load page properties / abilities / Concept / RuleNode / Claim-Evidence to avoid per-component detail N+1
- derive property evidence from current ordinal/value + accepted Claim + supporting EvidenceBinding; stale/candidate claims do not verify current fields
- show COMPONENTS tab only when at least one RuleSet has a catalog
- mount/fetch full ComponentsPanel only after the user opens the tab
- add generic card/tile/token/die renderer with no game-specific property keys
- generate enum / boolean / numeric / text filters and sortable fields from PropertyDefinition
- load 100+ catalogs page-by-page and apply filters/sort globally
- fail closed on unknown future property types
- show field-level VERIFIED / CONTESTED / UNVERIFIED state and links to Claim evidence, Concept and Rule evidence traces
- support multiple catalog RuleSets with explicit selection instead of guessing
- remain usable without component images
- add responsive layout for 375 / 768 / 1440 targets with keyboard-accessible detail region
- add backend, Node unit and Playwright E2E contract gates plus reviewable screenshots/traces artifacts
- document Components UI v1 contract

## Verification
- missing catalog => no COMPONENTS tab and no full catalog request
- card / tile / token / die use the same renderer/filter helpers
- enum / integer / boolean / text filtering
- sortable property definitions
- unknown property type fail-closed
- 125 components load in two API pages
- keyboard opens component detail
- field evidence trace links are available
- no image dependency
- no horizontal page overflow at 375 / 768 / 1440

## Dependencies
- #151 Presentation Projection (completed)
- #173 Component Catalog (completed)
- #174 RuleSet identity (completed)
- #175 Claim/Evidence Binding (completed)