### PR TITLE
Flatten Quick Rules to one desktop row

### DIFF
--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -65,8 +65,8 @@ body {
 
 .game-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 1.5rem;
+  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  gap: clamp(2rem, 4vw, 3rem);
   align-items: start;
   width: min(1440px, 100%);
   margin: 0 auto;
@@ -84,7 +84,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  order: 0;
 }
 
 .game-sidebar .pro-stats-grid,
@@ -98,8 +97,12 @@ body {
 
 .game-main {
   width: 100%;
-  max-width: none;
-  order: -1;
+  max-width: 900px;
+}
+
+/* Keep the page's two-column structure; only flatten the four quick-rule cards from two rows to one on wide screens. */
+.game-main .quick-rules-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .game-main .game-content {
@@ -152,6 +155,12 @@ body {
   justify-content: flex-end;
 }
 
+@media (max-width: 1199px) {
+  .game-main .quick-rules-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 900px) {
   #root {
     grid-template-columns: minmax(0, 1fr);
@@ -176,6 +185,12 @@ body {
 
   .game-sidebar {
     order: 0;
+  }
+}
+
+@media (max-width: 700px) {
+  .game-main .quick-rules-grid {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -32,7 +32,7 @@ const bigShot = {
 async function mockGameApi(page, game = bigShot) {
   await page.route('**/api/games**', async route => {
     const url = new URL(route.request().url())
-    if (url.pathname === '/api/games/big-shot') {
+    if (url.pathname === `/api/games/${game.slug}`) {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
       return
     }
@@ -86,6 +86,35 @@ test('game detail keeps a readable desktop main and puts quick rules before meta
   expect(Math.abs(compact.sidebar.width - compact.main.width)).toBeLessThan(2)
   expect(compact.sidebar.y).toBeGreaterThan(compact.main.y + compact.main.height - 2)
   await expect(page.getByText('検証済みの要約はまだありません')).toBeVisible()
+})
+
+test('quick rules flatten from two rows to one on desktop without flattening the page columns', async ({ page }) => {
+  const skullKing = {
+    ...bigShot,
+    id: 269,
+    slug: 'skull-king',
+    title: 'Skull King',
+    title_ja: 'スカルキング',
+  }
+
+  await mockGameApi(page, skullKing)
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await page.goto('/games/skull-king')
+
+  const cards = page.locator('.quick-rule-card')
+  await expect(cards).toHaveCount(4)
+
+  const boxes = await cards.evaluateAll(nodes => nodes.map(node => {
+    const rect = node.getBoundingClientRect()
+    return { x: rect.x, y: rect.y, width: rect.width }
+  }))
+
+  const ys = boxes.map(box => box.y)
+  expect(Math.max(...ys) - Math.min(...ys)).toBeLessThan(2)
+  expect(boxes.every(box => box.width > 0)).toBe(true)
+
+  const desktop = await readLayout(page)
+  expect(desktop.main.x).toBeGreaterThan(desktop.sidebar.x + desktop.sidebar.width)
 })
 
 test('setup tab shows only game-specific summaries and fails closed when missing', async ({ page }) => {

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -60,16 +60,7 @@ async function readLayout(page) {
   })
 }
 
-function expectSingleColumn(layout) {
-  expect(layout.scrollWidth).toBe(layout.clientWidth)
-  expect(Math.abs(layout.sidebar.x - layout.main.x)).toBeLessThan(2)
-  expect(Math.abs(layout.sidebar.width - layout.main.width)).toBeLessThan(2)
-  expect(layout.sidebar.y).toBeGreaterThan(layout.main.y + layout.main.height - 2)
-  expect(layout.titleX).toBeGreaterThanOrEqual(layout.main.x)
-  expect(layout.tabsX).toBeGreaterThanOrEqual(layout.main.x)
-}
-
-test('game detail stays single-column at desktop and compact widths', async ({ page }) => {
+test('game detail keeps a readable desktop main and puts quick rules before metadata at 800px', async ({ page }) => {
   await mockGameApi(page)
   await page.setViewportSize({ width: 1280, height: 900 })
   await page.goto('/games/big-shot')
@@ -78,14 +69,22 @@ test('game detail stays single-column at desktop and compact widths', async ({ p
   await expect(page.getByRole('tab', { name: /詳しいルール/ })).toBeVisible()
 
   const desktop = await readLayout(page)
-  expectSingleColumn(desktop)
-  expect(desktop.main.width).toBeGreaterThan(1000)
+  expect(desktop.scrollWidth).toBe(desktop.clientWidth)
+  expect(desktop.sidebar.width).toBeGreaterThanOrEqual(280)
+  expect(desktop.sidebar.width).toBeLessThanOrEqual(340)
+  expect(desktop.main.width).toBeGreaterThan(600)
+  expect(desktop.main.x).toBeGreaterThan(desktop.sidebar.x + desktop.sidebar.width)
+  expect(desktop.titleX).toBeGreaterThanOrEqual(desktop.main.x)
+  expect(desktop.tabsX).toBeGreaterThanOrEqual(desktop.main.x)
 
   await page.setViewportSize({ width: 800, height: 900 })
   await expect(page.locator('.game-layout')).toHaveCSS('grid-template-columns', /\d+(?:\.\d+)?px/)
 
   const compact = await readLayout(page)
-  expectSingleColumn(compact)
+  expect(compact.scrollWidth).toBe(compact.clientWidth)
+  expect(Math.abs(compact.sidebar.x - compact.main.x)).toBeLessThan(2)
+  expect(Math.abs(compact.sidebar.width - compact.main.width)).toBeLessThan(2)
+  expect(compact.sidebar.y).toBeGreaterThan(compact.main.y + compact.main.height - 2)
   await expect(page.getByText('検証済みの要約はまだありません')).toBeVisible()
 })
 


### PR DESCRIPTION
## Outcome

Correct the earlier scope mistake.

- restore the game detail page's original two-column desktop layout
- keep the existing GamePage information/interaction structure unchanged
- change only the four QUICK RULES cards from 2 columns × 2 rows to 4 columns × 1 row on wide desktop
- preserve responsive wrapping on narrower screens
- add a regression that verifies both conditions together: page remains two-column, QUICK RULES cards share one row

This supersedes the incorrect layout interpretation in #271.