### PR TITLE
Deploy main when Vercel Git integration misses a push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,10 +90,30 @@ jobs:
       - name: Record quota-deferred production state
         if: steps.budget.outputs.state == 'quota_saturated'
         run: |
-          echo "Production build passed; deployment verification is deferred because the Vercel team is at the observed 24h deployment limit." >> "$GITHUB_STEP_SUMMARY"
+          echo "Production build passed; deployment is deferred because the Vercel team is at the observed 24h deployment limit." >> "$GITHUB_STEP_SUMMARY"
           echo "No deployment creation was attempted by GitHub Actions." >> "$GITHUB_STEP_SUMMARY"
-      - name: Verify canonical Vercel Git production deployment
-        if: steps.budget.outputs.state == 'deployable' || steps.budget.outputs.state == 'unknown'
+      - name: Deploy latest main once
+        if: steps.budget.outputs.state == 'deployable'
+        id: deploy
+        shell: bash
+        run: |
+          set +e
+          output="$(vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1)"
+          code=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$code" -eq 0 ]; then
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$output" | grep -Fq 'api-deployments-free-per-day'; then
+            echo "deployed=false" >> "$GITHUB_OUTPUT"
+            echo "Push deployment reached Vercel quota after preflight; deployment is deferred without retry." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          exit "$code"
+      - name: Verify production deployment
+        if: steps.deploy.outputs.deployed == 'true' || steps.budget.outputs.state == 'current' || steps.budget.outputs.state == 'unknown'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: >-


### PR DESCRIPTION
## Evidence
Production run #645 built merge commit `440cd07cd8f38668bb8186209571ee7c9aff1c5d` successfully and generated all 68 catalog WebPs, but the canonical Vercel Git deployment remained `not-found` for the full 180-second verification window.

## Outcome
Closed without merge. The repository has an explicit verifier contract that production pushes must not create deployments; this proposal violated that invariant. The existing scheduled/workflow-dispatch catch-up remains the approved deployment path.