### PR TITLE
feat: add atomic component ingestion apply path

### DIFF
--- a/.github/workflows/test-component-ingestion-rpc.yml
+++ b/.github/workflows/test-component-ingestion-rpc.yml
@@ -1,0 +1,305 @@
+name: Component ingestion RPC
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/models/component_ingestion.py"
+      - "backend/app/services/component_ingestion.py"
+      - "backend/app/services/component_ingestion_repository.py"
+      - "backend/scripts/component_ingest.py"
+      - "backend/data/component_ingestion/**"
+      - "backend/app/db/migrations/019_component_ingestion_rpc.sql"
+      - "backend/tests/test_component_ingestion.py"
+      - "backend/tests/test_component_ingestion_repository.py"
+      - ".github/workflows/test-component-ingestion-rpc.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/app/models/component_ingestion.py"
+      - "backend/app/services/component_ingestion.py"
+      - "backend/app/services/component_ingestion_repository.py"
+      - "backend/scripts/component_ingest.py"
+      - "backend/data/component_ingestion/**"
+      - "backend/app/db/migrations/019_component_ingestion_rpc.sql"
+      - "backend/tests/test_component_ingestion.py"
+      - "backend/tests/test_component_ingestion_repository.py"
+      - ".github/workflows/test-component-ingestion-rpc.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  component-ingestion-rpc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: component_ingestion_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d component_ingestion_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/component_ingestion_test
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile and lint ingestion apply slice
+        shell: bash
+        run: |
+          uv run python -m compileall -q \
+            backend/app/models/component_ingestion.py \
+            backend/app/services/component_ingestion.py \
+            backend/app/services/component_ingestion_repository.py \
+            backend/scripts/component_ingest.py \
+            backend/tests/test_component_ingestion.py \
+            backend/tests/test_component_ingestion_repository.py
+          uv run --with ruff ruff check \
+            backend/app/models/component_ingestion.py \
+            backend/app/services/component_ingestion.py \
+            backend/app/services/component_ingestion_repository.py \
+            backend/scripts/component_ingest.py \
+            backend/tests/test_component_ingestion.py \
+            backend/tests/test_component_ingestion_repository.py
+
+      - name: Run manifest and plan regression tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_component_ingestion.py
+          backend/tests/test_component_ingestion_repository.py
+          backend/tests/test_component_evidence_targets.py
+          backend/tests/test_component_catalog.py
+
+      - name: Build canonical schema through migration 019
+        shell: bash
+        run: |
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          CREATE ROLE anon NOLOGIN;
+          CREATE ROLE authenticated NOLOGIN;
+          CREATE ROLE service_role NOLOGIN;
+          CREATE TABLE public.game_works (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid()
+          );
+          CREATE TABLE public.games (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            slug text NOT NULL UNIQUE,
+            title text,
+            work_id uuid REFERENCES public.game_works(id),
+            identity_status text NOT NULL DEFAULT 'unverified'
+          );
+          INSERT INTO public.game_works(id) VALUES ('00000000-0000-0000-0000-000000000010');
+          INSERT INTO public.games(id, slug, title, work_id, identity_status)
+          VALUES (
+            '00000000-0000-0000-0000-000000000001',
+            'fixture-game',
+            'Fixture Game',
+            '00000000-0000-0000-0000-000000000010',
+            'verified'
+          );
+          SQL
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/010_rule_graph.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/011_concept_taxonomy.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/013_ruleset_identity.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/014_component_catalog.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/015_claim_evidence.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/018_component_evidence_targets.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/app/db/migrations/019_component_ingestion_rpc.sql
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          INSERT INTO public.rule_sets(
+            id, game_id, work_id, version, language_code, edition_label,
+            platform, revision_label, status, verification_status, is_active
+          ) VALUES (
+            '00000000-0000-0000-0000-000000000178',
+            '00000000-0000-0000-0000-000000000001',
+            '00000000-0000-0000-0000-000000000010',
+            1, 'en', 'Fixture Edition', 'Fixture Platform', 'r1', 'active', 'source_bound', true
+          );
+          SQL
+
+      - name: Apply the same atomic payload twice
+        shell: bash
+        run: |
+          cat > /tmp/apply_fixture.sql <<'SQL'
+          SELECT public.apply_component_ingestion_v1($payload$
+          {
+            "schema_version": "1.0",
+            "game_slug": "fixture-game",
+            "game_id": "00000000-0000-0000-0000-000000000001",
+            "ruleset_id": "00000000-0000-0000-0000-000000000178",
+            "completeness": "complete",
+            "expected_count": 1,
+            "unresolved_count": 0,
+            "catalog_metadata": {"component_ingestion": {"schema_version": "1.0", "completeness": "complete"}},
+            "sources": [
+              {
+                "source_id": "source:fixture:rpc",
+                "url": "https://example.com/components",
+                "source_type": "publisher_component_list",
+                "revision_label": "r1",
+                "trust_metadata": {"authority": "publisher", "extraction_method": "fixture"}
+              }
+            ],
+            "source_locators": [
+              {
+                "locator_id": "locator:fixture:rpc",
+                "source_id": "source:fixture:rpc",
+                "section_heading": "Components"
+              }
+            ],
+            "component_sets": [
+              {
+                "component_set_id": "cards",
+                "canonical_name": "Cards",
+                "kind": "card",
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:rpc"],
+                "metadata": {}
+              }
+            ],
+            "property_definitions": [
+              {
+                "property_key": "rank",
+                "labels": {"en": "Rank"},
+                "value_type": "integer",
+                "cardinality": "one",
+                "enum_values": [],
+                "filterable": true,
+                "sortable": true,
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:rpc"],
+                "metadata": {}
+              }
+            ],
+            "components": [
+              {
+                "component_id": "card.alpha",
+                "component_set_id": "cards",
+                "canonical_name": "Alpha",
+                "kind": "card",
+                "quantity": 1,
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:rpc"],
+                "metadata": {}
+              }
+            ],
+            "component_properties": [
+              {
+                "component_id": "card.alpha",
+                "property_key": "rank",
+                "value_type": "integer",
+                "cardinality": "one",
+                "ordinal": 0,
+                "integer_value": 1,
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:rpc"],
+                "metadata": {}
+              }
+            ],
+            "component_abilities": [
+              {
+                "component_id": "card.alpha",
+                "ability_id": "ability.alpha",
+                "printed_text": "Printed text",
+                "normalized_label": "Normalized effect",
+                "verification_status": "source_bound",
+                "source_ids": ["source:fixture:rpc"],
+                "metadata": {}
+              }
+            ],
+            "component_concepts": [],
+            "component_rule_nodes": [],
+            "ability_concepts": [],
+            "ability_rule_nodes": [],
+            "claims": [
+              {"claim_id":"ci:fixture:claim:set","claim_type":"component_ingestion_component_set","normalized_payload":{"canonical_name":"Cards"},"target_type":"component_set","component_set_id":"cards","lifecycle_status":"accepted","generator_provenance":{}},
+              {"claim_id":"ci:fixture:claim:def","claim_type":"component_ingestion_property_definition","normalized_payload":{"value_type":"integer"},"target_type":"property_definition","property_key":"rank","lifecycle_status":"accepted","generator_provenance":{}},
+              {"claim_id":"ci:fixture:claim:component","claim_type":"component_ingestion_component","normalized_payload":{"canonical_name":"Alpha"},"target_type":"component","component_id":"card.alpha","lifecycle_status":"accepted","generator_provenance":{}},
+              {"claim_id":"ci:fixture:claim:property","claim_type":"component_ingestion_component_property","normalized_payload":{"value":1},"target_type":"component_property","component_id":"card.alpha","property_key":"rank","ordinal":0,"lifecycle_status":"accepted","generator_provenance":{}},
+              {"claim_id":"ci:fixture:claim:printed","claim_type":"component_ingestion_ability_printed_text","normalized_payload":{"value":"Printed text"},"target_type":"ability_printed_text","ability_id":"ability.alpha","lifecycle_status":"accepted","generator_provenance":{}},
+              {"claim_id":"ci:fixture:claim:normalized","claim_type":"component_ingestion_ability_normalized","normalized_payload":{"value":"Normalized effect"},"target_type":"ability_normalized","ability_id":"ability.alpha","lifecycle_status":"accepted","generator_provenance":{}}
+            ],
+            "evidence_bindings": [
+              {"binding_id":"ci:fixture:binding:set","claim_id":"ci:fixture:claim:set","source_id":"source:fixture:rpc","locator_id":"locator:fixture:rpc","relation":"supports","reviewer_provenance":{},"generator_provenance":{}},
+              {"binding_id":"ci:fixture:binding:def","claim_id":"ci:fixture:claim:def","source_id":"source:fixture:rpc","locator_id":"locator:fixture:rpc","relation":"supports","reviewer_provenance":{},"generator_provenance":{}},
+              {"binding_id":"ci:fixture:binding:component","claim_id":"ci:fixture:claim:component","source_id":"source:fixture:rpc","locator_id":"locator:fixture:rpc","relation":"supports","reviewer_provenance":{},"generator_provenance":{}},
+              {"binding_id":"ci:fixture:binding:property","claim_id":"ci:fixture:claim:property","source_id":"source:fixture:rpc","locator_id":"locator:fixture:rpc","relation":"supports","reviewer_provenance":{},"generator_provenance":{}},
+              {"binding_id":"ci:fixture:binding:printed","claim_id":"ci:fixture:claim:printed","source_id":"source:fixture:rpc","locator_id":"locator:fixture:rpc","relation":"supports","reviewer_provenance":{},"generator_provenance":{}},
+              {"binding_id":"ci:fixture:binding:normalized","claim_id":"ci:fixture:claim:normalized","source_id":"source:fixture:rpc","locator_id":"locator:fixture:rpc","relation":"supports","reviewer_provenance":{},"generator_provenance":{}}
+            ]
+          }
+          $payload$::jsonb);
+          SQL
+
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/apply_fixture.sql
+          psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/apply_fixture.sql
+
+      - name: Verify idempotent cardinalities and function permissions
+        shell: bash
+        run: |
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_catalogs;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_sets;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_property_definitions;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.components;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_properties;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_abilities;")" = "1"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.claims;")" = "6"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.evidence_bindings;")" = "6"
+          test "$(psql "$DATABASE_URL" -Atc "select has_function_privilege('anon','public.apply_component_ingestion_v1(jsonb)','EXECUTE');")" = "f"
+          test "$(psql "$DATABASE_URL" -Atc "select has_function_privilege('authenticated','public.apply_component_ingestion_v1(jsonb)','EXECUTE');")" = "f"
+          test "$(psql "$DATABASE_URL" -Atc "select has_function_privilege('service_role','public.apply_component_ingestion_v1(jsonb)','EXECUTE');")" = "t"
+
+      - name: Verify atomic rollback on invalid evidence target
+        shell: bash
+        run: |
+          cat > /tmp/invalid_apply.sql <<'SQL'
+          SELECT public.apply_component_ingestion_v1($payload$
+          {
+            "schema_version":"1.0",
+            "game_slug":"fixture-game",
+            "game_id":"00000000-0000-0000-0000-000000000001",
+            "ruleset_id":"00000000-0000-0000-0000-000000000178",
+            "completeness":"partial",
+            "catalog_metadata":{},
+            "sources":[{"source_id":"source:fixture:rollback","url":"https://example.com/rollback","source_type":"fixture","trust_metadata":{}}],
+            "source_locators":[{"locator_id":"locator:fixture:rollback","source_id":"source:fixture:rollback","section_heading":"Rollback"}],
+            "component_sets":[{"component_set_id":"rollback-cards","canonical_name":"Rollback Cards","kind":"card","verification_status":"source_bound","source_ids":["source:fixture:rollback"],"metadata":{}}],
+            "property_definitions":[],
+            "components":[{"component_id":"card.rollback","component_set_id":"rollback-cards","canonical_name":"Rollback","kind":"card","verification_status":"source_bound","source_ids":["source:fixture:rollback"],"metadata":{}}],
+            "component_properties":[],
+            "component_abilities":[],
+            "component_concepts":[],
+            "component_rule_nodes":[],
+            "ability_concepts":[],
+            "ability_rule_nodes":[],
+            "claims":[{"claim_id":"ci:fixture:claim:rollback-invalid","claim_type":"component_ingestion_component","normalized_payload":{},"target_type":"component","component_id":"card.does-not-exist","lifecycle_status":"accepted","generator_provenance":{}}],
+            "evidence_bindings":[]
+          }
+          $payload$::jsonb);
+          SQL
+
+          if psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f /tmp/invalid_apply.sql; then
+            echo "invalid ingestion unexpectedly succeeded"
+            exit 1
+          fi
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.components where component_id='card.rollback';")" = "0"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.component_sets where component_set_id='rollback-cards';")" = "0"
+          test "$(psql "$DATABASE_URL" -Atc "select count(*) from public.evidence_sources where source_id='source:fixture:rollback';")" = "0"

