### PR TITLE
fix: audit canonical source URLs

### DIFF
--- a/backend/app/scripts/validate_urls.py
+++ b/backend/app/scripts/validate_urls.py
@@ -10,6 +10,7 @@ load_dotenv()
 _VALIDATE_FIELDS = [
     "bgg_url",
     "bga_url",
+    "source_url",
     "official_url",
     "image_url",
     "amazon_url",

--- a/backend/tests/test_validate_urls.py
+++ b/backend/tests/test_validate_urls.py
@@ -1,0 +1,5 @@
+from app.scripts.validate_urls import _VALIDATE_FIELDS
+
+
+def test_primary_source_links_are_url_audited():
+    assert {"source_url", "official_url"} <= set(_VALIDATE_FIELDS)


### PR DESCRIPTION
## Finding
`task validate-urls` audited `official_url` but not the canonical `source_url` exposed by `GameDetail` and used by the GamePage source link.

Current production has 189 games, with 96 non-empty `source_url` values. One record (`relative-space`) has a source URL with no `official_url`, and three records (`flip-7-with-a-vengeance`, `skull-king`, `yro`) have different `source_url` and `official_url` values. Those exact source links therefore were not covered by the URL audit.

## Change
- include `source_url` in `_VALIDATE_FIELDS`
- add a regression test requiring both `source_url` and `official_url` to remain audited

No database mutation is performed by this PR; `validate-urls` remains read-only unless `--apply` is explicitly passed.

## Verification target
- targeted pytest for `test_validate_urls.py`
- backend lint/test CI
- exact-head checks before merge