### PR TITLE
Use generated WebP art for games without catalogue images

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -1,13 +1,13 @@
 name: UI UX regression
 
 on:
-  pull_request:
-    paths:
-      - "frontend/**"
-      - ".github/workflows/ui-ux-regression.yml"
   push:
     branches:
       - main
+    paths:
+      - "frontend/**"
+      - ".github/workflows/ui-ux-regression.yml"
+  pull_request:
     paths:
       - "frontend/**"
       - ".github/workflows/ui-ux-regression.yml"
@@ -93,7 +93,7 @@ jobs:
         working-directory: frontend
         run: npx playwright install --with-deps chromium
 
-      - name: Gate existing list navigation loading and auth contracts
+      - name: Gate existing list navigation loading auth and image contracts
         working-directory: frontend
         run: >-
           npx playwright test
@@ -102,6 +102,7 @@ jobs:
           tests/performance.spec.js
           tests/game_layout.spec.js
           tests/auth.spec.js
+          tests/generated-game-images.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,17 @@ const TIME_FILTERS = [
   { id: '60-120', label: '60-120分' },
   { id: '120+', label: '120分以上' },
 ]
+const NO_IMAGE_URL = '/assets/no-image.webp'
+
+function gameImageUrl(game) {
+  const configured = game.image_url?.trim()
+  if (configured && !configured.includes('placeholder') && !configured.endsWith(NO_IMAGE_URL)) return configured
+  return game.slug ? `/images/games/generated/${game.slug}.webp` : NO_IMAGE_URL
+}
+
+function handleGameImageError(event) {
+  if (!event.currentTarget.src.endsWith(NO_IMAGE_URL)) event.currentTarget.src = NO_IMAGE_URL
+}
 
 function Filters({
   activePlayers,
@@ -277,7 +288,7 @@ function App() {
           {compareList.map((game) => (
             <div key={game.id} className="battle-col">
               <div className="pro-card comparison-game-card">
-                <img src={game.image_url || '/assets/no-image.webp'} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
+                <img src={gameImageUrl(game)} onError={handleGameImageError} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
                 <div className="pro-stat-value">{game.title_ja || game.title}</div>
                 {game.strategy_tier && <div className="tier-badge comparison-tier">TIER {game.strategy_tier}</div>}
               </div>
@@ -416,7 +427,7 @@ function App() {
                   <Link to={`/games/${game.slug}`} className="asset-card asset-card-link">
                     <div className="asset-thumb-container">
                       {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
-                      <img src={game.image_url || '/assets/no-image.webp'} alt={title} className="asset-thumb" loading="lazy" />
+                      <img src={gameImageUrl(game)} onError={handleGameImageError} alt={title} className="asset-thumb" loading="lazy" />
                     </div>
                     <div className="asset-info">
                       <div className="asset-title">{title}</div>
@@ -462,7 +473,7 @@ function App() {
             const title = game.title_ja || game.title || 'ゲーム'
             return (
               <div key={game.id} className="compare-item">
-                <img src={game.image_url || '/assets/no-image.webp'} alt={title} />
+                <img src={gameImageUrl(game)} onError={handleGameImageError} alt={title} />
                 <button type="button" aria-label={`${title}を比較から外す`} onClick={() => toggleCompare(game)}>×</button>
               </div>
             )

--- a/frontend/tests/generated-game-images.spec.js
+++ b/frontend/tests/generated-game-images.spec.js
@@ -19,3 +19,33 @@ test('games that were missing artwork are generated as WebP assets', async ({ re
     expect(body.subarray(8, 12).toString('ascii'), slug).toBe('WEBP')
   }
 })
+
+test('catalogue uses generated WebP when image_url is missing', async ({ page }) => {
+  await page.route('**/api/games?**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        games: [
+          {
+            id: 'missing-image-fixture',
+            slug: 'bounce-off',
+            title: 'Bounce-Off',
+            title_ja: 'バウンス・オフ！',
+            image_url: null,
+            min_players: 2,
+            max_players: 4,
+            play_time: 15,
+            published_year: 2014,
+          },
+        ],
+        total: 1,
+      }),
+    })
+  })
+
+  await page.goto('/')
+
+  const image = page.getByRole('img', { name: 'バウンス・オフ！' })
+  await expect(image).toHaveAttribute('src', '/images/games/generated/bounce-off.webp')
+})


### PR DESCRIPTION
## Outcome
Wire the 68 generated WebP assets from #257 into the catalogue UI.

## Behavior
- Missing, blank, `placeholder`, or generic `no-image` image values resolve to `/images/games/generated/<slug>.webp`.
- If no generated asset exists for a future slug, the browser falls back to the existing `/assets/no-image.webp` instead of leaving a broken image.
- The same resolver is used by cards, comparison tray, and comparison battle.

This keeps production database rows unchanged and avoids a 68-row data migration solely for presentation fallback.