--- a/backend/app/db/migrations/019_component_ingestion_rpc.sql
+++ b/backend/app/db/migrations/019_component_ingestion_rpc.sql
@@ -1,0 +1,417 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.apply_component_ingestion_v1(payload jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  v_item jsonb;
+  v_game_id uuid;
+  v_rule_set_id uuid;
+  v_catalog_id uuid;
+  v_source_ids text[];
+  v_enum_values text[];
+  v_claim_id text;
+  v_binding_id text;
+BEGIN
+  IF COALESCE(payload->>'schema_version', '') <> '1.0' THEN
+    RAISE EXCEPTION 'unsupported component ingestion schema_version';
+  END IF;
+  IF COALESCE(payload->>'game_slug', '') = '' OR COALESCE(payload->>'ruleset_id', '') = '' THEN
+    RAISE EXCEPTION 'game_slug and ruleset_id are required';
+  END IF;
+
+  v_rule_set_id := (payload->>'ruleset_id')::uuid;
+  SELECT g.id
+    INTO v_game_id
+  FROM public.games g
+  JOIN public.rule_sets rs ON rs.game_id = g.id
+  WHERE g.slug = payload->>'game_slug'
+    AND g.identity_status = 'verified'
+    AND rs.id = v_rule_set_id
+    AND g.id::text = payload->>'game_id';
+
+  IF v_game_id IS NULL THEN
+    RAISE EXCEPTION 'verified Game / RuleSet binding did not resolve';
+  END IF;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'sources', '[]'::jsonb))
+  LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM public.evidence_sources es
+      WHERE es.source_id = v_item->>'source_id'
+        AND es.url IS NOT NULL
+        AND v_item->>'url' IS NOT NULL
+        AND es.url <> v_item->>'url'
+    ) THEN
+      RAISE EXCEPTION 'source_id % is already bound to a different URL', v_item->>'source_id';
+    END IF;
+
+    INSERT INTO public.evidence_sources (
+      source_id, url, source_type, revision_label, trust_metadata
+    ) VALUES (
+      v_item->>'source_id',
+      v_item->>'url',
+      v_item->>'source_type',
+      NULLIF(v_item->>'revision_label', ''),
+      COALESCE(v_item->'trust_metadata', '{}'::jsonb)
+    )
+    ON CONFLICT (source_id) DO UPDATE SET
+      url = COALESCE(public.evidence_sources.url, EXCLUDED.url),
+      source_type = EXCLUDED.source_type,
+      revision_label = COALESCE(EXCLUDED.revision_label, public.evidence_sources.revision_label),
+      trust_metadata = public.evidence_sources.trust_metadata || EXCLUDED.trust_metadata,
+      updated_at = now();
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'source_locators', '[]'::jsonb))
+  LOOP
+    IF EXISTS (
+      SELECT 1
+      FROM public.source_locators sl
+      WHERE sl.locator_id = v_item->>'locator_id'
+        AND sl.source_id <> v_item->>'source_id'
+    ) THEN
+      RAISE EXCEPTION 'locator_id % is already bound to a different source', v_item->>'locator_id';
+    END IF;
+
+    INSERT INTO public.source_locators (
+      locator_id, source_id, page_number, section_heading, anchor, selector,
+      structured_path, external_reference
+    ) VALUES (
+      v_item->>'locator_id',
+      v_item->>'source_id',
+      NULLIF(v_item->>'page_number', '')::integer,
+      NULLIF(v_item->>'section_heading', ''),
+      NULLIF(v_item->>'anchor', ''),
+      NULLIF(v_item->>'selector', ''),
+      NULLIF(v_item->>'structured_path', ''),
+      NULLIF(v_item->>'external_reference', '')
+    )
+    ON CONFLICT (locator_id) DO UPDATE SET
+      page_number = EXCLUDED.page_number,
+      section_heading = EXCLUDED.section_heading,
+      anchor = EXCLUDED.anchor,
+      selector = EXCLUDED.selector,
+      structured_path = EXCLUDED.structured_path,
+      external_reference = EXCLUDED.external_reference;
+  END LOOP;
+
+  INSERT INTO public.component_catalogs (rule_set_id, schema_version, metadata)
+  VALUES (
+    v_rule_set_id,
+    payload->>'schema_version',
+    COALESCE(payload->'catalog_metadata', '{}'::jsonb)
+  )
+  ON CONFLICT (rule_set_id) DO UPDATE SET
+    schema_version = EXCLUDED.schema_version,
+    metadata = public.component_catalogs.metadata || EXCLUDED.metadata,
+    updated_at = now()
+  RETURNING id INTO v_catalog_id;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'component_sets', '[]'::jsonb))
+  LOOP
+    v_source_ids := ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_item->'source_ids', '[]'::jsonb)));
+    INSERT INTO public.component_sets (
+      catalog_id, rule_set_id, component_set_id, canonical_name, kind,
+      parent_component_set_id, verification_status, source_ids, metadata
+    ) VALUES (
+      v_catalog_id,
+      v_rule_set_id,
+      v_item->>'component_set_id',
+      v_item->>'canonical_name',
+      NULLIF(v_item->>'kind', ''),
+      NULLIF(v_item->>'parent_component_set_id', ''),
+      COALESCE(v_item->>'verification_status', 'unknown'),
+      v_source_ids,
+      COALESCE(v_item->'metadata', '{}'::jsonb)
+    )
+    ON CONFLICT (rule_set_id, component_set_id) DO UPDATE SET
+      catalog_id = EXCLUDED.catalog_id,
+      canonical_name = EXCLUDED.canonical_name,
+      kind = EXCLUDED.kind,
+      parent_component_set_id = EXCLUDED.parent_component_set_id,
+      verification_status = EXCLUDED.verification_status,
+      source_ids = EXCLUDED.source_ids,
+      metadata = public.component_sets.metadata || EXCLUDED.metadata,
+      updated_at = now();
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'property_definitions', '[]'::jsonb))
+  LOOP
+    v_source_ids := ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_item->'source_ids', '[]'::jsonb)));
+    v_enum_values := ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_item->'enum_values', '[]'::jsonb)));
+    INSERT INTO public.component_property_definitions (
+      catalog_id, rule_set_id, property_key, labels, value_type, cardinality,
+      unit, enum_values, filterable, sortable, verification_status, source_ids, metadata
+    ) VALUES (
+      v_catalog_id,
+      v_rule_set_id,
+      v_item->>'property_key',
+      COALESCE(v_item->'labels', '{}'::jsonb),
+      v_item->>'value_type',
+      COALESCE(v_item->>'cardinality', 'one'),
+      NULLIF(v_item->>'unit', ''),
+      v_enum_values,
+      COALESCE((v_item->>'filterable')::boolean, false),
+      COALESCE((v_item->>'sortable')::boolean, false),
+      COALESCE(v_item->>'verification_status', 'unknown'),
+      v_source_ids,
+      COALESCE(v_item->'metadata', '{}'::jsonb)
+    )
+    ON CONFLICT (rule_set_id, property_key) DO UPDATE SET
+      catalog_id = EXCLUDED.catalog_id,
+      labels = EXCLUDED.labels,
+      value_type = EXCLUDED.value_type,
+      cardinality = EXCLUDED.cardinality,
+      unit = EXCLUDED.unit,
+      enum_values = EXCLUDED.enum_values,
+      filterable = EXCLUDED.filterable,
+      sortable = EXCLUDED.sortable,
+      verification_status = EXCLUDED.verification_status,
+      source_ids = EXCLUDED.source_ids,
+      metadata = public.component_property_definitions.metadata || EXCLUDED.metadata,
+      updated_at = now();
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'components', '[]'::jsonb))
+  LOOP
+    v_source_ids := ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_item->'source_ids', '[]'::jsonb)));
+    INSERT INTO public.components (
+      catalog_id, rule_set_id, component_id, component_set_id, canonical_name,
+      kind, quantity, verification_status, source_ids, metadata
+    ) VALUES (
+      v_catalog_id,
+      v_rule_set_id,
+      v_item->>'component_id',
+      NULLIF(v_item->>'component_set_id', ''),
+      v_item->>'canonical_name',
+      v_item->>'kind',
+      NULLIF(v_item->>'quantity', '')::integer,
+      COALESCE(v_item->>'verification_status', 'unknown'),
+      v_source_ids,
+      COALESCE(v_item->'metadata', '{}'::jsonb)
+    )
+    ON CONFLICT (rule_set_id, component_id) DO UPDATE SET
+      catalog_id = EXCLUDED.catalog_id,
+      component_set_id = EXCLUDED.component_set_id,
+      canonical_name = EXCLUDED.canonical_name,
+      kind = EXCLUDED.kind,
+      quantity = EXCLUDED.quantity,
+      verification_status = EXCLUDED.verification_status,
+      source_ids = EXCLUDED.source_ids,
+      metadata = public.components.metadata || EXCLUDED.metadata,
+      updated_at = now();
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'component_properties', '[]'::jsonb))
+  LOOP
+    v_source_ids := ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_item->'source_ids', '[]'::jsonb)));
+    INSERT INTO public.component_properties (
+      rule_set_id, component_id, property_key, value_type, cardinality, ordinal,
+      text_value, integer_value, number_value, boolean_value, enum_value,
+      concept_ref_id, component_ref_id, verification_status, source_ids, metadata
+    ) VALUES (
+      v_rule_set_id,
+      v_item->>'component_id',
+      v_item->>'property_key',
+      v_item->>'value_type',
+      v_item->>'cardinality',
+      (v_item->>'ordinal')::integer,
+      NULLIF(v_item->>'text_value', ''),
+      NULLIF(v_item->>'integer_value', '')::bigint,
+      NULLIF(v_item->>'number_value', '')::double precision,
+      NULLIF(v_item->>'boolean_value', '')::boolean,
+      NULLIF(v_item->>'enum_value', ''),
+      NULLIF(v_item->>'concept_ref_id', ''),
+      NULLIF(v_item->>'component_ref_id', ''),
+      COALESCE(v_item->>'verification_status', 'unknown'),
+      v_source_ids,
+      COALESCE(v_item->'metadata', '{}'::jsonb)
+    )
+    ON CONFLICT (rule_set_id, component_id, property_key, ordinal) DO UPDATE SET
+      value_type = EXCLUDED.value_type,
+      cardinality = EXCLUDED.cardinality,
+      text_value = EXCLUDED.text_value,
+      integer_value = EXCLUDED.integer_value,
+      number_value = EXCLUDED.number_value,
+      boolean_value = EXCLUDED.boolean_value,
+      enum_value = EXCLUDED.enum_value,
+      concept_ref_id = EXCLUDED.concept_ref_id,
+      component_ref_id = EXCLUDED.component_ref_id,
+      verification_status = EXCLUDED.verification_status,
+      source_ids = EXCLUDED.source_ids,
+      metadata = public.component_properties.metadata || EXCLUDED.metadata;
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'component_abilities', '[]'::jsonb))
+  LOOP
+    v_source_ids := ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_item->'source_ids', '[]'::jsonb)));
+    INSERT INTO public.component_abilities (
+      rule_set_id, component_id, ability_id, printed_text, normalized_label,
+      verification_status, source_ids, metadata
+    ) VALUES (
+      v_rule_set_id,
+      v_item->>'component_id',
+      v_item->>'ability_id',
+      NULLIF(v_item->>'printed_text', ''),
+      NULLIF(v_item->>'normalized_label', ''),
+      COALESCE(v_item->>'verification_status', 'unknown'),
+      v_source_ids,
+      COALESCE(v_item->'metadata', '{}'::jsonb)
+    )
+    ON CONFLICT (rule_set_id, ability_id) DO UPDATE SET
+      component_id = EXCLUDED.component_id,
+      printed_text = EXCLUDED.printed_text,
+      normalized_label = EXCLUDED.normalized_label,
+      verification_status = EXCLUDED.verification_status,
+      source_ids = EXCLUDED.source_ids,
+      metadata = public.component_abilities.metadata || EXCLUDED.metadata,
+      updated_at = now();
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'component_concepts', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.component_concepts (rule_set_id, component_id, concept_id, reference_kind)
+    VALUES (v_rule_set_id, v_item->>'component_id', v_item->>'concept_id', COALESCE(v_item->>'reference_kind', 'classifies'))
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'component_rule_nodes', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.component_rule_nodes (rule_set_id, component_id, rule_id, reference_kind)
+    VALUES (v_rule_set_id, v_item->>'component_id', v_item->>'rule_id', COALESCE(v_item->>'reference_kind', 'governed_by'))
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'ability_concepts', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.component_ability_concepts (rule_set_id, ability_id, concept_id)
+    VALUES (v_rule_set_id, v_item->>'ability_id', v_item->>'concept_id')
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'ability_rule_nodes', '[]'::jsonb))
+  LOOP
+    INSERT INTO public.component_ability_rule_nodes (rule_set_id, ability_id, rule_id)
+    VALUES (v_rule_set_id, v_item->>'ability_id', v_item->>'rule_id')
+    ON CONFLICT DO NOTHING;
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'claims', '[]'::jsonb))
+  LOOP
+    v_claim_id := v_item->>'claim_id';
+    IF EXISTS (
+      SELECT 1
+      FROM public.claims c
+      WHERE c.claim_id = v_claim_id
+        AND (
+          c.rule_set_id <> v_rule_set_id OR
+          c.target_type <> v_item->>'target_type' OR
+          c.rule_id IS DISTINCT FROM NULLIF(v_item->>'rule_id', '') OR
+          c.component_id IS DISTINCT FROM NULLIF(v_item->>'component_id', '') OR
+          c.component_set_id IS DISTINCT FROM NULLIF(v_item->>'component_set_id', '') OR
+          c.property_key IS DISTINCT FROM NULLIF(v_item->>'property_key', '') OR
+          c.ordinal IS DISTINCT FROM NULLIF(v_item->>'ordinal', '')::integer OR
+          c.ability_id IS DISTINCT FROM NULLIF(v_item->>'ability_id', '') OR
+          c.field_path IS DISTINCT FROM NULLIF(v_item->>'field_path', '')
+        )
+    ) THEN
+      RAISE EXCEPTION 'claim_id % collides with a different target', v_claim_id;
+    END IF;
+
+    INSERT INTO public.claims (
+      claim_id, rule_set_id, claim_type, normalized_payload, target_type,
+      rule_id, component_id, component_set_id, property_key, ordinal, ability_id, field_path,
+      lifecycle_status, generator_provenance
+    ) VALUES (
+      v_claim_id,
+      v_rule_set_id,
+      v_item->>'claim_type',
+      COALESCE(v_item->'normalized_payload', '{}'::jsonb),
+      v_item->>'target_type',
+      NULLIF(v_item->>'rule_id', ''),
+      NULLIF(v_item->>'component_id', ''),
+      NULLIF(v_item->>'component_set_id', ''),
+      NULLIF(v_item->>'property_key', ''),
+      NULLIF(v_item->>'ordinal', '')::integer,
+      NULLIF(v_item->>'ability_id', ''),
+      NULLIF(v_item->>'field_path', ''),
+      COALESCE(v_item->>'lifecycle_status', 'candidate'),
+      COALESCE(v_item->'generator_provenance', '{}'::jsonb)
+    )
+    ON CONFLICT (claim_id) DO UPDATE SET
+      claim_type = EXCLUDED.claim_type,
+      normalized_payload = EXCLUDED.normalized_payload,
+      lifecycle_status = EXCLUDED.lifecycle_status,
+      generator_provenance = public.claims.generator_provenance || EXCLUDED.generator_provenance,
+      updated_at = now();
+  END LOOP;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(COALESCE(payload->'evidence_bindings', '[]'::jsonb))
+  LOOP
+    v_binding_id := v_item->>'binding_id';
+    IF EXISTS (
+      SELECT 1
+      FROM public.evidence_bindings eb
+      WHERE eb.binding_id = v_binding_id
+        AND (
+          eb.claim_id <> v_item->>'claim_id' OR
+          eb.source_id <> v_item->>'source_id' OR
+          eb.locator_id IS DISTINCT FROM NULLIF(v_item->>'locator_id', '') OR
+          eb.relation <> v_item->>'relation'
+        )
+    ) THEN
+      RAISE EXCEPTION 'binding_id % collides with a different evidence relation', v_binding_id;
+    END IF;
+
+    INSERT INTO public.evidence_bindings (
+      binding_id, claim_id, source_id, locator_id, relation,
+      reviewer_provenance, generator_provenance
+    ) VALUES (
+      v_binding_id,
+      v_item->>'claim_id',
+      v_item->>'source_id',
+      NULLIF(v_item->>'locator_id', ''),
+      v_item->>'relation',
+      COALESCE(v_item->'reviewer_provenance', '{}'::jsonb),
+      COALESCE(v_item->'generator_provenance', '{}'::jsonb)
+    )
+    ON CONFLICT (binding_id) DO UPDATE SET
+      reviewer_provenance = public.evidence_bindings.reviewer_provenance || EXCLUDED.reviewer_provenance,
+      generator_provenance = public.evidence_bindings.generator_provenance || EXCLUDED.generator_provenance;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ruleset_id', v_rule_set_id::text,
+    'catalog_id', v_catalog_id::text,
+    'persisted', jsonb_build_object(
+      'component_sets', (SELECT count(*) FROM public.component_sets cs WHERE cs.rule_set_id = v_rule_set_id),
+      'property_definitions', (SELECT count(*) FROM public.component_property_definitions pd WHERE pd.rule_set_id = v_rule_set_id),
+      'components', (SELECT count(*) FROM public.components c WHERE c.rule_set_id = v_rule_set_id),
+      'component_properties', (SELECT count(*) FROM public.component_properties cp WHERE cp.rule_set_id = v_rule_set_id),
+      'component_abilities', (SELECT count(*) FROM public.component_abilities ca WHERE ca.rule_set_id = v_rule_set_id),
+      'claims', (SELECT count(*) FROM public.claims c WHERE c.rule_set_id = v_rule_set_id)
+    )
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.apply_component_ingestion_v1(jsonb) FROM PUBLIC;
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon') THEN
+    REVOKE ALL ON FUNCTION public.apply_component_ingestion_v1(jsonb) FROM anon;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN
+    REVOKE ALL ON FUNCTION public.apply_component_ingestion_v1(jsonb) FROM authenticated;
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
+    GRANT EXECUTE ON FUNCTION public.apply_component_ingestion_v1(jsonb) TO service_role;
+  END IF;
+END $$;
+
+COMMIT;

