### PR TITLE
feat: add evidence-gated component ingestion contract

### DIFF
--- a/.github/workflows/test-component-ingestion.yml
+++ b/.github/workflows/test-component-ingestion.yml
@@ -1,0 +1,83 @@
+name: Component ingestion contract
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/component_ingestion.py"
+      - "backend/app/services/component_ingestion.py"
+      - "backend/scripts/component_ingest.py"
+      - "backend/data/component_ingestion/**"
+      - "backend/tests/test_component_ingestion.py"
+      - ".github/workflows/test-component-ingestion.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/app/models/component_ingestion.py"
+      - "backend/app/services/component_ingestion.py"
+      - "backend/scripts/component_ingest.py"
+      - "backend/data/component_ingestion/**"
+      - "backend/tests/test_component_ingestion.py"
+      - ".github/workflows/test-component-ingestion.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  component-ingestion:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile ingestion modules
+        run: >-
+          uv run python -m compileall -q
+          backend/app/models/component_ingestion.py
+          backend/app/services/component_ingestion.py
+          backend/scripts/component_ingest.py
+          backend/tests/test_component_ingestion.py
+
+      - name: Ruff ingestion slice
+        run: >-
+          uv run ruff check
+          backend/app/models/component_ingestion.py
+          backend/app/services/component_ingestion.py
+          backend/scripts/component_ingest.py
+          backend/tests/test_component_ingestion.py
+
+      - name: Run targeted ingestion tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_component_ingestion.py backend/tests/test_component_catalog.py
+
+      - name: Run YRO manifest dry-run and export v1 schema
+        env:
+          PYTHONPATH: backend
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          uv run python backend/scripts/component_ingest.py \
+            backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml \
+            --resolved-ruleset-id 00000000-0000-0000-0000-000000000178 \
+            > artifacts/yro-component-ingest-dry-run.json
+          uv run python backend/scripts/component_ingest.py \
+            backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml \
+            --schema \
+            > artifacts/component-source-manifest-v1.schema.json
+          python -m json.tool artifacts/yro-component-ingest-dry-run.json >/dev/null
+          python -m json.tool artifacts/component-source-manifest-v1.schema.json >/dev/null
+          grep -q '"blockers": \[\]' artifacts/yro-component-ingest-dry-run.json
+          grep -q '"schema_version"' artifacts/component-source-manifest-v1.schema.json
+
+      - name: Upload ingestion audit contract artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: component-ingestion-contract
+          path: artifacts/
+          if-no-files-found: error

--- a/.github/workflows/test-component-ingestion.yml
+++ b/.github/workflows/test-component-ingestion.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Ruff ingestion slice
         run: >-
-          uv run ruff check
+          uv run --with ruff ruff check
           backend/app/models/component_ingestion.py
           backend/app/services/component_ingestion.py
           backend/scripts/component_ingest.py

--- a/backend/app/models/component_ingestion.py
+++ b/backend/app/models/component_ingestion.py
@@ -6,12 +6,12 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
 from app.models.component_catalog import (
+    STABLE_ID_PATTERN,
     Ability,
     ComponentKind,
     ComponentProperty,
     ComponentVerificationStatus,
     PropertyDefinition,
-    STABLE_ID_PATTERN,
 )
 
 COMPONENT_SOURCE_MANIFEST_SCHEMA_VERSION = "1.0"

