### PR TITLE
Collapse duplicate game-detail controls to one row

### DIFF
--- a/frontend/src/components/game/QuickRulesPanel.jsx
+++ b/frontend/src/components/game/QuickRulesPanel.jsx
@@ -1,7 +1,7 @@
 import { ScoringBreakdown } from './ScoringBreakdown'
 import './rule-guide.css'
 
-export function QuickRulesPanel({ guide, onShowFlow, onShowRules }) {
+export function QuickRulesPanel({ guide }) {
   if (!guide) {
     return (
       <section className="quick-rules-panel quick-rules-unavailable" aria-label="すぐ遊ぶ">
@@ -10,11 +10,6 @@ export function QuickRulesPanel({ guide, onShowFlow, onShowRules }) {
         <p style={{ marginTop: '0.55rem', lineHeight: 1.6 }}>
           未確認内容は推測表示しません。詳しいルールと出典を確認してください。
         </p>
-        {onShowRules && (
-          <div className="quick-rules-actions">
-            <button type="button" className="quick-rule-action" onClick={onShowRules}>詳しいルールを見る</button>
-          </div>
-        )}
       </section>
     )
   }
@@ -62,14 +57,9 @@ export function QuickRulesPanel({ guide, onShowFlow, onShowRules }) {
 
       <ScoringBreakdown scoring={guide.scoring} />
 
-      <div className="quick-rules-actions">
-        {onShowFlow && <button type="button" className="quick-rule-action" onClick={onShowFlow}>図で見る</button>}
-        {onShowRules && <button type="button" className="quick-rule-action" onClick={onShowRules}>詳しいルール</button>}
-        <a className="quick-rule-action" href={guide.source.url} target="_blank" rel="noreferrer">公式出典</a>
-      </div>
-
       <div className="quick-rules-source">
-        {guide.source.label} / rule version: {guide.ruleVersion}。要約は公式裁定そのものではありません。
+        <a href={guide.source.url} target="_blank" rel="noreferrer">公式出典: {guide.source.label}</a>
+        {' / '}rule version: {guide.ruleVersion}。要約は公式裁定そのものではありません。
       </div>
     </section>
   )

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -117,6 +117,26 @@ test('quick rules flatten from two rows to one on desktop without flattening the
   expect(desktop.main.x).toBeGreaterThan(desktop.sidebar.x + desktop.sidebar.width)
 })
 
+test('game detail uses one navigation row after quick rules', async ({ page }) => {
+  const skullKing = {
+    ...bigShot,
+    id: 269,
+    slug: 'skull-king',
+    title: 'Skull King',
+    title_ja: 'スカルキング',
+  }
+
+  await mockGameApi(page, skullKing)
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await page.goto('/games/skull-king')
+
+  await expect(page.locator('.quick-rules-actions')).toHaveCount(0)
+  await expect(page.getByRole('tablist', { name: 'ゲーム詳細表示' })).toHaveCount(1)
+  await expect(page.getByRole('tab', { name: /詳しいルール/ })).toHaveCount(1)
+  await expect(page.getByRole('tab', { name: /図で見る/ })).toHaveCount(1)
+  await expect(page.getByRole('link', { name: /公式出典:/ })).toHaveCount(1)
+})
+
 test('setup tab shows only game-specific summaries and fails closed when missing', async ({ page }) => {
   await mockGameApi(page)
   await page.goto('/games/big-shot')

--- a/frontend/tests/rule_guide.spec.js
+++ b/frontend/tests/rule_guide.spec.js
@@ -125,7 +125,7 @@ test('new user can search IPSO and reach quick rules, scoring, diagram and sourc
   await scoring.scrollIntoViewIfNeeded()
   await page.screenshot({ path: testInfo.outputPath(`ipso-scoring-${testInfo.project.name}.png`), animations: 'disabled' })
 
-  await page.getByRole('button', { name: '図で見る', exact: true }).first().click()
+  await page.getByRole('tab', { name: /図で見る/ }).click()
   const flow = page.getByTestId('rule-flow-diagram')
   await expect(flow).toBeVisible()
   await expect(flow.getByText('全員の14枚がすべて表向き？')).toBeVisible()


### PR DESCRIPTION
## Outcome

Fix the unreadable transition shown on the Skull King detail page without changing page columns or Quick Rules card layout.

- remove the duplicate Quick Rules action row (`図で見る / 詳しいルール / 公式出典`)
- keep the existing game-detail tab row as the single navigation row
- move `公式出典` into the provenance/source line instead of presenting it as navigation
- keep the two-column desktop page and current Quick Rules card layout unchanged
- add a browser regression proving the duplicate action row is absent and exactly one game-detail tablist remains

Production component delta: QuickRulesPanel -10 net lines. No GamePage information architecture change.