--- a/backend/app/models/component_ingestion.py
+++ b/backend/app/models/component_ingestion.py
@@ -13,8 +13,17 @@ from app.models.component_catalog import (
     ComponentVerificationStatus,
     PropertyDefinition,
 )
+from app.models.evidence import ClaimTarget, EvidenceRelation, EvidenceTargetType, SourceLocator
 
 COMPONENT_SOURCE_MANIFEST_SCHEMA_VERSION = "1.0"
+_COMPONENT_INGEST_TARGET_TYPES = {
+    EvidenceTargetType.COMPONENT,
+    EvidenceTargetType.COMPONENT_SET,
+    EvidenceTargetType.PROPERTY_DEFINITION,
+    EvidenceTargetType.COMPONENT_PROPERTY,
+    EvidenceTargetType.ABILITY_PRINTED_TEXT,
+    EvidenceTargetType.ABILITY_NORMALIZED,
+}
 
 
 class ManifestModel(BaseModel):
@@ -34,13 +43,6 @@ class SourceAuthority(StrEnum):
     REPLAY = "replay"
     LOG = "log"
     OTHER = "other"
-
-
-class EvidenceRelation(StrEnum):
-    SUPPORTS = "supports"
-    CONTRADICTS = "contradicts"
-    CONTEXTUALIZES = "contextualizes"
-    UNRESOLVED = "unresolved"
 
 
 class RuleSetSelector(ManifestModel):
@@ -94,10 +96,16 @@ class ManifestComponent(ManifestModel):
 
 class ManifestEvidenceBinding(ManifestModel):
     binding_id: str = Field(pattern=STABLE_ID_PATTERN)
-    target_path: str = Field(min_length=1)
+    target: ClaimTarget
     source_id: str = Field(pattern=STABLE_ID_PATTERN)
     locator_id: str = Field(pattern=STABLE_ID_PATTERN)
     relation: EvidenceRelation = EvidenceRelation.SUPPORTS
+
+    @model_validator(mode="after")
+    def require_component_ingestion_target(self):
+        if self.target.target_type not in _COMPONENT_INGEST_TARGET_TYPES:
+            raise ValueError("component ingestion evidence binding has unsupported target_type")
+        return self
 
 
 class ComponentSourceManifest(ManifestModel):
@@ -105,6 +113,7 @@ class ComponentSourceManifest(ManifestModel):
     game_slug: str = Field(pattern=r"^[a-z0-9][a-z0-9-]{1,127}$")
     ruleset: RuleSetSelector
     sources: list[ComponentManifestSource] = Field(min_length=1)
+    source_locators: list[SourceLocator] = Field(default_factory=list)
     component_sets: list[ManifestComponentSet] = Field(default_factory=list)
     property_definitions: list[PropertyDefinition] = Field(default_factory=list)
     components: list[ManifestComponent] = Field(default_factory=list)
@@ -121,6 +130,14 @@ class ComponentSourceManifest(ManifestModel):
             raise ValueError("duplicate source_id")
         known_sources = set(source_ids)
 
+        locator_ids = [locator.locator_id for locator in self.source_locators]
+        if len(locator_ids) != len(set(locator_ids)):
+            raise ValueError("duplicate locator_id")
+        locators = {locator.locator_id: locator for locator in self.source_locators}
+        for locator in self.source_locators:
+            if locator.source_id not in known_sources:
+                raise ValueError(f"locator {locator.locator_id} references unknown source")
+
         set_ids = [item.component_set_id for item in self.component_sets]
         if len(set_ids) != len(set(set_ids)):
             raise ValueError("duplicate component_set_id")
@@ -133,12 +150,14 @@ class ComponentSourceManifest(ManifestModel):
         definition_keys = [item.property_key for item in self.property_definitions]
         if len(definition_keys) != len(set(definition_keys)):
             raise ValueError("duplicate property_key")
+        known_definitions = set(definition_keys)
         for definition in self.property_definitions:
             self._require_known_sources(definition.source_ids, known_sources, f"property_definition:{definition.property_key}")
 
         component_ids = [item.component_id for item in self.components]
         if len(component_ids) != len(set(component_ids)):
             raise ValueError("duplicate component_id")
+        components = {item.component_id: item for item in self.components}
         for component in self.components:
             if component.component_set_id and component.component_set_id not in known_sets:
                 raise ValueError(f"component {component.component_id} references unknown component set")
@@ -162,6 +181,12 @@ class ComponentSourceManifest(ManifestModel):
         for binding in self.evidence_bindings:
             if binding.source_id not in known_sources:
                 raise ValueError(f"evidence binding {binding.binding_id} references unknown source")
