### PR TITLE
Deploy fallback from source instead of broken prebuilt Python output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -111,7 +111,7 @@ jobs:
         shell: bash
         run: |
           set +e
-          output="$(vercel deploy --prebuilt --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1)"
+          output="$(vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }} 2>&1)"
           code=$?
           set -e
           printf '%s\n' "$output"

--- a/.github/workflows/test-vercel-git-deployment.yml
+++ b/.github/workflows/test-vercel-git-deployment.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Assert production deploys at most once after exact-SHA verification misses
         shell: bash
         run: |
-          test "$(grep -Fc 'vercel deploy --prod --yes' .github/workflows/deploy.yml)" = "1"
-          test "$(grep -Fc 'vercel deploy --prebuilt --prod --yes' .github/workflows/deploy.yml)" = "1"
+          test "$(grep -Fc 'vercel deploy --prod --yes' .github/workflows/deploy.yml)" = "2"
           grep -F "id: git_verification" .github/workflows/deploy.yml
           grep -F "steps.budget.outputs.state == 'deployable' && steps.git_verification.outcome == 'failure'" .github/workflows/deploy.yml
           grep -F "steps.push_fallback.outputs.deployed == 'true'" .github/workflows/deploy.yml


### PR DESCRIPTION
## Evidence
Main push run #652 reached the new fallback, but `vercel deploy --prebuilt --prod` failed while deploying `.vercel/output` with `ENOENT` for `StrEnum-0.4.15.dist-info/LICENSE` inside the generated Python virtualenv.

## Fix
Use the same source deployment command already exercised by the scheduled catch-up path: `vercel deploy --prod --yes`. Keep the exact-SHA miss gate and one-attempt behavior unchanged.

## Contract
The verifier now expects exactly two source deployment call sites: one exact-SHA-gated push fallback and one scheduled/manual catch-up.