### PR TITLE
Replace unclear SYNOPSIS heading with Japanese game summary label

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -171,7 +171,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
 
           <div className="pro-card pro-card--synopsis">
-            <div className="pro-card-title">SYNOPSIS</div>
+            <div className="pro-card-title">30秒でわかる「{title}」</div>
             <div className="summary-text">{game.summary || game.description}</div>
           </div>
 


### PR DESCRIPTION
## What changed
- replace the English `SYNOPSIS` heading on every game detail page with `30秒でわかる「{ゲーム名}」`
- keep the existing summary data and layout unchanged

## Why
The production game page exposed an unexplained English label even though the product is Japanese-first. The new heading tells users exactly what the section contains and reuses the actual game title.

## Verification
- branch diff against `main`: 1 file, 1 addition, 1 deletion
- no data/schema/layout behavior changed