+            locator = locators.get(binding.locator_id)
+            if locator is None:
+                raise ValueError(f"evidence binding {binding.binding_id} references unknown locator")
+            if locator.source_id != binding.source_id:
+                raise ValueError(f"evidence binding {binding.binding_id} source does not match locator source")
+            self._validate_target(binding.target, known_sets, known_definitions, components)
 
         if self.completeness == CompletenessState.COMPLETE:
             if self.expected_count is None:
@@ -179,6 +204,50 @@ class ComponentSourceManifest(ManifestModel):
         unknown = sorted(set(source_ids) - known_sources)
         if unknown:
             raise ValueError(f"{target} references unknown sources: {', '.join(unknown)}")
+
+    @staticmethod
+    def _validate_target(
+        target: ClaimTarget,
+        known_sets: set[str],
+        known_definitions: set[str],
+        components: dict[str, ManifestComponent],
+    ) -> None:
+        if target.target_type == EvidenceTargetType.COMPONENT_SET:
+            if target.component_set_id not in known_sets:
+                raise ValueError("evidence target references unknown component set")
+            return
+        if target.target_type == EvidenceTargetType.PROPERTY_DEFINITION:
+            if target.property_key not in known_definitions:
+                raise ValueError("evidence target references unknown property definition")
+            return
+        if target.target_type == EvidenceTargetType.COMPONENT:
+            if target.component_id not in components:
+                raise ValueError("evidence target references unknown component")
+            return
+        if target.target_type == EvidenceTargetType.COMPONENT_PROPERTY:
+            component = components.get(target.component_id or "")
+            if component is None:
+                raise ValueError("component_property evidence target references unknown component")
+            prop = next((item for item in component.properties if item.property_key == target.property_key), None)
+            if prop is None:
+                raise ValueError("component_property evidence target references unknown component property")
+            if target.ordinal is None or target.ordinal >= len(prop.values):
+                raise ValueError("component_property evidence target ordinal is out of range")
+            return
+        if target.target_type in {EvidenceTargetType.ABILITY_PRINTED_TEXT, EvidenceTargetType.ABILITY_NORMALIZED}:
+            matches = [
+                ability
+                for component in components.values()
+                for ability in component.abilities
+                if ability.ability_id == target.ability_id
+            ]
+            if len(matches) != 1:
+                raise ValueError("ability evidence target must resolve to exactly one manifest ability")
+            ability = matches[0]
+            if target.target_type == EvidenceTargetType.ABILITY_PRINTED_TEXT and not ability.printed_text:
+                raise ValueError("ability_printed_text target requires printed_text")
+            if target.target_type == EvidenceTargetType.ABILITY_NORMALIZED and not ability.normalized_label:
+                raise ValueError("ability_normalized target requires normalized_label")
 
 
 class EvidenceCoverage(ManifestModel):

--- a/backend/app/models/component_ingestion.py
+++ b/backend/app/models/component_ingestion.py
@@ -124,20 +124,32 @@ class ComponentSourceManifest(ManifestModel):
     notes: list[str] = Field(default_factory=list)
 
     @model_validator(mode="after")
-    def validate_manifest(self):  # noqa: PLR0912 - fail-closed contract is intentionally explicit
+    def validate_manifest(self):
+        known_sources = self._validate_sources()
+        locators = self._validate_locators(known_sources)
+        known_sets = self._validate_sets(known_sources)
+        known_definitions = self._validate_definitions(known_sources)
+        components = self._validate_components(known_sources, known_sets)
+        self._validate_bindings(known_sources, locators, known_sets, known_definitions, components)
+        self._validate_completeness()
+        return self
+
+    def _validate_sources(self) -> set[str]:
         source_ids = [source.source_id for source in self.sources]
         if len(source_ids) != len(set(source_ids)):
             raise ValueError("duplicate source_id")
-        known_sources = set(source_ids)
+        return set(source_ids)
 
+    def _validate_locators(self, known_sources: set[str]) -> dict[str, SourceLocator]:
         locator_ids = [locator.locator_id for locator in self.source_locators]
         if len(locator_ids) != len(set(locator_ids)):
             raise ValueError("duplicate locator_id")
-        locators = {locator.locator_id: locator for locator in self.source_locators}
         for locator in self.source_locators:
             if locator.source_id not in known_sources:
                 raise ValueError(f"locator {locator.locator_id} references unknown source")
+        return {locator.locator_id: locator for locator in self.source_locators}
 
+    def _validate_sets(self, known_sources: set[str]) -> set[str]:
         set_ids = [item.component_set_id for item in self.component_sets]
         if len(set_ids) != len(set(set_ids)):
             raise ValueError("duplicate component_set_id")
@@ -146,18 +158,24 @@ class ComponentSourceManifest(ManifestModel):
             if item.parent_component_set_id and item.parent_component_set_id not in known_sets:
                 raise ValueError("parent component set is not present in manifest")
             self._require_known_sources(item.source_ids, known_sources, f"component_set:{item.component_set_id}")
+        return known_sets
 
+    def _validate_definitions(self, known_sources: set[str]) -> set[str]:
         definition_keys = [item.property_key for item in self.property_definitions]
         if len(definition_keys) != len(set(definition_keys)):
             raise ValueError("duplicate property_key")
-        known_definitions = set(definition_keys)
         for definition in self.property_definitions:
             self._require_known_sources(definition.source_ids, known_sources, f"property_definition:{definition.property_key}")
+        return set(definition_keys)
 
+    def _validate_components(
+        self,
+        known_sources: set[str],
+        known_sets: set[str],
+    ) -> dict[str, ManifestComponent]:
         component_ids = [item.component_id for item in self.components]
         if len(component_ids) != len(set(component_ids)):
             raise ValueError("duplicate component_id")
-        components = {item.component_id: item for item in self.components}
         for component in self.components:
             if component.component_set_id and component.component_set_id not in known_sets:
                 raise ValueError(f"component {component.component_id} references unknown component set")
@@ -174,7 +192,16 @@ class ComponentSourceManifest(ManifestModel):
                     known_sources,
                     f"component:{component.component_id}:ability:{ability.ability_id}",
                 )
+        return {item.component_id: item for item in self.components}
 
+    def _validate_bindings(
+        self,
+        known_sources: set[str],
+        locators: dict[str, SourceLocator],
+        known_sets: set[str],
+        known_definitions: set[str],
+        components: dict[str, ManifestComponent],
+    ) -> None:
         binding_ids = [binding.binding_id for binding in self.evidence_bindings]
         if len(binding_ids) != len(set(binding_ids)):
             raise ValueError("duplicate evidence binding_id")
@@ -188,6 +215,7 @@ class ComponentSourceManifest(ManifestModel):
                 raise ValueError(f"evidence binding {binding.binding_id} source does not match locator source")
             self._validate_target(binding.target, known_sets, known_definitions, components)
 
+    def _validate_completeness(self) -> None:
         if self.completeness == CompletenessState.COMPLETE:
             if self.expected_count is None:
                 raise ValueError("complete manifest requires source-backed expected_count")
@@ -197,7 +225,6 @@ class ComponentSourceManifest(ManifestModel):
                 raise ValueError("complete manifest cannot have unresolved components")
         elif self.completeness == CompletenessState.UNKNOWN and self.expected_count is not None:
             raise ValueError("unknown completeness cannot claim an expected_count")
-        return self
 
     @staticmethod
     def _require_known_sources(source_ids: list[str], known_sources: set[str], target: str) -> None:
@@ -225,29 +252,37 @@ class ComponentSourceManifest(ManifestModel):
                 raise ValueError("evidence target references unknown component")
             return
         if target.target_type == EvidenceTargetType.COMPONENT_PROPERTY:
-            component = components.get(target.component_id or "")
-            if component is None:
-                raise ValueError("component_property evidence target references unknown component")
-            prop = next((item for item in component.properties if item.property_key == target.property_key), None)
-            if prop is None:
-                raise ValueError("component_property evidence target references unknown component property")
-            if target.ordinal is None or target.ordinal >= len(prop.values):
-                raise ValueError("component_property evidence target ordinal is out of range")
+            ComponentSourceManifest._validate_property_target(target, components)
             return
         if target.target_type in {EvidenceTargetType.ABILITY_PRINTED_TEXT, EvidenceTargetType.ABILITY_NORMALIZED}:
-            matches = [
-                ability
-                for component in components.values()
-                for ability in component.abilities
-                if ability.ability_id == target.ability_id
-            ]
-            if len(matches) != 1:
-                raise ValueError("ability evidence target must resolve to exactly one manifest ability")
-            ability = matches[0]
-            if target.target_type == EvidenceTargetType.ABILITY_PRINTED_TEXT and not ability.printed_text:
-                raise ValueError("ability_printed_text target requires printed_text")
-            if target.target_type == EvidenceTargetType.ABILITY_NORMALIZED and not ability.normalized_label:
-                raise ValueError("ability_normalized target requires normalized_label")
+            ComponentSourceManifest._validate_ability_target(target, components)
+
+    @staticmethod
+    def _validate_property_target(target: ClaimTarget, components: dict[str, ManifestComponent]) -> None:
+        component = components.get(target.component_id or "")
+        if component is None:
+            raise ValueError("component_property evidence target references unknown component")
+        prop = next((item for item in component.properties if item.property_key == target.property_key), None)
+        if prop is None:
+            raise ValueError("component_property evidence target references unknown component property")
+        if target.ordinal is None or target.ordinal >= len(prop.values):
+            raise ValueError("component_property evidence target ordinal is out of range")
+
+    @staticmethod
+    def _validate_ability_target(target: ClaimTarget, components: dict[str, ManifestComponent]) -> None:
+        matches = [
+            ability
+            for component in components.values()
+            for ability in component.abilities
+            if ability.ability_id == target.ability_id
+        ]
+        if len(matches) != 1:
+            raise ValueError("ability evidence target must resolve to exactly one manifest ability")
+        ability = matches[0]
+        if target.target_type == EvidenceTargetType.ABILITY_PRINTED_TEXT and not ability.printed_text:
+            raise ValueError("ability_printed_text target requires printed_text")
+        if target.target_type == EvidenceTargetType.ABILITY_NORMALIZED and not ability.normalized_label:
+            raise ValueError("ability_normalized target requires normalized_label")
 
 
 class EvidenceCoverage(ManifestModel):

--- a/backend/app/services/component_ingestion.py
+++ b/backend/app/services/component_ingestion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import re
 import unicodedata
 from collections import defaultdict
@@ -11,10 +12,10 @@ from app.models.component_ingestion import (
     ComponentIngestAuditReport,
     ComponentSourceManifest,
     EvidenceCoverage,
-    EvidenceRelation,
     ManifestComponent,
     ManifestComponentSet,
 )
+from app.models.evidence import ClaimTarget, EvidenceRelation, EvidenceTargetType
 
 
 class ExistingComponentSnapshot(BaseModel):
@@ -33,6 +34,10 @@ def _normalized_name(value: str) -> str:
 
 def _jsonish(model) -> dict:
     return model.model_dump(mode="json", exclude_none=True)
+
+
+def _target_key(target: ClaimTarget) -> str:
+    return json.dumps(target.model_dump(mode="json", exclude_none=True), sort_keys=True, separators=(",", ":"))
 
 
 class ComponentIngestionDryRun:
