### PR TITLE
Queue catch-up behind main deploy and remove redundant local build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,9 @@ permissions:
 
 concurrency:
   group: vercel-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Never let an hourly catch-up cancel a main-push production verification.
+  # A queued catch-up re-checks the exact SHA and becomes a no-op when production is current.
+  cancel-in-progress: false
 
 jobs:
   Build-Preview:
@@ -181,9 +183,6 @@ jobs:
       - name: Verify Google OAuth provider redirect
         if: steps.budget.outputs.state == 'deployable'
         run: python scripts/check_google_oauth.py .vercel/.env.production.local
-      - name: Build latest main for catch-up
-        if: steps.budget.outputs.state == 'deployable'
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy latest main once
         if: steps.budget.outputs.state == 'deployable'
         id: catchup

--- a/.github/workflows/test-vercel-git-deployment.yml
+++ b/.github/workflows/test-vercel-git-deployment.yml
@@ -39,14 +39,19 @@ jobs:
         env:
           PYTHONPATH: .
         run: uv run pytest -q backend/tests/test_vercel_git_deployment.py
-      - name: Assert production deploys at most once after exact-SHA verification misses
+      - name: Assert production deploy and catch-up coordination contract
         shell: bash
         run: |
           test "$(grep -Fc 'vercel deploy --prod --yes' .github/workflows/deploy.yml)" = "2"
+          grep -F "cancel-in-progress: false" .github/workflows/deploy.yml
           grep -F "id: git_verification" .github/workflows/deploy.yml
           grep -F "steps.budget.outputs.state == 'deployable' && steps.git_verification.outcome == 'failure'" .github/workflows/deploy.yml
           grep -F "steps.push_fallback.outputs.deployed == 'true'" .github/workflows/deploy.yml
           grep -F "if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'" .github/workflows/deploy.yml
+          if grep -Fq "Build latest main for catch-up" .github/workflows/deploy.yml; then
+            echo "Catch-up must not perform a redundant local Vercel build before source deployment."
+            exit 1
+          fi
           grep -F "api-deployments-free-per-day" .github/workflows/deploy.yml
           grep -F "vercel_deployment_budget.py" .github/workflows/deploy.yml
           grep -F "verify_vercel_git_deployment.py" .github/workflows/deploy.yml


### PR DESCRIPTION
## Evidence
The hourly schedule run #655 cancelled the in-flight main push run #654 because both shared the same concurrency group with `cancel-in-progress: true`. The scheduled catch-up then failed before deployment because its local `vercel build` attempted to spawn `uv`, which that job never installs (`spawn uv ENOENT`).

## Fix
- Set `cancel-in-progress: false` so an hourly catch-up queues behind a main push instead of cancelling it. Once it starts, its exact-SHA budget check makes it a no-op if production is already current.
- Remove the redundant local `vercel build` from catch-up. Catch-up already performs a normal source `vercel deploy --prod --yes`, whose remote production build is the deployment authority.
- Extend the verifier contract to prevent these regressions.

## Outcome
Main push gets an uninterrupted 180s Git-integration check and one source-deploy fallback. Scheduled catch-up remains a recovery path rather than an interrupting competing deploy.