--- a/backend/app/models/component_ingestion.py
+++ b/backend/app/models/component_ingestion.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
+
+from app.models.component_catalog import (
+    Ability,
+    ComponentKind,
+    ComponentProperty,
+    ComponentVerificationStatus,
+    PropertyDefinition,
+    STABLE_ID_PATTERN,
+)
+
+COMPONENT_SOURCE_MANIFEST_SCHEMA_VERSION = "1.0"
+
+
+class ManifestModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class CompletenessState(StrEnum):
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    UNKNOWN = "unknown"
+
+
+class SourceAuthority(StrEnum):
+    PUBLISHER = "publisher"
+    PLATFORM = "platform"
+    COMMUNITY = "community"
+    REPLAY = "replay"
+    LOG = "log"
+    OTHER = "other"
+
+
+class EvidenceRelation(StrEnum):
+    SUPPORTS = "supports"
+    CONTRADICTS = "contradicts"
+    CONTEXTUALIZES = "contextualizes"
+    UNRESOLVED = "unresolved"
+
+
+class RuleSetSelector(ManifestModel):
+    ruleset_id: str | None = None
+    platform: str | None = None
+    revision_label: str | None = None
+    language_code: str | None = None
+    edition_label: str | None = None
+
+    @model_validator(mode="after")
+    def require_exact_selector(self):
+        if self.ruleset_id:
+            return self
+        if not self.platform or not self.revision_label:
+            raise ValueError("ruleset selector requires ruleset_id or platform + revision_label")
+        return self
+
+
+class ComponentManifestSource(ManifestModel):
+    source_id: str = Field(pattern=STABLE_ID_PATTERN)
+    url: HttpUrl
+    source_type: str = Field(min_length=1)
+    authority: SourceAuthority
+    revision_label: str | None = None
+    observed_date: str | None = None
+    extraction_method: str = Field(min_length=1)
+
+
+class ManifestComponentSet(ManifestModel):
+    component_set_id: str = Field(pattern=STABLE_ID_PATTERN)
+    canonical_name: str = Field(min_length=1)
+    kind: ComponentKind | None = None
+    parent_component_set_id: str | None = Field(default=None, pattern=STABLE_ID_PATTERN)
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+
+class ManifestComponent(ManifestModel):
+    component_id: str = Field(pattern=STABLE_ID_PATTERN)
+    component_set_id: str | None = Field(default=None, pattern=STABLE_ID_PATTERN)
+    canonical_name: str = Field(min_length=1)
+    kind: ComponentKind
+    quantity: int | None = Field(default=None, ge=1)
+    properties: list[ComponentProperty] = Field(default_factory=list)
+    abilities: list[Ability] = Field(default_factory=list)
+    concept_ids: list[str] = Field(default_factory=list)
+    rule_ids: list[str] = Field(default_factory=list)
+    verification_status: ComponentVerificationStatus = ComponentVerificationStatus.UNKNOWN
+    source_ids: list[str] = Field(default_factory=list)
+
+
+class ManifestEvidenceBinding(ManifestModel):
+    binding_id: str = Field(pattern=STABLE_ID_PATTERN)
+    target_path: str = Field(min_length=1)
+    source_id: str = Field(pattern=STABLE_ID_PATTERN)
+    locator_id: str = Field(pattern=STABLE_ID_PATTERN)
+    relation: EvidenceRelation = EvidenceRelation.SUPPORTS
+
+
+class ComponentSourceManifest(ManifestModel):
+    schema_version: Literal["1.0"] = COMPONENT_SOURCE_MANIFEST_SCHEMA_VERSION
+    game_slug: str = Field(pattern=r"^[a-z0-9][a-z0-9-]{1,127}$")
+    ruleset: RuleSetSelector
+    sources: list[ComponentManifestSource] = Field(min_length=1)
+    component_sets: list[ManifestComponentSet] = Field(default_factory=list)
+    property_definitions: list[PropertyDefinition] = Field(default_factory=list)
+    components: list[ManifestComponent] = Field(default_factory=list)
+    evidence_bindings: list[ManifestEvidenceBinding] = Field(default_factory=list)
+    completeness: CompletenessState
+    expected_count: int | None = Field(default=None, ge=0)
+    unresolved_count: int | None = Field(default=None, ge=0)
+    notes: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def validate_manifest(self):  # noqa: PLR0912 - fail-closed contract is intentionally explicit
+        source_ids = [source.source_id for source in self.sources]
+        if len(source_ids) != len(set(source_ids)):
+            raise ValueError("duplicate source_id")
+        known_sources = set(source_ids)
+
+        set_ids = [item.component_set_id for item in self.component_sets]
+        if len(set_ids) != len(set(set_ids)):
+            raise ValueError("duplicate component_set_id")
+        known_sets = set(set_ids)
+        for item in self.component_sets:
+            if item.parent_component_set_id and item.parent_component_set_id not in known_sets:
+                raise ValueError("parent component set is not present in manifest")
+            self._require_known_sources(item.source_ids, known_sources, f"component_set:{item.component_set_id}")
+
+        definition_keys = [item.property_key for item in self.property_definitions]
+        if len(definition_keys) != len(set(definition_keys)):
+            raise ValueError("duplicate property_key")
+        for definition in self.property_definitions:
+            self._require_known_sources(definition.source_ids, known_sources, f"property_definition:{definition.property_key}")
+
+        component_ids = [item.component_id for item in self.components]
+        if len(component_ids) != len(set(component_ids)):
+            raise ValueError("duplicate component_id")
+        for component in self.components:
+            if component.component_set_id and component.component_set_id not in known_sets:
+                raise ValueError(f"component {component.component_id} references unknown component set")
+            self._require_known_sources(component.source_ids, known_sources, f"component:{component.component_id}")
+            for prop in component.properties:
+                self._require_known_sources(
+                    prop.source_ids,
+                    known_sources,
+                    f"component:{component.component_id}:property:{prop.property_key}",
+                )
+            for ability in component.abilities:
+                self._require_known_sources(
+                    ability.source_ids,
+                    known_sources,
+                    f"component:{component.component_id}:ability:{ability.ability_id}",
+                )
+
+        binding_ids = [binding.binding_id for binding in self.evidence_bindings]
+        if len(binding_ids) != len(set(binding_ids)):
+            raise ValueError("duplicate evidence binding_id")
+        for binding in self.evidence_bindings:
+            if binding.source_id not in known_sources:
+                raise ValueError(f"evidence binding {binding.binding_id} references unknown source")
+
+        if self.completeness == CompletenessState.COMPLETE:
+            if self.expected_count is None:
+                raise ValueError("complete manifest requires source-backed expected_count")
+            if self.expected_count != len(self.components):
+                raise ValueError("complete manifest expected_count must equal observed component count")
+            if self.unresolved_count not in {None, 0}:
+                raise ValueError("complete manifest cannot have unresolved components")
+        elif self.completeness == CompletenessState.UNKNOWN and self.expected_count is not None:
+            raise ValueError("unknown completeness cannot claim an expected_count")
+        return self
+
+    @staticmethod
+    def _require_known_sources(source_ids: list[str], known_sources: set[str], target: str) -> None:
+        unknown = sorted(set(source_ids) - known_sources)
+        if unknown:
+            raise ValueError(f"{target} references unknown sources: {', '.join(unknown)}")
+
+
+class EvidenceCoverage(ManifestModel):
+    required_fields: int = Field(ge=0)
+    supported_fields: int = Field(ge=0)
+    ratio: float = Field(ge=0, le=1)
+
+
+class ComponentIngestAuditReport(ManifestModel):
+    schema_version: Literal["1.0"] = COMPONENT_SOURCE_MANIFEST_SCHEMA_VERSION
+    game_slug: str
+    resolved_ruleset_id: str | None = None
+    completeness: CompletenessState
+    creates: list[str] = Field(default_factory=list)
+    updates: list[str] = Field(default_factory=list)
+    unchanged: list[str] = Field(default_factory=list)
+    duplicate_candidates: list[list[str]] = Field(default_factory=list)
+    rejected_unknown_properties: list[str] = Field(default_factory=list)
+    blockers: list[str] = Field(default_factory=list)
+    evidence_coverage: EvidenceCoverage
+    affected_records: dict[str, int] = Field(default_factory=dict)