@@ -73,6 +78,7 @@ class ComponentIngestionDryRun:
         creates, updates, unchanged = self._component_diff(manifest, existing)
         affected_records = {
             "sources": len(manifest.sources),
+            "source_locators": len(manifest.source_locators),
             "component_sets": len(manifest.component_sets),
             "property_definitions": len(manifest.property_definitions),
             "components": len(manifest.components),
@@ -136,42 +142,65 @@ class ComponentIngestionDryRun:
         buckets: dict[tuple[str, str], list[str]] = defaultdict(list)
         for component in manifest.components:
             buckets[(component.kind.value, _normalized_name(component.canonical_name))].append(component.component_id)
-        return sorted(
-            sorted(ids)
-            for ids in buckets.values()
-            if len(set(ids)) > 1
-        )
+        return sorted(sorted(ids) for ids in buckets.values() if len(set(ids)) > 1)
 
     @staticmethod
     def _required_evidence_targets(manifest: ComponentSourceManifest) -> dict[str, set[str]]:
         targets: dict[str, set[str]] = {}
 
-        def register(target: str, status: ComponentVerificationStatus, source_ids: list[str]) -> None:
+        def register(target: ClaimTarget, status: ComponentVerificationStatus, source_ids: list[str]) -> None:
             if status in {ComponentVerificationStatus.SOURCE_BOUND, ComponentVerificationStatus.VERIFIED}:
-                targets[target] = set(source_ids)
+                targets[_target_key(target)] = set(source_ids)
 
         for item in manifest.component_sets:
-            register(f"component_sets.{item.component_set_id}", item.verification_status, item.source_ids)
+            register(
+                ClaimTarget(target_type=EvidenceTargetType.COMPONENT_SET, component_set_id=item.component_set_id),
+                item.verification_status,
+                item.source_ids,
+            )
         for definition in manifest.property_definitions:
             register(
-                f"property_definitions.{definition.property_key}",
+                ClaimTarget(target_type=EvidenceTargetType.PROPERTY_DEFINITION, property_key=definition.property_key),
                 definition.verification_status,
                 definition.source_ids,
             )
         for component in manifest.components:
-            register(f"components.{component.component_id}", component.verification_status, component.source_ids)
+            register(
+                ClaimTarget(target_type=EvidenceTargetType.COMPONENT, component_id=component.component_id),
+                component.verification_status,
+                component.source_ids,
+            )
             for prop in component.properties:
-                register(
-                    f"components.{component.component_id}.properties.{prop.property_key}",
-                    prop.verification_status,
-                    prop.source_ids,
-                )
+                for ordinal, _value in enumerate(prop.values):
+                    register(
+                        ClaimTarget(
+                            target_type=EvidenceTargetType.COMPONENT_PROPERTY,
+                            component_id=component.component_id,
+                            property_key=prop.property_key,
+                            ordinal=ordinal,
+                        ),
+                        prop.verification_status,
+                        prop.source_ids,
+                    )
             for ability in component.abilities:
-                register(
-                    f"components.{component.component_id}.abilities.{ability.ability_id}",
-                    ability.verification_status,
-                    ability.source_ids,
-                )
+                if ability.printed_text:
+                    register(
+                        ClaimTarget(
+                            target_type=EvidenceTargetType.ABILITY_PRINTED_TEXT,
+                            ability_id=ability.ability_id,
+                        ),
+                        ability.verification_status,
+                        ability.source_ids,
+                    )
+                if ability.normalized_label:
+                    register(
+                        ClaimTarget(
+                            target_type=EvidenceTargetType.ABILITY_NORMALIZED,
+                            ability_id=ability.ability_id,
+                        ),
+                        ability.verification_status,
+                        ability.source_ids,
+                    )
         return targets
 
     @classmethod
@@ -180,7 +209,7 @@ class ComponentIngestionDryRun:
         supporting: dict[str, set[str]] = defaultdict(set)
         for binding in manifest.evidence_bindings:
             if binding.relation == EvidenceRelation.SUPPORTS:
-                supporting[binding.target_path].add(binding.source_id)
+                supporting[_target_key(binding.target)].add(binding.source_id)
         supported = sum(
             1
             for target, allowed_sources in required.items()

--- a/backend/app/services/component_ingestion_repository.py
+++ b/backend/app/services/component_ingestion_repository.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.core import supabase
+from app.models.component_catalog import ComponentVerificationStatus
+from app.models.component_ingestion import ComponentSourceManifest
+from app.models.evidence import ClaimTarget, EvidenceRelation, EvidenceTargetType
+from app.services.component_ingestion import ComponentIngestionDryRun
+
+
+class ComponentIngestionResolutionError(RuntimeError):
+    pass
+
+
+class ComponentIngestionBlockedError(RuntimeError):
+    pass
+
+
+class ComponentIngestionReadbackError(RuntimeError):
+    pass
+
+
+class ResolvedRuleSet(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    game_id: str
+    ruleset_id: str
+    game_slug: str
+
+
+class ComponentIngestionApplyResult(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    ruleset_id: str
+    catalog_id: str
+    persisted: dict[str, int] = Field(default_factory=dict)
+
+
+def _stable_id(prefix: str, game_slug: str, identity: str) -> str:
+    digest = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
+    return f"ci:{game_slug}:{prefix}:{digest}"
+
+
+def _target_identity(manifest: ComponentSourceManifest, target: ClaimTarget) -> str:
+    selector = manifest.ruleset.model_dump(mode="json", exclude_none=True)
+    target_payload = target.model_dump(mode="json", exclude_none=True)
+    return json.dumps(
+        {"selector": selector, "target": target_payload},
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _target_claim_id(manifest: ComponentSourceManifest, target: ClaimTarget) -> str:
+    return _stable_id("claim", manifest.game_slug, _target_identity(manifest, target))
+
+
+def _binding_id(manifest: ComponentSourceManifest, manifest_binding_id: str) -> str:
+    identity = json.dumps(
+        {"selector": manifest.ruleset.model_dump(mode="json", exclude_none=True), "binding": manifest_binding_id},
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _stable_id("binding", manifest.game_slug, identity)
+
+
+def _target_payload(manifest: ComponentSourceManifest, target: ClaimTarget) -> tuple[dict[str, Any], ComponentVerificationStatus]:
+    if target.target_type == EvidenceTargetType.COMPONENT_SET:
+        item = next(item for item in manifest.component_sets if item.component_set_id == target.component_set_id)
+        return item.model_dump(mode="json", exclude_none=True), item.verification_status
+    if target.target_type == EvidenceTargetType.PROPERTY_DEFINITION:
+        item = next(item for item in manifest.property_definitions if item.property_key == target.property_key)
+        return item.model_dump(mode="json", exclude_none=True), item.verification_status
+    if target.target_type == EvidenceTargetType.COMPONENT:
+        item = next(item for item in manifest.components if item.component_id == target.component_id)
+        payload = item.model_dump(mode="json", exclude_none=True, exclude={"properties", "abilities"})
+        return payload, item.verification_status
+    if target.target_type == EvidenceTargetType.COMPONENT_PROPERTY:
+        component = next(item for item in manifest.components if item.component_id == target.component_id)
+        prop = next(item for item in component.properties if item.property_key == target.property_key)
+        value = prop.values[target.ordinal or 0]
+        return {
+            "component_id": component.component_id,
+            "property_key": prop.property_key,
+            "ordinal": target.ordinal,
+            "value": value.model_dump(mode="json"),
+        }, prop.verification_status
+    if target.target_type in {EvidenceTargetType.ABILITY_PRINTED_TEXT, EvidenceTargetType.ABILITY_NORMALIZED}:
+        ability = next(
+            ability
+            for component in manifest.components
+            for ability in component.abilities
+            if ability.ability_id == target.ability_id
+        )
+        value = ability.printed_text if target.target_type == EvidenceTargetType.ABILITY_PRINTED_TEXT else ability.normalized_label
+        return {"ability_id": ability.ability_id, "value": value}, ability.verification_status
+    raise ValueError(f"unsupported component ingestion target: {target.target_type}")
+
+
+def _claim_lifecycle(status: ComponentVerificationStatus) -> str:
+    if status in {ComponentVerificationStatus.SOURCE_BOUND, ComponentVerificationStatus.VERIFIED}:
+        return "accepted"
+    if status == ComponentVerificationStatus.REJECTED:
+        return "rejected"
+    return "candidate"
+
+
+def _property_row(
+    *,
+    ruleset_id: str,
+    component_id: str,
+    prop,
+    definition,
+    ordinal: int,
+    value,
+) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "rule_set_id": ruleset_id,
+        "component_id": component_id,
+        "property_key": prop.property_key,
+        "value_type": value.value_type,
+        "cardinality": definition.cardinality.value,
+        "ordinal": ordinal,
+        "verification_status": prop.verification_status.value,
+        "source_ids": prop.source_ids,
+        "metadata": {},
+        "text_value": None,
+        "integer_value": None,
+        "number_value": None,
+        "boolean_value": None,
+        "enum_value": None,
+        "concept_ref_id": None,
+        "component_ref_id": None,
+    }
+    field_by_type = {
+        "text": "text_value",
+        "integer": "integer_value",
+        "number": "number_value",
+        "boolean": "boolean_value",
+        "enum": "enum_value",
+        "concept_ref": "concept_ref_id",
+        "component_ref": "component_ref_id",
+    }
+    row[field_by_type[value.value_type]] = value.value
+    return row
+
+
+class ComponentIngestionPlanBuilder:
+    def build(self, manifest: ComponentSourceManifest, resolved: ResolvedRuleSet) -> dict[str, Any]:
+        definitions = {item.property_key: item for item in manifest.property_definitions}
+        claims: dict[str, dict[str, Any]] = {}
+        bindings: list[dict[str, Any]] = []
+
+        for binding in manifest.evidence_bindings:
+            claim_id = _target_claim_id(manifest, binding.target)
+            normalized_payload, status = _target_payload(manifest, binding.target)
+            target_fields = binding.target.model_dump(mode="json", exclude_none=True)
+            target_type = target_fields.pop("target_type")
+            claims[claim_id] = {
+                "claim_id": claim_id,
+                "rule_set_id": resolved.ruleset_id,
+                "claim_type": f"component_ingestion_{target_type}",
+                "normalized_payload": normalized_payload,
+                "target_type": target_type,
+                "lifecycle_status": _claim_lifecycle(status),
+                "generator_provenance": {
+                    "component_source_manifest_schema": manifest.schema_version,
+                    "game_slug": manifest.game_slug,
+                },
+                **target_fields,
+            }
+            bindings.append(
+                {
+                    "binding_id": _binding_id(manifest, binding.binding_id),
+                    "manifest_binding_id": binding.binding_id,
+                    "claim_id": claim_id,
+                    "source_id": binding.source_id,
+                    "locator_id": binding.locator_id,
+                    "relation": binding.relation.value,
+                    "reviewer_provenance": {},
+                    "generator_provenance": {
+                        "component_source_manifest_schema": manifest.schema_version,
+                        "manifest_binding_id": binding.binding_id,
+                    },
+                }
+            )
+
+        component_properties: list[dict[str, Any]] = []
+        component_abilities: list[dict[str, Any]] = []
+        component_concepts: list[dict[str, Any]] = []
+        component_rule_nodes: list[dict[str, Any]] = []
+        ability_concepts: list[dict[str, Any]] = []
+        ability_rule_nodes: list[dict[str, Any]] = []
+        for component in manifest.components:
+            for prop in component.properties:
+                definition = definitions[prop.property_key]
+                for ordinal, value in enumerate(prop.values):
+                    component_properties.append(
+                        _property_row(
+                            ruleset_id=resolved.ruleset_id,
+                            component_id=component.component_id,
+                            prop=prop,
+                            definition=definition,
+                            ordinal=ordinal,
+                            value=value,
+                        )
+                    )
+            for ability in component.abilities:
+                component_abilities.append(
+                    {
+                        "rule_set_id": resolved.ruleset_id,
+                        "component_id": component.component_id,
+                        "ability_id": ability.ability_id,
+                        "printed_text": ability.printed_text,
+                        "normalized_label": ability.normalized_label,
+                        "verification_status": ability.verification_status.value,
+                        "source_ids": ability.source_ids,
+                        "metadata": {},
+                    }
+                )
+                ability_concepts.extend(
+                    {
+                        "rule_set_id": resolved.ruleset_id,
+                        "ability_id": ability.ability_id,
+                        "concept_id": concept_id,
+                    }
+                    for concept_id in ability.concept_ids
+                )
+                ability_rule_nodes.extend(
+                    {
+                        "rule_set_id": resolved.ruleset_id,
+                        "ability_id": ability.ability_id,
+                        "rule_id": rule_id,
+                    }
+                    for rule_id in ability.rule_ids
+                )
+            component_concepts.extend(
+                {
+                    "rule_set_id": resolved.ruleset_id,
+                    "component_id": component.component_id,
+                    "concept_id": concept_id,
+                    "reference_kind": "classifies",
+                }
+                for concept_id in component.concept_ids
+            )
+            component_rule_nodes.extend(
+                {
+                    "rule_set_id": resolved.ruleset_id,
+                    "component_id": component.component_id,
+                    "rule_id": rule_id,
+                    "reference_kind": "governed_by",
+                }
+                for rule_id in component.rule_ids
+            )
+
+        return {
+            "schema_version": manifest.schema_version,
+            "game_slug": manifest.game_slug,
+            "game_id": resolved.game_id,
+            "ruleset_id": resolved.ruleset_id,
+            "completeness": manifest.completeness.value,
+            "expected_count": manifest.expected_count,
+            "unresolved_count": manifest.unresolved_count,
+            "sources": [
+                {
+                    "source_id": item.source_id,
+                    "url": str(item.url),
+                    "source_type": item.source_type,
+                    "revision_label": item.revision_label,
+                    "trust_metadata": {
+                        "authority": item.authority.value,
+                        "observed_date": item.observed_date,
+                        "extraction_method": item.extraction_method,
+                        "component_source_manifest_schema": manifest.schema_version,
+                    },
+                }
+                for item in manifest.sources
+            ],
+            "source_locators": [item.model_dump(mode="json", exclude_none=True) for item in manifest.source_locators],
+            "component_sets": [
+                {
+                    "rule_set_id": resolved.ruleset_id,
+                    **item.model_dump(mode="json", exclude_none=True),
+                    "metadata": {},
+                }
+                for item in manifest.component_sets
+            ],
+            "property_definitions": [
+                {
+                    "rule_set_id": resolved.ruleset_id,
+                    **item.model_dump(mode="json", exclude_none=True),
+                    "metadata": {},
+                }
+                for item in manifest.property_definitions
+            ],
+            "components": [
+                {
+                    "rule_set_id": resolved.ruleset_id,
+                    **item.model_dump(mode="json", exclude_none=True, exclude={"properties", "abilities", "concept_ids", "rule_ids"}),
+                    "metadata": {},
+                }
+                for item in manifest.components
+            ],
+            "component_properties": component_properties,
+            "component_abilities": component_abilities,
+            "component_concepts": component_concepts,
+            "component_rule_nodes": component_rule_nodes,
+            "ability_concepts": ability_concepts,
+            "ability_rule_nodes": ability_rule_nodes,
+            "claims": list(claims.values()),
+            "evidence_bindings": bindings,
+            "catalog_metadata": {
+                "component_ingestion": {
+                    "schema_version": manifest.schema_version,
+                    "completeness": manifest.completeness.value,
+                    "expected_count": manifest.expected_count,
+                    "unresolved_count": manifest.unresolved_count,
+                }
+            },
+        }
+
+
+class ComponentIngestionRepository:
+    def __init__(self, client=None):
+        self.client = client or supabase._get_client()
+        self.plan_builder = ComponentIngestionPlanBuilder()
+
+    def resolve_ruleset(self, manifest: ComponentSourceManifest) -> ResolvedRuleSet:
+        games = (
+            self.client.table("games")
+            .select("id,slug,identity_status")
+            .eq("slug", manifest.game_slug)
+            .limit(2)
+            .execute()
+            .data
+        )
+        if len(games) != 1 or games[0].get("identity_status") != "verified":
+            raise ComponentIngestionResolutionError("canonical verified Game identity did not resolve exactly once")
+        game = games[0]
+
+        query = self.client.table("rule_sets").select(
+            "id,game_id,platform,revision_label,language_code,edition_label,is_active"
+        ).eq("game_id", game["id"])
+        selector = manifest.ruleset
+        if selector.ruleset_id:
+            query = query.eq("id", selector.ruleset_id)
+        else:
+            query = query.eq("platform", selector.platform).eq("revision_label", selector.revision_label).eq("is_active", True)
+            if selector.language_code:
+                query = query.eq("language_code", selector.language_code)
+            if selector.edition_label:
+                query = query.eq("edition_label", selector.edition_label)
+        rows = query.limit(2).execute().data
+        if len(rows) != 1:
+            raise ComponentIngestionResolutionError("RuleSet selector did not resolve exactly once")
+        return ResolvedRuleSet(game_id=str(game["id"]), ruleset_id=str(rows[0]["id"]), game_slug=manifest.game_slug)
+
+    def read_component_ids(self, ruleset_id: str) -> list[str]:
+        rows = self.client.table("components").select("component_id").eq("rule_set_id", ruleset_id).execute().data
+        return sorted(str(row["component_id"]) for row in rows)
+
+    def apply(self, manifest: ComponentSourceManifest) -> ComponentIngestionApplyResult:
+        resolved = self.resolve_ruleset(manifest)
+        existing_ids = self.read_component_ids(resolved.ruleset_id)
+        dry_run = ComponentIngestionDryRun().run(manifest, resolved_ruleset_id=resolved.ruleset_id)
+        if dry_run.blockers:
+            raise ComponentIngestionBlockedError(",".join(dry_run.blockers))
+        if manifest.completeness.value == "complete":
+            manifest_ids = {item.component_id for item in manifest.components}
+            stale_ids = sorted(set(existing_ids) - manifest_ids)
+            if stale_ids:
+                raise ComponentIngestionBlockedError("COMPLETE_RECONCILIATION_REQUIRES_EXPLICIT_DELETE_POLICY")
+
+        payload = self.plan_builder.build(manifest, resolved)
+        response = self.client.rpc("apply_component_ingestion_v1", {"payload": payload}).execute().data
+        if not isinstance(response, dict):
+            raise ComponentIngestionReadbackError("component ingestion RPC returned an invalid response")
+        result = ComponentIngestionApplyResult.model_validate(response)
+        self.verify_readback(manifest, resolved, payload)
+        return result
+
+    def verify_readback(
+        self,
+        manifest: ComponentSourceManifest,
+        resolved: ResolvedRuleSet,
+        payload: dict[str, Any],
+    ) -> None:
+        checks: list[tuple[str, str, list[str]]] = [
+            ("component_sets", "component_set_id", [item.component_set_id for item in manifest.component_sets]),
+            ("component_property_definitions", "property_key", [item.property_key for item in manifest.property_definitions]),
+            ("components", "component_id", [item.component_id for item in manifest.components]),
+            ("claims", "claim_id", [item["claim_id"] for item in payload["claims"]]),
+            ("evidence_bindings", "binding_id", [item["binding_id"] for item in payload["evidence_bindings"]]),
+        ]
+        for table, key, expected in checks:
+            if not expected:
+                continue
+            query = self.client.table(table).select(key).in_(key, expected)
+            if table in {"component_sets", "component_property_definitions", "components", "claims"}:
+                query = query.eq("rule_set_id", resolved.ruleset_id)
+            actual = {str(row[key]) for row in query.execute().data}
+            if actual != set(expected):
+                raise ComponentIngestionReadbackError(f"read-back mismatch for {table}")

--- a/backend/app/services/component_ingestion_repository.py
+++ b/backend/app/services/component_ingestion_repository.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.core import supabase
 from app.models.component_catalog import ComponentVerificationStatus
 from app.models.component_ingestion import ComponentSourceManifest
-from app.models.evidence import ClaimTarget, EvidenceRelation, EvidenceTargetType
+from app.models.evidence import ClaimTarget, EvidenceTargetType
 from app.services.component_ingestion import ComponentIngestionDryRun
 
 
@@ -111,7 +111,7 @@ def _claim_lifecycle(status: ComponentVerificationStatus) -> str:
     return "candidate"
 
 
-def _property_row(
+def _property_row(  # noqa: PLR0913
     *,
     ruleset_id: str,
     component_id: str,

--- a/backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml
+++ b/backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml
@@ -19,6 +19,23 @@ sources:
     authority: publisher
     observed_date: "2026-08-14"
     extraction_method: manual_primary_source_normalization
+source_locators:
+  - locator_id: yro:bga:overview
+    source_id: bga:yro:260725-1445
+    section_heading: YRO overview
+    external_reference: game metadata, factions, 3x3 grid and core resources
+  - locator_id: yro:bga:setup
+    source_id: bga:yro:260725-1445
+    section_heading: SETUP
+    external_reference: player board, markers, shared boards, starting Money/hand and Quest display
+  - locator_id: yro:bga:key-concepts
+    source_id: bga:yro:260725-1445
+    section_heading: KEY CONCEPTS
+    external_reference: factions, professions, Technology, Magic and Resources
+  - locator_id: yro:bga:phase:recruit
+    source_id: bga:yro:260725-1445
+    section_heading: Recruit Phase
+    external_reference: phase 2
 component_sets:
   - component_set_id: adventurers
     canonical_name: Adventurers
@@ -78,32 +95,44 @@ property_definitions:
 components: []
 evidence_bindings:
   - binding_id: yro:component-set:adventurers:bga
-    target_path: component_sets.adventurers
+    target:
+      target_type: component_set
+      component_set_id: adventurers
     source_id: bga:yro:260725-1445
     locator_id: yro:bga:overview
     relation: supports
   - binding_id: yro:component-set:quests:bga
-    target_path: component_sets.quests
+    target:
+      target_type: component_set
+      component_set_id: quests
     source_id: bga:yro:260725-1445
     locator_id: yro:bga:setup
     relation: supports
   - binding_id: yro:property:faction:bga
-    target_path: property_definitions.faction
+    target:
+      target_type: property_definition
+      property_key: faction
     source_id: bga:yro:260725-1445
     locator_id: yro:bga:key-concepts
     relation: supports
   - binding_id: yro:property:profession:bga
-    target_path: property_definitions.profession
+    target:
+      target_type: property_definition
+      property_key: profession
     source_id: bga:yro:260725-1445
     locator_id: yro:bga:key-concepts
     relation: supports
   - binding_id: yro:property:combat-value:bga
-    target_path: property_definitions.combat_value
+    target:
+      target_type: property_definition
+      property_key: combat_value
     source_id: bga:yro:260725-1445
     locator_id: yro:bga:overview
     relation: supports
   - binding_id: yro:property:recruit-cost:bga
-    target_path: property_definitions.recruit_cost
+    target:
+      target_type: property_definition
+      property_key: recruit_cost
     source_id: bga:yro:260725-1445
     locator_id: yro:bga:phase:recruit
     relation: supports

--- a/backend/scripts/component_ingest.py
+++ b/backend/scripts/component_ingest.py
@@ -8,6 +8,7 @@ import yaml
 
 from app.models.component_ingestion import ComponentSourceManifest
 from app.services.component_ingestion import ComponentIngestionDryRun, ExistingComponentSnapshot
+from app.services.component_ingestion_repository import ComponentIngestionRepository
 
 
 def _load_manifest(path: Path) -> ComponentSourceManifest:
@@ -26,21 +27,26 @@ def _existing_snapshot(path: Path, ruleset_id: str) -> ExistingComponentSnapshot
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Validate and dry-run a Component Source Manifest v1.")
+    parser = argparse.ArgumentParser(description="Validate, dry-run or atomically apply a Component Source Manifest v1.")
     parser.add_argument("manifest", type=Path)
     parser.add_argument(
         "--resolved-ruleset-id",
-        help="Exact RuleSet ID resolved by the caller. Required when the manifest uses a natural-key selector.",
+        help="Exact RuleSet ID resolved by the caller for offline dry-run mode.",
     )
     parser.add_argument(
         "--existing-manifest",
         type=Path,
-        help="Optional current-state fixture for deterministic diff testing. Production adapters may supply DB state instead.",
+        help="Optional current-state fixture for deterministic offline diff testing.",
     )
     parser.add_argument(
         "--schema",
         action="store_true",
         help="Print the generated JSON Schema for Component Source Manifest v1 and exit.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Resolve the canonical RuleSet, run fail-closed validation, apply one atomic RPC transaction and verify read-back.",
     )
     args = parser.parse_args()
 
@@ -49,6 +55,13 @@ def main() -> int:
         return 0
 
     manifest = _load_manifest(args.manifest)
+    if args.apply:
+        if args.existing_manifest or args.resolved_ruleset_id:
+            raise SystemExit("--apply resolves production state itself; do not combine it with offline snapshot options")
+        result = ComponentIngestionRepository().apply(manifest)
+        print(result.model_dump_json(indent=2))
+        return 0
+
     resolved_ruleset_id = args.resolved_ruleset_id or manifest.ruleset.ruleset_id
     existing = None
     if args.existing_manifest:

--- a/backend/tests/test_component_ingestion.py
+++ b/backend/tests/test_component_ingestion.py
@@ -31,6 +31,28 @@ def _payload() -> dict:
                 "extraction_method": "fixture",
             }
         ],
+        "source_locators": [
+            {
+                "locator_id": "locator:set:cards",
+                "source_id": "source:fixture:1",
+                "section_heading": "Components",
+            },
+            {
+                "locator_id": "locator:def:rank",
+                "source_id": "source:fixture:1",
+                "section_heading": "Card fields",
+            },
+            {
+                "locator_id": "locator:component:alpha",
+                "source_id": "source:fixture:1",
+                "external_reference": "Alpha",
+            },
+            {
+                "locator_id": "locator:component:alpha:rank",
+                "source_id": "source:fixture:1",
+                "external_reference": "Alpha rank",
+            },
+        ],
         "component_sets": [
             {
                 "component_set_id": "cards",
@@ -71,28 +93,33 @@ def _payload() -> dict:
         "evidence_bindings": [
             {
                 "binding_id": "binding:set:cards",
-                "target_path": "component_sets.cards",
+                "target": {"target_type": "component_set", "component_set_id": "cards"},
                 "source_id": "source:fixture:1",
                 "locator_id": "locator:set:cards",
                 "relation": "supports",
             },
             {
                 "binding_id": "binding:def:rank",
-                "target_path": "property_definitions.rank",
+                "target": {"target_type": "property_definition", "property_key": "rank"},
                 "source_id": "source:fixture:1",
                 "locator_id": "locator:def:rank",
                 "relation": "supports",
             },
             {
                 "binding_id": "binding:component:alpha",
-                "target_path": "components.card.alpha",
+                "target": {"target_type": "component", "component_id": "card.alpha"},
                 "source_id": "source:fixture:1",
                 "locator_id": "locator:component:alpha",
                 "relation": "supports",
             },
             {
-                "binding_id": "binding:component:alpha:rank",
-                "target_path": "components.card.alpha.properties.rank",
+                "binding_id": "binding:component:alpha:rank:0",
+                "target": {
+                    "target_type": "component_property",
+                    "component_id": "card.alpha",
+                    "property_key": "rank",
+                    "ordinal": 0,
+                },
                 "source_id": "source:fixture:1",
                 "locator_id": "locator:component:alpha:rank",
                 "relation": "supports",
@@ -117,6 +144,7 @@ def test_yro_manifest_is_source_bound_unknown_and_does_not_fabricate_cards():
     assert manifest.expected_count is None
     assert manifest.components == []
     assert {item.component_set_id for item in manifest.component_sets} == {"adventurers", "quests"}
+    assert len(manifest.source_locators) == 4
     assert report.blockers == []
     assert report.evidence_coverage.required_fields == YRO_EVIDENCE_FIELDS
     assert report.evidence_coverage.supported_fields == YRO_EVIDENCE_FIELDS
@@ -131,6 +159,7 @@ def test_ruleset_must_resolve_before_dry_run_can_promote():
 def test_unknown_property_definition_is_rejected_in_report():
     payload = _payload()
     payload["components"][0]["properties"][0]["property_key"] = "mystery"
+    payload["evidence_bindings"][3]["target"]["property_key"] = "mystery"
     manifest = _manifest(payload)
     report = ComponentIngestionDryRun().run(manifest, resolved_ruleset_id=RULESET_ID)
     assert report.rejected_unknown_properties == ["card.alpha:mystery"]
@@ -148,7 +177,7 @@ def test_property_type_mismatch_is_fail_closed():
 def test_field_level_evidence_must_cover_source_bound_property():
     payload = _payload()
     payload["evidence_bindings"] = [
-        item for item in payload["evidence_bindings"] if item["binding_id"] != "binding:component:alpha:rank"
+        item for item in payload["evidence_bindings"] if item["binding_id"] != "binding:component:alpha:rank:0"
     ]
     report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
     assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
@@ -167,11 +196,97 @@ def test_source_url_does_not_implicitly_verify_a_field():
             "extraction_method": "fixture",
         }
     )
-    for binding in payload["evidence_bindings"]:
-        if binding["binding_id"] == "binding:component:alpha:rank":
-            binding["source_id"] = "source:fixture:2"
+    payload["source_locators"].append(
+        {
+            "locator_id": "locator:other:alpha-rank",
+            "source_id": "source:fixture:2",
+            "section_heading": "Other",
+        }
+    )
+    binding = next(item for item in payload["evidence_bindings"] if item["binding_id"] == "binding:component:alpha:rank:0")
+    binding["source_id"] = "source:fixture:2"
+    binding["locator_id"] = "locator:other:alpha-rank"
     report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
     assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
+
+
+def test_binding_requires_declared_locator_and_matching_source():
+    payload = _payload()
+    payload["evidence_bindings"][0]["locator_id"] = "locator:not-declared"
+    with pytest.raises(ValidationError, match="references unknown locator"):
+        _manifest(payload)
+
+    payload = _payload()
+    payload["sources"].append(
+        {
+            "source_id": "source:fixture:2",
+            "url": "https://example.org/other",
+            "source_type": "community_list",
+            "authority": "community",
+            "extraction_method": "fixture",
+        }
+    )
+    payload["evidence_bindings"][0]["source_id"] = "source:fixture:2"
+    with pytest.raises(ValidationError, match="source does not match locator source"):
+        _manifest(payload)
+
+
+def test_component_property_evidence_is_ordinal_specific():
+    payload = _payload()
+    payload["property_definitions"][0]["cardinality"] = "many"
+    payload["components"][0]["properties"][0]["values"].append({"value_type": "integer", "value": 2})
+    payload["completeness"] = "partial"
+    payload["expected_count"] = 2
+    payload["unresolved_count"] = 1
+    report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
+    assert report.evidence_coverage.required_fields == FIXTURE_EVIDENCE_FIELDS + 1
+    assert report.evidence_coverage.supported_fields == FIXTURE_EVIDENCE_FIELDS
+    assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
+
+
+def test_ability_printed_and_normalized_evidence_are_independent_targets():
+    payload = _payload()
+    payload["components"][0]["abilities"] = [
+        {
+            "ability_id": "ability.alpha",
+            "printed_text": "Printed ability text",
+            "normalized_label": "Normalized effect",
+            "verification_status": "source_bound",
+            "source_ids": ["source:fixture:1"],
+        }
+    ]
+    payload["source_locators"].append(
+        {
+            "locator_id": "locator:ability:alpha",
+            "source_id": "source:fixture:1",
+            "external_reference": "Alpha ability",
+        }
+    )
+    payload["evidence_bindings"].append(
+        {
+            "binding_id": "binding:ability:alpha:printed",
+            "target": {"target_type": "ability_printed_text", "ability_id": "ability.alpha"},
+            "source_id": "source:fixture:1",
+            "locator_id": "locator:ability:alpha",
+            "relation": "supports",
+        }
+    )
+    report = ComponentIngestionDryRun().run(_manifest(payload), resolved_ruleset_id=RULESET_ID)
+    assert report.evidence_coverage.required_fields == FIXTURE_EVIDENCE_FIELDS + 2
+    assert report.evidence_coverage.supported_fields == FIXTURE_EVIDENCE_FIELDS + 1
+    assert "FIELD_EVIDENCE_COVERAGE_INCOMPLETE" in report.blockers
+
+
+def test_structured_target_must_resolve_to_manifest_entity():
+    payload = _payload()
+    payload["evidence_bindings"][0]["target"]["component_set_id"] = "missing"
+    with pytest.raises(ValidationError, match="unknown component set"):
+        _manifest(payload)
+
+    payload = _payload()
+    payload["evidence_bindings"][3]["target"]["ordinal"] = 1
+    with pytest.raises(ValidationError, match="ordinal is out of range"):
+        _manifest(payload)
 
 
 def test_duplicate_stable_identity_candidate_is_reported_even_with_distinct_ids():

--- a/backend/tests/test_component_ingestion.py
+++ b/backend/tests/test_component_ingestion.py
@@ -11,6 +11,7 @@ from app.services.component_ingestion import ComponentIngestionDryRun, ExistingC
 YRO_MANIFEST = Path("backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml")
 RULESET_ID = "00000000-0000-0000-0000-000000000178"
 YRO_EVIDENCE_FIELDS = 6
+YRO_SOURCE_LOCATORS = 4
 FIXTURE_EVIDENCE_FIELDS = 4
 FIXTURE_SUPPORTED_WITH_ONE_MISSING = 3
 
@@ -144,7 +145,7 @@ def test_yro_manifest_is_source_bound_unknown_and_does_not_fabricate_cards():
     assert manifest.expected_count is None
     assert manifest.components == []
     assert {item.component_set_id for item in manifest.component_sets} == {"adventurers", "quests"}
-    assert len(manifest.source_locators) == 4
+    assert len(manifest.source_locators) == YRO_SOURCE_LOCATORS
     assert report.blockers == []
     assert report.evidence_coverage.required_fields == YRO_EVIDENCE_FIELDS
     assert report.evidence_coverage.supported_fields == YRO_EVIDENCE_FIELDS

--- a/backend/tests/test_component_ingestion_repository.py
+++ b/backend/tests/test_component_ingestion_repository.py
@@ -12,6 +12,13 @@ RULESET = ResolvedRuleSet(
     ruleset_id="00000000-0000-0000-0000-000000000178",
     game_slug="yro",
 )
+YRO_SOURCE_COUNT = 2
+YRO_LOCATOR_COUNT = 4
+YRO_COMPONENT_SET_COUNT = 2
+YRO_PROPERTY_DEFINITION_COUNT = 4
+YRO_INGESTION_CLAIM_COUNT = 6
+FIXTURE_PROPERTY_VALUE_COUNT = 2
+FIXTURE_INGESTION_CLAIM_COUNT = 7
 
 
 def _yro_manifest() -> ComponentSourceManifest:
@@ -100,11 +107,21 @@ def _component_manifest() -> ComponentSourceManifest:
         ("component", {"target_type": "component", "component_id": "card.alpha"}),
         (
             "rank-0",
-            {"target_type": "component_property", "component_id": "card.alpha", "property_key": "rank", "ordinal": 0},
+            {
+                "target_type": "component_property",
+                "component_id": "card.alpha",
+                "property_key": "rank",
+                "ordinal": 0,
+            },
         ),
         (
             "rank-1",
-            {"target_type": "component_property", "component_id": "card.alpha", "property_key": "rank", "ordinal": 1},
+            {
+                "target_type": "component_property",
+                "component_id": "card.alpha",
+                "property_key": "rank",
+                "ordinal": 1,
+            },
         ),
         ("printed", {"target_type": "ability_printed_text", "ability_id": "ability.alpha"}),
         ("normalized", {"target_type": "ability_normalized", "ability_id": "ability.alpha"}),
@@ -128,34 +145,36 @@ def _component_manifest() -> ComponentSourceManifest:
 
 def test_yro_plan_preserves_zero_component_fail_closed_state():
     plan = ComponentIngestionPlanBuilder().build(_yro_manifest(), RULESET)
-    assert len(plan["sources"]) == 2
-    assert len(plan["source_locators"]) == 4
-    assert len(plan["component_sets"]) == 2
-    assert len(plan["property_definitions"]) == 4
+    assert len(plan["sources"]) == YRO_SOURCE_COUNT
+    assert len(plan["source_locators"]) == YRO_LOCATOR_COUNT
+    assert len(plan["component_sets"]) == YRO_COMPONENT_SET_COUNT
+    assert len(plan["property_definitions"]) == YRO_PROPERTY_DEFINITION_COUNT
     assert plan["components"] == []
     assert plan["component_properties"] == []
-    assert len(plan["claims"]) == 6
-    assert len(plan["evidence_bindings"]) == 6
+    assert len(plan["claims"]) == YRO_INGESTION_CLAIM_COUNT
+    assert len(plan["evidence_bindings"]) == YRO_INGESTION_CLAIM_COUNT
     assert plan["catalog_metadata"]["component_ingestion"]["completeness"] == "unknown"
 
 
 def test_plan_flattens_multi_value_property_and_two_ability_claim_targets():
-    plan = ComponentIngestionPlanBuilder().build(_component_manifest(), RULESET.model_copy(update={"game_slug": "fixture-game"}))
-    assert [row["ordinal"] for row in plan["component_properties"]] == [0, 1]
+    resolved = RULESET.model_copy(update={"game_slug": "fixture-game"})
+    plan = ComponentIngestionPlanBuilder().build(_component_manifest(), resolved)
+    assert [row["ordinal"] for row in plan["component_properties"]] == list(range(FIXTURE_PROPERTY_VALUE_COUNT))
     assert [row["integer_value"] for row in plan["component_properties"]] == [1, 2]
     assert len(plan["component_abilities"]) == 1
     target_types = {row["target_type"] for row in plan["claims"]}
     assert {"component", "component_set", "property_definition", "component_property"}.issubset(target_types)
     assert "ability_printed_text" in target_types
     assert "ability_normalized" in target_types
-    assert len(plan["claims"]) == 7
+    assert len(plan["claims"]) == FIXTURE_INGESTION_CLAIM_COUNT
 
 
 def test_claim_and_binding_ids_are_deterministic_across_reruns():
     manifest = _component_manifest()
     builder = ComponentIngestionPlanBuilder()
-    first = builder.build(manifest, RULESET.model_copy(update={"game_slug": "fixture-game"}))
-    second = builder.build(deepcopy(manifest), RULESET.model_copy(update={"game_slug": "fixture-game"}))
+    resolved = RULESET.model_copy(update={"game_slug": "fixture-game"})
+    first = builder.build(manifest, resolved)
+    second = builder.build(deepcopy(manifest), resolved)
     assert [row["claim_id"] for row in first["claims"]] == [row["claim_id"] for row in second["claims"]]
     assert [row["binding_id"] for row in first["evidence_bindings"]] == [
         row["binding_id"] for row in second["evidence_bindings"]

--- a/backend/tests/test_component_ingestion_repository.py
+++ b/backend/tests/test_component_ingestion_repository.py
@@ -1,0 +1,169 @@
+from copy import deepcopy
+from pathlib import Path
+
+import yaml
+
+from app.models.component_ingestion import ComponentSourceManifest
+from app.services.component_ingestion_repository import ComponentIngestionPlanBuilder, ResolvedRuleSet
+
+YRO_MANIFEST = Path("backend/data/component_ingestion/yro-bga-260725-1445.v1.yaml")
+RULESET = ResolvedRuleSet(
+    game_id="00000000-0000-0000-0000-000000000001",
+    ruleset_id="00000000-0000-0000-0000-000000000178",
+    game_slug="yro",
+)
+
+
+def _yro_manifest() -> ComponentSourceManifest:
+    return ComponentSourceManifest.model_validate(yaml.safe_load(YRO_MANIFEST.read_text(encoding="utf-8")))
+
+
+def _component_manifest() -> ComponentSourceManifest:
+    payload = yaml.safe_load(YRO_MANIFEST.read_text(encoding="utf-8"))
+    payload["game_slug"] = "fixture-game"
+    payload["ruleset"] = {"ruleset_id": RULESET.ruleset_id}
+    payload["sources"] = [
+        {
+            "source_id": "source:fixture:1",
+            "url": "https://example.com/components",
+            "source_type": "publisher_component_list",
+            "authority": "publisher",
+            "observed_date": "2026-08-14",
+            "extraction_method": "fixture",
+        }
+    ]
+    payload["source_locators"] = [
+        {
+            "locator_id": "locator:fixture:component",
+            "source_id": "source:fixture:1",
+            "section_heading": "Components",
+        },
+        {
+            "locator_id": "locator:fixture:ability",
+            "source_id": "source:fixture:1",
+            "section_heading": "Ability",
+        },
+    ]
+    payload["component_sets"] = [
+        {
+            "component_set_id": "cards",
+            "canonical_name": "Cards",
+            "kind": "card",
+            "verification_status": "source_bound",
+            "source_ids": ["source:fixture:1"],
+        }
+    ]
+    payload["property_definitions"] = [
+        {
+            "property_key": "rank",
+            "value_type": "integer",
+            "cardinality": "many",
+            "verification_status": "source_bound",
+            "source_ids": ["source:fixture:1"],
+        }
+    ]
+    payload["components"] = [
+        {
+            "component_id": "card.alpha",
+            "component_set_id": "cards",
+            "canonical_name": "Alpha",
+            "kind": "card",
+            "quantity": 1,
+            "verification_status": "source_bound",
+            "source_ids": ["source:fixture:1"],
+            "properties": [
+                {
+                    "property_key": "rank",
+                    "values": [
+                        {"value_type": "integer", "value": 1},
+                        {"value_type": "integer", "value": 2},
+                    ],
+                    "verification_status": "source_bound",
+                    "source_ids": ["source:fixture:1"],
+                }
+            ],
+            "abilities": [
+                {
+                    "ability_id": "ability.alpha",
+                    "printed_text": "Printed text",
+                    "normalized_label": "Normalized effect",
+                    "verification_status": "source_bound",
+                    "source_ids": ["source:fixture:1"],
+                }
+            ],
+        }
+    ]
+    payload["evidence_bindings"] = []
+    targets = [
+        ("set", {"target_type": "component_set", "component_set_id": "cards"}),
+        ("definition", {"target_type": "property_definition", "property_key": "rank"}),
+        ("component", {"target_type": "component", "component_id": "card.alpha"}),
+        (
+            "rank-0",
+            {"target_type": "component_property", "component_id": "card.alpha", "property_key": "rank", "ordinal": 0},
+        ),
+        (
+            "rank-1",
+            {"target_type": "component_property", "component_id": "card.alpha", "property_key": "rank", "ordinal": 1},
+        ),
+        ("printed", {"target_type": "ability_printed_text", "ability_id": "ability.alpha"}),
+        ("normalized", {"target_type": "ability_normalized", "ability_id": "ability.alpha"}),
+    ]
+    for name, target in targets:
+        locator_id = "locator:fixture:ability" if name in {"printed", "normalized"} else "locator:fixture:component"
+        payload["evidence_bindings"].append(
+            {
+                "binding_id": f"binding:fixture:{name}",
+                "target": target,
+                "source_id": "source:fixture:1",
+                "locator_id": locator_id,
+                "relation": "supports",
+            }
+        )
+    payload["completeness"] = "complete"
+    payload["expected_count"] = 1
+    payload["unresolved_count"] = 0
+    return ComponentSourceManifest.model_validate(payload)
+
+
+def test_yro_plan_preserves_zero_component_fail_closed_state():
+    plan = ComponentIngestionPlanBuilder().build(_yro_manifest(), RULESET)
+    assert len(plan["sources"]) == 2
+    assert len(plan["source_locators"]) == 4
+    assert len(plan["component_sets"]) == 2
+    assert len(plan["property_definitions"]) == 4
+    assert plan["components"] == []
+    assert plan["component_properties"] == []
+    assert len(plan["claims"]) == 6
+    assert len(plan["evidence_bindings"]) == 6
+    assert plan["catalog_metadata"]["component_ingestion"]["completeness"] == "unknown"
+
+
+def test_plan_flattens_multi_value_property_and_two_ability_claim_targets():
+    plan = ComponentIngestionPlanBuilder().build(_component_manifest(), RULESET.model_copy(update={"game_slug": "fixture-game"}))
+    assert [row["ordinal"] for row in plan["component_properties"]] == [0, 1]
+    assert [row["integer_value"] for row in plan["component_properties"]] == [1, 2]
+    assert len(plan["component_abilities"]) == 1
+    target_types = {row["target_type"] for row in plan["claims"]}
+    assert {"component", "component_set", "property_definition", "component_property"}.issubset(target_types)
+    assert "ability_printed_text" in target_types
+    assert "ability_normalized" in target_types
+    assert len(plan["claims"]) == 7
+
+
+def test_claim_and_binding_ids_are_deterministic_across_reruns():
+    manifest = _component_manifest()
+    builder = ComponentIngestionPlanBuilder()
+    first = builder.build(manifest, RULESET.model_copy(update={"game_slug": "fixture-game"}))
+    second = builder.build(deepcopy(manifest), RULESET.model_copy(update={"game_slug": "fixture-game"}))
+    assert [row["claim_id"] for row in first["claims"]] == [row["claim_id"] for row in second["claims"]]
+    assert [row["binding_id"] for row in first["evidence_bindings"]] == [
+        row["binding_id"] for row in second["evidence_bindings"]
+    ]
+
+
+def test_manifest_binding_id_is_kept_in_generator_provenance():
+    plan = ComponentIngestionPlanBuilder().build(_yro_manifest(), RULESET)
+    binding = plan["evidence_bindings"][0]
+    assert binding["manifest_binding_id"].startswith("yro:")
+    assert binding["generator_provenance"]["manifest_binding_id"] == binding["manifest_binding_id"]


### PR DESCRIPTION
## Summary

Continues #178 from the merged manifest/dry-run contract and first-class evidence targets.

This slice closes two data-loss gaps before enabling production writes:

1. Component Source Manifest v1 now carries concrete `SourceLocator` records instead of binding to locator IDs that are absent from the manifest.
2. Evidence bindings now use structured `ClaimTarget` identities instead of opaque path strings, so multi-valued component properties retain `ordinal` and ability printed/normalized evidence remains distinct.

It then adds the production apply path:

- structured target validation against actual manifest entities;
- exact field-level evidence coverage for ComponentSet / PropertyDefinition / Component / property value ordinal / printed ability / normalized ability;
- deterministic Claim and EvidenceBinding IDs;
- typed property-row flattening;
- exact verified Game + RuleSet resolution;
- `ComponentIngestionPlanBuilder` for a normalized write plan;
- `ComponentIngestionRepository` with fail-closed dry-run and post-write read-back;
- CLI `--apply` mode (default remains offline dry-run);
- PostgreSQL RPC `apply_component_ingestion_v1(jsonb)` for **one atomic transaction** across Sources, Locators, Catalog, Sets, Definitions, Components, property values, abilities, links, Claims and EvidenceBindings;
- RPC execution revoked from PUBLIC / anon / authenticated and granted only to service_role when present;
- no deletion for unknown/partial manifests;
- complete manifests with stale production components are blocked until an explicit deletion/reconciliation policy exists.

## CI fixed points

A PostgreSQL 18 workflow:

- builds the canonical schema through migration 019;
- applies the same component payload twice and requires stable cardinalities;
- verifies service-role-only RPC permission;
- applies a payload that creates Source/Set/Component but has an invalid later Claim target and requires the **entire call to roll back**;
- runs structured-target, ordinal, ability, plan-builder and existing Component/Evidence regression tests.

## YRO behavior

The YRO manifest remains `completeness=unknown` with **0 individual cards**. This slice therefore cannot fabricate card data. Once merged and migration 019 is present in production, YRO can be safely applied through the generic adapter to persist its 2 ComponentSets + 4 PropertyDefinitions + six first-class Claim/Evidence pairs without changing its intentional zero-card state.

#178 remains open after this PR for production YRO apply/read-back plus the tile-centric and dice/token-centric genericity rollouts.