### PR TITLE
Fallback to one production deploy when Vercel Git misses main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,9 +90,11 @@ jobs:
       - name: Record quota-deferred production state
         if: steps.budget.outputs.state == 'quota_saturated'
         run: |
-          echo "Production build passed; deployment verification is deferred because the Vercel team is at the observed 24h deployment limit." >> "$GITHUB_STEP_SUMMARY"
+          echo "Production build passed; deployment is deferred because the Vercel team is at the observed 24h deployment limit." >> "$GITHUB_STEP_SUMMARY"
           echo "No deployment creation was attempted by GitHub Actions." >> "$GITHUB_STEP_SUMMARY"
       - name: Verify canonical Vercel Git production deployment
+        id: git_verification
+        continue-on-error: true
         if: steps.budget.outputs.state == 'deployable' || steps.budget.outputs.state == 'unknown'
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
@@ -103,6 +105,46 @@ jobs:
           --team-id "${VERCEL_ORG_ID}"
           --timeout-seconds 180
           --poll-seconds 5
+      - name: Deploy production once when Git integration missed exact SHA
+        if: steps.budget.outputs.state == 'deployable' && steps.git_verification.outcome == 'failure'
+        id: push_fallback
+        shell: bash
+        run: |
+          set +e
+          output="$(vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1)"
+          code=$?
+          set -e
+          printf '%s\n' "$output"
+          if [ "$code" -eq 0 ]; then
+            echo "deployed=true" >> "$GITHUB_OUTPUT"
+            echo "Vercel Git integration missed the exact main SHA, so GitHub Actions performed one production fallback deployment." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if printf '%s\n' "$output" | grep -Fq 'api-deployments-free-per-day'; then
+            echo "deployed=false" >> "$GITHUB_OUTPUT"
+            echo "Fallback reached the Vercel deployment quota after preflight; no retry was attempted." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          exit "$code"
+      - name: Verify fallback production deployment
+        if: steps.push_fallback.outputs.deployed == 'true'
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: >-
+          python scripts/verify_vercel_git_deployment.py
+          --sha "${GITHUB_SHA}"
+          --project-id "${VERCEL_PROJECT_ID}"
+          --team-id "${VERCEL_ORG_ID}"
+          --timeout-seconds 180
+          --poll-seconds 5
+      - name: Fail closed when production is still not current
+        if: >-
+          steps.git_verification.outcome == 'failure' &&
+          steps.push_fallback.outputs.deployed != 'true' &&
+          steps.budget.outputs.state != 'quota_saturated'
+        run: |
+          echo "Production still does not match the exact main SHA after verification/fallback." >> "$GITHUB_STEP_SUMMARY"
+          exit 1
 
   Production-Catch-Up:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/test-vercel-git-deployment.yml
+++ b/.github/workflows/test-vercel-git-deployment.yml
@@ -39,12 +39,15 @@ jobs:
         env:
           PYTHONPATH: .
         run: uv run pytest -q backend/tests/test_vercel_git_deployment.py
-      - name: Assert production push never creates a deployment
+      - name: Assert production deploys at most once after exact-SHA verification misses
         shell: bash
         run: |
           test "$(grep -Fc 'vercel deploy --prod --yes' .github/workflows/deploy.yml)" = "1"
+          test "$(grep -Fc 'vercel deploy --prebuilt --prod --yes' .github/workflows/deploy.yml)" = "1"
+          grep -F "id: git_verification" .github/workflows/deploy.yml
+          grep -F "steps.budget.outputs.state == 'deployable' && steps.git_verification.outcome == 'failure'" .github/workflows/deploy.yml
+          grep -F "steps.push_fallback.outputs.deployed == 'true'" .github/workflows/deploy.yml
           grep -F "if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'" .github/workflows/deploy.yml
-          grep -F "if: steps.budget.outputs.state == 'deployable'" .github/workflows/deploy.yml
           grep -F "api-deployments-free-per-day" .github/workflows/deploy.yml
           grep -F "vercel_deployment_budget.py" .github/workflows/deploy.yml
           grep -F "verify_vercel_git_deployment.py" .github/workflows/deploy.yml


### PR DESCRIPTION
## Problem
The current production domain is still serving an older Git SHA even though main contains the auth-header fix and generated WebP catalogue art. The push workflow successfully builds and verifies Supabase/Google OAuth, but exact-SHA Vercel Git verification times out as `not-found`.

## Change
- Keep Vercel Git as the canonical first path.
- If the exact main SHA is still absent after the existing 180-second verification window and the deployment budget is `deployable`, perform exactly one `vercel deploy --prebuilt --prod --yes` fallback.
- Verify the fallback against the exact GitHub SHA.
- Fail closed when production is still stale.
- Update the verifier contract so duplicate deployments remain prohibited: one scheduled catch-up path plus one push fallback only after a failed exact-SHA check.

## Intended outcome
The already-merged auth layout and 68 generated game WebPs can actually reach `bodoge-no-mikata.vercel.app` without waiting for a broken Git integration path.