--- a/backend/app/services/component_ingestion.py
+++ b/backend/app/services/component_ingestion.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import defaultdict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.models.component_catalog import ComponentVerificationStatus, PropertyCardinality, PropertyValueType
+from app.models.component_ingestion import (
+    ComponentIngestAuditReport,
+    ComponentSourceManifest,
+    EvidenceCoverage,
+    EvidenceRelation,
+    ManifestComponent,
+    ManifestComponentSet,
+)
+
+
+class ExistingComponentSnapshot(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    ruleset_id: str
+    component_sets: list[ManifestComponentSet] = Field(default_factory=list)
+    property_definitions: list[dict] = Field(default_factory=list)
+    components: list[ManifestComponent] = Field(default_factory=list)
+
+
+def _normalized_name(value: str) -> str:
+    normalized = unicodedata.normalize("NFKC", value).casefold().strip()
+    return re.sub(r"[^\w]+", "", normalized, flags=re.UNICODE)
+
+
+def _jsonish(model) -> dict:
+    return model.model_dump(mode="json", exclude_none=True)
+
+
+class ComponentIngestionDryRun:
+    """Pure fail-closed diff/validation engine for component source manifests.
+
+    Database resolution and writes are intentionally kept outside this class so
+    every promotion rule can be exhaustively tested before production access.
+    """
+
+    def run(
+        self,
+        manifest: ComponentSourceManifest,
+        *,
+        resolved_ruleset_id: str | None,
+        existing: ExistingComponentSnapshot | None = None,
+    ) -> ComponentIngestAuditReport:
+        blockers: list[str] = []
+        rejected_unknown_properties = self._unknown_properties(manifest)
+        if rejected_unknown_properties:
+            blockers.append("UNKNOWN_PROPERTY_DEFINITION")
+
+        blockers.extend(self._property_contract_blockers(manifest))
+        duplicate_candidates = self._duplicate_candidates(manifest)
+        if duplicate_candidates:
+            blockers.append("DUPLICATE_COMPONENT_IDENTITY_CANDIDATE")
+
+        if resolved_ruleset_id is None:
+            blockers.append("RULESET_NOT_RESOLVED")
+        elif manifest.ruleset.ruleset_id and manifest.ruleset.ruleset_id != resolved_ruleset_id:
+            blockers.append("RULESET_SELECTOR_MISMATCH")
+        if existing is not None and resolved_ruleset_id is not None and existing.ruleset_id != resolved_ruleset_id:
+            blockers.append("EXISTING_SNAPSHOT_RULESET_MISMATCH")
+
+        coverage = self._evidence_coverage(manifest)
+        if coverage.required_fields != coverage.supported_fields:
+            blockers.append("FIELD_EVIDENCE_COVERAGE_INCOMPLETE")
+
+        creates, updates, unchanged = self._component_diff(manifest, existing)
+        affected_records = {
+            "sources": len(manifest.sources),
+            "component_sets": len(manifest.component_sets),
+            "property_definitions": len(manifest.property_definitions),
+            "components": len(manifest.components),
+            "evidence_bindings": len(manifest.evidence_bindings),
+        }
+        return ComponentIngestAuditReport(
+            game_slug=manifest.game_slug,
+            resolved_ruleset_id=resolved_ruleset_id,
+            completeness=manifest.completeness,
+            creates=creates,
+            updates=updates,
+            unchanged=unchanged,
+            duplicate_candidates=duplicate_candidates,
+            rejected_unknown_properties=rejected_unknown_properties,
+            blockers=sorted(set(blockers)),
+            evidence_coverage=coverage,
+            affected_records=affected_records,
+        )
+
+    @staticmethod
+    def _unknown_properties(manifest: ComponentSourceManifest) -> list[str]:
+        known = {definition.property_key for definition in manifest.property_definitions}
+        return sorted(
+            {
+                f"{component.component_id}:{prop.property_key}"
+                for component in manifest.components
+                for prop in component.properties
+                if prop.property_key not in known
+            }
+        )
+
+    @staticmethod
+    def _property_contract_blockers(manifest: ComponentSourceManifest) -> list[str]:
+        definitions = {definition.property_key: definition for definition in manifest.property_definitions}
+        component_ids = {component.component_id for component in manifest.components}
+        blockers: list[str] = []
+        for component in manifest.components:
+            for prop in component.properties:
+                definition = definitions.get(prop.property_key)
+                if definition is None:
+                    continue
+                if definition.cardinality == PropertyCardinality.ONE and len(prop.values) != 1:
+                    blockers.append(f"PROPERTY_CARDINALITY_MISMATCH:{component.component_id}:{prop.property_key}")
+                    continue
+                actual_type = prop.values[0].value_type
+                if actual_type != definition.value_type.value:
+                    blockers.append(f"PROPERTY_TYPE_MISMATCH:{component.component_id}:{prop.property_key}")
+                    continue
+                if definition.value_type == PropertyValueType.ENUM:
+                    invalid = [value.value for value in prop.values if value.value not in definition.enum_values]
+                    if invalid:
+                        blockers.append(f"PROPERTY_ENUM_UNKNOWN:{component.component_id}:{prop.property_key}")
+                if definition.value_type == PropertyValueType.COMPONENT_REF:
+                    unknown = [value.value for value in prop.values if value.value not in component_ids]
+                    if unknown:
+                        blockers.append(f"PROPERTY_COMPONENT_REF_UNKNOWN:{component.component_id}:{prop.property_key}")
+        return blockers
+
+    @staticmethod
+    def _duplicate_candidates(manifest: ComponentSourceManifest) -> list[list[str]]:
+        buckets: dict[tuple[str, str], list[str]] = defaultdict(list)
+        for component in manifest.components:
+            buckets[(component.kind.value, _normalized_name(component.canonical_name))].append(component.component_id)
+        return sorted(
+            sorted(ids)
+            for ids in buckets.values()
+            if len(set(ids)) > 1
+        )
+
+    @staticmethod
+    def _required_evidence_targets(manifest: ComponentSourceManifest) -> dict[str, set[str]]:
+        targets: dict[str, set[str]] = {}
+
+        def register(target: str, status: ComponentVerificationStatus, source_ids: list[str]) -> None:
+            if status in {ComponentVerificationStatus.SOURCE_BOUND, ComponentVerificationStatus.VERIFIED}:
+                targets[target] = set(source_ids)
+
+        for item in manifest.component_sets:
+            register(f"component_sets.{item.component_set_id}", item.verification_status, item.source_ids)
+        for definition in manifest.property_definitions:
+            register(
+                f"property_definitions.{definition.property_key}",
+                definition.verification_status,
+                definition.source_ids,
+            )
+        for component in manifest.components:
+            register(f"components.{component.component_id}", component.verification_status, component.source_ids)
+            for prop in component.properties:
+                register(
+                    f"components.{component.component_id}.properties.{prop.property_key}",
+                    prop.verification_status,
+                    prop.source_ids,
+                )
+            for ability in component.abilities:
+                register(
+                    f"components.{component.component_id}.abilities.{ability.ability_id}",
+                    ability.verification_status,
+                    ability.source_ids,
+                )
+        return targets
+
+    @classmethod
+    def _evidence_coverage(cls, manifest: ComponentSourceManifest) -> EvidenceCoverage:
+        required = cls._required_evidence_targets(manifest)
+        supporting: dict[str, set[str]] = defaultdict(set)
+        for binding in manifest.evidence_bindings:
+            if binding.relation == EvidenceRelation.SUPPORTS:
+                supporting[binding.target_path].add(binding.source_id)
+        supported = sum(
+            1
+            for target, allowed_sources in required.items()
+            if supporting.get(target, set()) & allowed_sources
+        )
+        total = len(required)
+        return EvidenceCoverage(
+            required_fields=total,
+            supported_fields=supported,
+            ratio=1.0 if total == 0 else supported / total,
+        )
+
+    @staticmethod
+    def _component_diff(
+        manifest: ComponentSourceManifest,
+        existing: ExistingComponentSnapshot | None,
+    ) -> tuple[list[str], list[str], list[str]]:
+        if existing is None:
+            return sorted(component.component_id for component in manifest.components), [], []
+        current = {component.component_id: component for component in existing.components}
+        creates: list[str] = []
+        updates: list[str] = []
+        unchanged: list[str] = []
+        for component in manifest.components:
+            prior = current.get(component.component_id)
+            if prior is None:
+                creates.append(component.component_id)
+            elif _jsonish(prior) == _jsonish(component):
+                unchanged.append(component.component_id)
+            else:
+                updates.append(component.component_id)
+        return sorted(creates), sorted(updates), sorted(unchanged)

--- a/backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml
+++ b/backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml
@@ -1,0 +1,113 @@
+schema_version: "1.0"
+game_slug: yro
+ruleset:
+  platform: Board Game Arena
+  revision_label: "260725-1445"
+  language_code: en
+  edition_label: BGA Release 260725-1445
+sources:
+  - source_id: bga:yro:260725-1445
+    url: https://en.boardgamearena.com/gamepanel?game=yro
+    source_type: platform_rules_summary
+    authority: platform
+    revision_label: "260725-1445"
+    observed_date: "2026-08-14"
+    extraction_method: manual_primary_source_normalization
+  - source_id: publisher:yro:studio-supernova-product
+    url: https://www.studiosupernova.it/products/yro
+    source_type: publisher_product_page
+    authority: publisher
+    observed_date: "2026-08-14"
+    extraction_method: manual_primary_source_normalization
+component_sets:
+  - component_set_id: adventurers
+    canonical_name: Adventurers
+    kind: card
+    verification_status: source_bound
+    source_ids:
+      - bga:yro:260725-1445
+      - publisher:yro:studio-supernova-product
+  - component_set_id: quests
+    canonical_name: Quests
+    kind: card
+    verification_status: source_bound
+    source_ids:
+      - bga:yro:260725-1445
+property_definitions:
+  - property_key: faction
+    labels:
+      en: Faction
+      ja: 派閥
+    value_type: text
+    cardinality: one
+    filterable: true
+    verification_status: source_bound
+    source_ids:
+      - bga:yro:260725-1445
+      - publisher:yro:studio-supernova-product
+  - property_key: profession
+    labels:
+      en: Profession
+      ja: 職業
+    value_type: text
+    cardinality: one
+    filterable: true
+    verification_status: source_bound
+    source_ids:
+      - bga:yro:260725-1445
+  - property_key: combat_value
+    labels:
+      en: Combat Value
+      ja: 戦闘値
+    value_type: integer
+    cardinality: one
+    sortable: true
+    verification_status: source_bound
+    source_ids:
+      - bga:yro:260725-1445
+  - property_key: recruit_cost
+    labels:
+      en: Recruit Cost
+      ja: 雇用コスト
+    value_type: integer
+    cardinality: one
+    sortable: true
+    verification_status: source_bound
+    source_ids:
+      - bga:yro:260725-1445
+components: []
+evidence_bindings:
+  - binding_id: yro:component-set:adventurers:bga
+    target_path: component_sets.adventurers
+    source_id: bga:yro:260725-1445
+    locator_id: yro:bga:overview
+    relation: supports
+  - binding_id: yro:component-set:quests:bga
+    target_path: component_sets.quests
+    source_id: bga:yro:260725-1445
+    locator_id: yro:bga:setup
+    relation: supports
+  - binding_id: yro:property:faction:bga
+    target_path: property_definitions.faction
+    source_id: bga:yro:260725-1445
+    locator_id: yro:bga:key-concepts
+    relation: supports
+  - binding_id: yro:property:profession:bga
+    target_path: property_definitions.profession
+    source_id: bga:yro:260725-1445
+    locator_id: yro:bga:key-concepts
+    relation: supports
+  - binding_id: yro:property:combat-value:bga
+    target_path: property_definitions.combat_value
+    source_id: bga:yro:260725-1445
+    locator_id: yro:bga:overview
+    relation: supports
+  - binding_id: yro:property:recruit-cost:bga
+    target_path: property_definitions.recruit_cost
+    source_id: bga:yro:260725-1445
+    locator_id: yro:bga:phase:recruit
+    relation: supports
+completeness: unknown
+notes:
+  - Complete first-party Adventurer and Quest enumeration was not found in the 2026-08-14 audit.
+  - Individual component records must remain absent until a source proves their identities and fields.

--- a/backend/scripts/component_ingest.py
+++ b/backend/scripts/component_ingest.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import yaml
+
+from app.models.component_ingestion import ComponentSourceManifest
+from app.services.component_ingestion import ComponentIngestionDryRun, ExistingComponentSnapshot
+
+
+def _load_manifest(path: Path) -> ComponentSourceManifest:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return ComponentSourceManifest.model_validate(payload)
+
+
+def _existing_snapshot(path: Path, ruleset_id: str) -> ExistingComponentSnapshot:
+    manifest = _load_manifest(path)
+    return ExistingComponentSnapshot(
+        ruleset_id=ruleset_id,
+        component_sets=manifest.component_sets,
+        property_definitions=[definition.model_dump(mode="json") for definition in manifest.property_definitions],
+        components=manifest.components,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate and dry-run a Component Source Manifest v1.")
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument(
+        "--resolved-ruleset-id",
+        help="Exact RuleSet ID resolved by the caller. Required when the manifest uses a natural-key selector.",
+    )
+    parser.add_argument(
+        "--existing-manifest",
+        type=Path,
+        help="Optional current-state fixture for deterministic diff testing. Production adapters may supply DB state instead.",
+    )
+    parser.add_argument(
+        "--schema",
+        action="store_true",
+        help="Print the generated JSON Schema for Component Source Manifest v1 and exit.",
+    )
+    args = parser.parse_args()
+
+    if args.schema:
+        print(json.dumps(ComponentSourceManifest.model_json_schema(), ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    manifest = _load_manifest(args.manifest)
+    resolved_ruleset_id = args.resolved_ruleset_id or manifest.ruleset.ruleset_id
+    existing = None
+    if args.existing_manifest:
+        if not resolved_ruleset_id:
+            raise SystemExit("--existing-manifest requires --resolved-ruleset-id or manifest.ruleset.ruleset_id")
+        existing = _existing_snapshot(args.existing_manifest, resolved_ruleset_id)
+
+    report = ComponentIngestionDryRun().run(
+        manifest,
+        resolved_ruleset_id=resolved_ruleset_id,
+        existing=existing,
+    )
+    print(report.model_dump_json(indent=2))
+    return 2 if report.blockers else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/test_component_ingestion.py
+++ b/backend/tests/test_component_ingestion.py
@@ -5,11 +5,14 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from app.models.component_ingestion import ComponentSourceManifest, CompletenessState
+from app.models.component_ingestion import CompletenessState, ComponentSourceManifest
 from app.services.component_ingestion import ComponentIngestionDryRun, ExistingComponentSnapshot
 
 YRO_MANIFEST = Path("backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml")
 RULESET_ID = "00000000-0000-0000-0000-000000000178"
+YRO_EVIDENCE_FIELDS = 6
+FIXTURE_EVIDENCE_FIELDS = 4
+FIXTURE_SUPPORTED_WITH_ONE_MISSING = 3
 
 
 def _payload() -> dict:
@@ -115,8 +118,8 @@ def test_yro_manifest_is_source_bound_unknown_and_does_not_fabricate_cards():
     assert manifest.components == []
     assert {item.component_set_id for item in manifest.component_sets} == {"adventurers", "quests"}
     assert report.blockers == []
-    assert report.evidence_coverage.required_fields == 6
-    assert report.evidence_coverage.supported_fields == 6
+    assert report.evidence_coverage.required_fields == YRO_EVIDENCE_FIELDS
+    assert report.evidence_coverage.supported_fields == YRO_EVIDENCE_FIELDS
     assert report.evidence_coverage.ratio == 1.0
 
 
@@ -149,8 +152,8 @@ def test_field_level_evidence_must_cover_source_bound_property():
     ]
     report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
     assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
-    assert report.evidence_coverage.required_fields == 4
-    assert report.evidence_coverage.supported_fields == 3
+    assert report.evidence_coverage.required_fields == FIXTURE_EVIDENCE_FIELDS
+    assert report.evidence_coverage.supported_fields == FIXTURE_SUPPORTED_WITH_ONE_MISSING
 
 
 def test_source_url_does_not_implicitly_verify_a_field():

--- a/backend/tests/test_component_ingestion.py
+++ b/backend/tests/test_component_ingestion.py
@@ -1,0 +1,255 @@
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from app.models.component_ingestion import ComponentSourceManifest, CompletenessState
+from app.services.component_ingestion import ComponentIngestionDryRun, ExistingComponentSnapshot
+
+YRO_MANIFEST = Path("backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml")
+RULESET_ID = "00000000-0000-0000-0000-000000000178"
+
+
+def _payload() -> dict:
+    return {
+        "schema_version": "1.0",
+        "game_slug": "fixture-game",
+        "ruleset": {"platform": "Fixture Platform", "revision_label": "r1", "language_code": "en"},
+        "sources": [
+            {
+                "source_id": "source:fixture:1",
+                "url": "https://example.com/fixture",
+                "source_type": "publisher_component_list",
+                "authority": "publisher",
+                "revision_label": "r1",
+                "observed_date": "2026-08-14",
+                "extraction_method": "fixture",
+            }
+        ],
+        "component_sets": [
+            {
+                "component_set_id": "cards",
+                "canonical_name": "Cards",
+                "kind": "card",
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:1"],
+            }
+        ],
+        "property_definitions": [
+            {
+                "property_key": "rank",
+                "value_type": "integer",
+                "cardinality": "one",
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:1"],
+            }
+        ],
+        "components": [
+            {
+                "component_id": "card.alpha",
+                "component_set_id": "cards",
+                "canonical_name": "Alpha",
+                "kind": "card",
+                "quantity": 1,
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:1"],
+                "properties": [
+                    {
+                        "property_key": "rank",
+                        "values": [{"value_type": "integer", "value": 1}],
+                        "verification_status": "source_bound",
+                        "source_ids": ["source:fixture:1"],
+                    }
+                ],
+            }
+        ],
+        "evidence_bindings": [
+            {
+                "binding_id": "binding:set:cards",
+                "target_path": "component_sets.cards",
+                "source_id": "source:fixture:1",
+                "locator_id": "locator:set:cards",
+                "relation": "supports",
+            },
+            {
+                "binding_id": "binding:def:rank",
+                "target_path": "property_definitions.rank",
+                "source_id": "source:fixture:1",
+                "locator_id": "locator:def:rank",
+                "relation": "supports",
+            },
+            {
+                "binding_id": "binding:component:alpha",
+                "target_path": "components.card.alpha",
+                "source_id": "source:fixture:1",
+                "locator_id": "locator:component:alpha",
+                "relation": "supports",
+            },
+            {
+                "binding_id": "binding:component:alpha:rank",
+                "target_path": "components.card.alpha.properties.rank",
+                "source_id": "source:fixture:1",
+                "locator_id": "locator:component:alpha:rank",
+                "relation": "supports",
+            },
+        ],
+        "completeness": "complete",
+        "expected_count": 1,
+        "unresolved_count": 0,
+    }
+
+
+def _manifest(payload: dict | None = None) -> ComponentSourceManifest:
+    return ComponentSourceManifest.model_validate(payload or _payload())
+
+
+def test_yro_manifest_is_source_bound_unknown_and_does_not_fabricate_cards():
+    manifest = ComponentSourceManifest.model_validate(yaml.safe_load(YRO_MANIFEST.read_text(encoding="utf-8")))
+    report = ComponentIngestionDryRun().run(manifest, resolved_ruleset_id=RULESET_ID)
+
+    assert manifest.game_slug == "yro"
+    assert manifest.completeness == CompletenessState.UNKNOWN
+    assert manifest.expected_count is None
+    assert manifest.components == []
+    assert {item.component_set_id for item in manifest.component_sets} == {"adventurers", "quests"}
+    assert report.blockers == []
+    assert report.evidence_coverage.required_fields == 6
+    assert report.evidence_coverage.supported_fields == 6
+    assert report.evidence_coverage.ratio == 1.0
+
+
+def test_ruleset_must_resolve_before_dry_run_can_promote():
+    report = ComponentIngestionDryRun().run(_manifest(), resolved_ruleset_id=None)
+    assert "RULESET_NOT_RESOLVED" in report.blockers
+
+
+def test_unknown_property_definition_is_rejected_in_report():
+    payload = _payload()
+    payload["components"][0]["properties"][0]["property_key"] = "mystery"
+    manifest = _manifest(payload)
+    report = ComponentIngestionDryRun().run(manifest, resolved_ruleset_id=RULESET_ID)
+    assert report.rejected_unknown_properties == ["card.alpha:mystery"]
+    assert "UNKNOWN_PROPERTY_DEFINITION" in report.blockers
+
+
+def test_property_type_mismatch_is_fail_closed():
+    payload = _payload()
+    payload["components"][0]["properties"][0]["values"] = [{"value_type": "text", "value": "one"}]
+    manifest = _manifest(payload)
+    report = ComponentIngestionDryRun().run(manifest, resolved_ruleset_id=RULESET_ID)
+    assert "PROPERTY_TYPE_MISMATCH:card.alpha:rank" in report.blockers
+
+
+def test_field_level_evidence_must_cover_source_bound_property():
+    payload = _payload()
+    payload["evidence_bindings"] = [
+        item for item in payload["evidence_bindings"] if item["binding_id"] != "binding:component:alpha:rank"
+    ]
+    report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
+    assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
+    assert report.evidence_coverage.required_fields == 4
+    assert report.evidence_coverage.supported_fields == 3
+
+
+def test_source_url_does_not_implicitly_verify_a_field():
+    payload = _payload()
+    payload["sources"].append(
+        {
+            "source_id": "source:fixture:2",
+            "url": "https://example.org/other",
+            "source_type": "community_list",
+            "authority": "community",
+            "extraction_method": "fixture",
+        }
+    )
+    for binding in payload["evidence_bindings"]:
+        if binding["binding_id"] == "binding:component:alpha:rank":
+            binding["source_id"] = "source:fixture:2"
+    report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
+    assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
+
+
+def test_duplicate_stable_identity_candidate_is_reported_even_with_distinct_ids():
+    payload = _payload()
+    duplicate = deepcopy(payload["components"][0])
+    duplicate["component_id"] = "card.alpha-alt"
+    duplicate["canonical_name"] = "Ａｌｐｈａ"
+    payload["components"].append(duplicate)
+    payload["completeness"] = "partial"
+    payload["expected_count"] = 3
+    payload["unresolved_count"] = 1
+    report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
+    assert ["card.alpha", "card.alpha-alt"] in report.duplicate_candidates
+    assert "DUPLICATE_COMPONENT_IDENTITY_CANDIDATE" in report.blockers
+
+
+def test_duplicate_component_id_is_invalid_manifest():
+    payload = _payload()
+    payload["components"].append(deepcopy(payload["components"][0]))
+    payload["expected_count"] = 2
+    with pytest.raises(ValidationError, match="duplicate component_id"):
+        _manifest(payload)
+
+
+def test_complete_requires_source_backed_expected_count_equal_to_observed():
+    payload = _payload()
+    payload["expected_count"] = 2
+    with pytest.raises(ValidationError, match="expected_count must equal observed"):
+        _manifest(payload)
+
+
+def test_unknown_completeness_cannot_claim_expected_count():
+    payload = _payload()
+    payload["completeness"] = "unknown"
+    with pytest.raises(ValidationError, match="unknown completeness cannot claim"):
+        _manifest(payload)
+
+
+def test_partial_source_is_never_promoted_to_complete_by_dry_run():
+    payload = _payload()
+    payload["completeness"] = "partial"
+    payload["expected_count"] = 2
+    payload["unresolved_count"] = 1
+    report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
+    assert report.completeness == CompletenessState.PARTIAL
+
+
+def test_identical_second_run_is_unchanged_not_duplicate_create():
+    manifest = _manifest()
+    existing = ExistingComponentSnapshot(
+        ruleset_id=RULESET_ID,
+        component_sets=manifest.component_sets,
+        property_definitions=[definition.model_dump(mode="json") for definition in manifest.property_definitions],
+        components=manifest.components,
+    )
+    report = ComponentIngestionDryRun().run(
+        manifest,
+        resolved_ruleset_id=RULESET_ID,
+        existing=existing,
+    )
+    assert report.creates == []
+    assert report.updates == []
+    assert report.unchanged == ["card.alpha"]
+
+
+def test_same_game_different_ruleset_snapshot_is_not_merged():
+    manifest = _manifest()
+    existing = ExistingComponentSnapshot(
+        ruleset_id="00000000-0000-0000-0000-000000000999",
+        components=manifest.components,
+    )
+    report = ComponentIngestionDryRun().run(
+        manifest,
+        resolved_ruleset_id=RULESET_ID,
+        existing=existing,
+    )
+    assert "EXISTING_SNAPSHOT_RULESET_MISMATCH" in report.blockers
+
+
+def test_manifest_cannot_reference_undeclared_source():
+    payload = _payload()
+    payload["component_sets"][0]["source_ids"] = ["source:not-declared"]
+    with pytest.raises(ValidationError, match="references unknown sources"):
+        _manifest(payload)


### PR DESCRIPTION
## Summary

Implements the reusable contract/dry-run slice of #178 on top of the production YRO pilot from #177.

- adds versioned `ComponentSourceManifest` v1
- separates RuleSet natural-key selector from generated production UUIDs
- records source type + authority + extraction method instead of collapsing publisher/platform/community/replay/log trust states
- validates declared source references, stable IDs, completeness semantics and source-bound data
- adds a pure fail-closed dry-run/diff engine
- reports creates / updates / unchanged / duplicate identity candidates / unknown properties / blockers / evidence coverage / affected-record counts
- requires explicit field-level supporting EvidenceBindings for source-bound component sets, property definitions, components, properties and abilities
- never treats a source URL alone as field verification
- detects same-normalized-name/different-ID duplicate candidates
- preserves RuleSet isolation and rejects existing-state snapshots from another RuleSet
- prevents `unknown` completeness from claiming an expected count and prevents `complete` unless expected == observed and unresolved == 0
- adds a CLI that exports the generated JSON Schema and emits a machine-readable dry-run report
- adds the YRO BGA `260725-1445` manifest as the first versioned source manifest; it intentionally contains **0 individual cards** and `completeness=unknown` because the first-party full card list is still unavailable
- adds targeted CI and uploads both the JSON Schema and YRO dry-run report as artifacts

## Command

```bash
PYTHONPATH=backend uv run python backend/scripts/component_ingest.py \
  backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml \
  --resolved-ruleset-id <resolved UUID>
```

Schema export:

```bash
PYTHONPATH=backend uv run python backend/scripts/component_ingest.py \
  backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml \
  --schema
```

## Scope boundary

This PR deliberately does not claim #178 complete. The remaining work after this contract slice is:

1. thin production RuleSet resolver / read-back adapter;
2. evidence-gated idempotent upsert path;
3. production API read-back verification;
4. one tile-centric and one dice/token-centric rollout fixture with sufficient primary sources.

#178 should remain open until those genericity gates pass.