### PR TITLE
Restore game detail to a single column

### DIFF
--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -65,8 +65,8 @@ body {
 
 .game-layout {
   display: grid;
-  grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
-  gap: clamp(2rem, 4vw, 3rem);
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1.5rem;
   align-items: start;
   width: min(1440px, 100%);
   margin: 0 auto;
@@ -84,6 +84,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+  order: 0;
 }
 
 .game-sidebar .pro-stats-grid,
@@ -97,10 +98,11 @@ body {
 
 .game-main {
   width: 100%;
-  max-width: 900px;
+  max-width: none;
+  order: -1;
 }
 
-/* Keep the page's two-column structure; only flatten the four quick-rule cards from two rows to one on wide screens. */
+/* Keep quick-rule cards flat on wide screens while the page itself stays single-column. */
 .game-main .quick-rules-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
@@ -171,20 +173,6 @@ body {
 
   #root > aside {
     display: none;
-  }
-
-  .game-layout {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.5rem;
-  }
-
-  .game-main {
-    max-width: none;
-    order: -1;
-  }
-
-  .game-sidebar {
-    order: 0;
   }
 }
 

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -60,7 +60,16 @@ async function readLayout(page) {
   })
 }
 
-test('game detail keeps a readable desktop main and puts quick rules before metadata at 800px', async ({ page }) => {
+function expectSingleColumn(layout) {
+  expect(layout.scrollWidth).toBe(layout.clientWidth)
+  expect(Math.abs(layout.sidebar.x - layout.main.x)).toBeLessThan(2)
+  expect(Math.abs(layout.sidebar.width - layout.main.width)).toBeLessThan(2)
+  expect(layout.sidebar.y).toBeGreaterThan(layout.main.y + layout.main.height - 2)
+  expect(Math.abs(layout.titleX - layout.main.x)).toBeLessThan(2)
+  expect(Math.abs(layout.tabsX - layout.main.x)).toBeLessThan(2)
+}
+
+test('game detail stays single-column at desktop and compact widths', async ({ page }) => {
   await mockGameApi(page)
   await page.setViewportSize({ width: 1280, height: 900 })
   await page.goto('/games/big-shot')
@@ -69,26 +78,16 @@ test('game detail keeps a readable desktop main and puts quick rules before meta
   await expect(page.getByRole('tab', { name: /詳しいルール/ })).toBeVisible()
 
   const desktop = await readLayout(page)
-  expect(desktop.scrollWidth).toBe(desktop.clientWidth)
-  expect(desktop.sidebar.width).toBeGreaterThanOrEqual(280)
-  expect(desktop.sidebar.width).toBeLessThanOrEqual(340)
-  expect(desktop.main.width).toBeGreaterThan(600)
-  expect(desktop.main.x).toBeGreaterThan(desktop.sidebar.x + desktop.sidebar.width)
-  expect(desktop.titleX).toBeGreaterThanOrEqual(desktop.main.x)
-  expect(desktop.tabsX).toBeGreaterThanOrEqual(desktop.main.x)
+  expectSingleColumn(desktop)
+  expect(desktop.main.width).toBeGreaterThan(1000)
 
   await page.setViewportSize({ width: 800, height: 900 })
-  await expect(page.locator('.game-layout')).toHaveCSS('grid-template-columns', /\d+(?:\.\d+)?px/)
-
   const compact = await readLayout(page)
-  expect(compact.scrollWidth).toBe(compact.clientWidth)
-  expect(Math.abs(compact.sidebar.x - compact.main.x)).toBeLessThan(2)
-  expect(Math.abs(compact.sidebar.width - compact.main.width)).toBeLessThan(2)
-  expect(compact.sidebar.y).toBeGreaterThan(compact.main.y + compact.main.height - 2)
+  expectSingleColumn(compact)
   await expect(page.getByText('検証済みの要約はまだありません')).toBeVisible()
 })
 
-test('quick rules flatten from two rows to one on desktop without flattening the page columns', async ({ page }) => {
+test('quick rules flatten to one row on wide desktop inside the single-column page', async ({ page }) => {
   const skullKing = {
     ...bigShot,
     id: 269,
@@ -112,9 +111,7 @@ test('quick rules flatten from two rows to one on desktop without flattening the
   const ys = boxes.map(box => box.y)
   expect(Math.max(...ys) - Math.min(...ys)).toBeLessThan(2)
   expect(boxes.every(box => box.width > 0)).toBe(true)
-
-  const desktop = await readLayout(page)
-  expect(desktop.main.x).toBeGreaterThan(desktop.sidebar.x + desktop.sidebar.width)
+  expectSingleColumn(await readLayout(page))
 })
 
 test('game detail uses one navigation row after quick rules', async ({ page }) => {


### PR DESCRIPTION
## Outcome

Fix the layout shown in production: the game detail page still had a left `GLOSSARY / LINKS` sidebar beside the rule content.

- change `.game-layout` from `340px + 1fr` to one full-width column
- keep `.game-main` first and move `.game-sidebar` below it
- remove the desktop `max-width: 900px` cap from the rule content
- keep Quick Rules card layout and the single navigation tab row unchanged
- update the browser geometry contract so 1280px and 800px both require one-column layout

Scope: layout CSS + its regression contract only. No information architecture or rule-content change.