### PR TITLE
Refine game detail layout for readable long-form flow

### DIFF
--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -84,7 +84,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  order: 0;
 }
 
 .game-sidebar .pro-stats-grid,
@@ -96,15 +95,26 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
+.game-sidebar .summary-text,
+.game-sidebar .tip-item,
+.game-sidebar .mistake-item {
+  max-width: 72ch;
+}
+
 .game-main {
   width: 100%;
   max-width: none;
-  order: -1;
 }
 
-/* Keep quick-rule cards flat on wide screens while the page itself stays single-column. */
+/* Wide, scan-heavy cards can use the canvas; long-form copy keeps a readable measure. */
 .game-main .quick-rules-grid {
   grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.game-main .markdown-content > :where(h1, h2, h3, h4, h5, h6, p, ul, ol, blockquote),
+.game-main .coach-mode,
+.game-main .persona-reviews {
+  max-width: 72ch;
 }
 
 .game-main .game-content {

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -146,71 +146,6 @@ export default function GamePage({ slug: propSlug, initialGame }) {
       </div>
 
       <div className="game-layout">
-        <div className="game-sidebar" aria-label="ゲーム基本情報">
-          <div className="pro-stats-grid">
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">PLAYERS</div>
-              <div className="pro-stat-value">
-                {game.min_players != null
-                  ? `${game.min_players}${game.max_players != null && game.max_players !== game.min_players ? `-${game.max_players}` : ''}`
-                  : 'N/A'}
-              </div>
-            </div>
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">TIME</div>
-              <div className="pro-stat-value">{game.play_time != null ? `${game.play_time}m` : 'N/A'}</div>
-            </div>
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">AGE</div>
-              <div className="pro-stat-value">{game.min_age != null ? `${game.min_age}+` : 'N/A'}</div>
-            </div>
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">YEAR</div>
-              <div className="pro-stat-value">{game.published_year || 'N/A'}</div>
-            </div>
-          </div>
-
-          <div className="pro-card pro-card--synopsis">
-            <div className="pro-card-title">30秒でわかる「{title}」</div>
-            <div className="summary-text">{game.summary || game.description}</div>
-          </div>
-
-          <div className="pro-card" aria-label="データ信頼状態">
-            <div className="pro-card-title">TRUST &amp; PROVENANCE</div>
-            <div className="game-empty-note">{identityLabel}</div>
-            <div className="game-empty-note">{sourceTrustLabel}</div>
-            <div className="game-empty-note">{reviewLabel}</div>
-          </div>
-
-          {sd.pro_tips?.length > 0 && (
-            <div className="pro-card">
-              <div className="pro-card-title">💡 PRO TIPS</div>
-              {sd.pro_tips.map((tip, i) => (
-                <div key={i} className="tip-item">
-                  <span className="tip-bullet">»</span>
-                  <span>{tip}</span>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {sd.rule_mistakes?.length > 0 && (
-            <div className="pro-card">
-              <div className="pro-card-title">⚠️ COMMON ERRORS</div>
-              {sd.rule_mistakes.map((err, i) => (
-                <div key={i} className="mistake-item">{err}</div>
-              ))}
-            </div>
-          )}
-
-          <ConceptGlossary slug={slug} legacyKeywords={sd.keywords || []} />
-
-          <div className="pro-card">
-            <div className="pro-card-title">LINKS</div>
-            <ExternalLinks game={game} />
-          </div>
-        </div>
-
         <div className="game-main">
           <div className="game-content">
             <h1 className="game-title">{title}</h1>
@@ -409,6 +344,71 @@ export default function GamePage({ slug: propSlug, initialGame }) {
             )}
 
             {activeTab === 'data' && <pre className="game-data-dump">{JSON.stringify(game, null, 2)}</pre>}
+          </div>
+        </div>
+
+        <div className="game-sidebar" aria-label="ゲーム基本情報">
+          <div className="pro-stats-grid">
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">PLAYERS</div>
+              <div className="pro-stat-value">
+                {game.min_players != null
+                  ? `${game.min_players}${game.max_players != null && game.max_players !== game.min_players ? `-${game.max_players}` : ''}`
+                  : 'N/A'}
+              </div>
+            </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">TIME</div>
+              <div className="pro-stat-value">{game.play_time != null ? `${game.play_time}m` : 'N/A'}</div>
+            </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">AGE</div>
+              <div className="pro-stat-value">{game.min_age != null ? `${game.min_age}+` : 'N/A'}</div>
+            </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">YEAR</div>
+              <div className="pro-stat-value">{game.published_year || 'N/A'}</div>
+            </div>
+          </div>
+
+          <div className="pro-card pro-card--synopsis">
+            <div className="pro-card-title">30秒でわかる「{title}」</div>
+            <div className="summary-text">{game.summary || game.description}</div>
+          </div>
+
+          <div className="pro-card" aria-label="データ信頼状態">
+            <div className="pro-card-title">TRUST &amp; PROVENANCE</div>
+            <div className="game-empty-note">{identityLabel}</div>
+            <div className="game-empty-note">{sourceTrustLabel}</div>
+            <div className="game-empty-note">{reviewLabel}</div>
+          </div>
+
+          {sd.pro_tips?.length > 0 && (
+            <div className="pro-card">
+              <div className="pro-card-title">💡 PRO TIPS</div>
+              {sd.pro_tips.map((tip, i) => (
+                <div key={i} className="tip-item">
+                  <span className="tip-bullet">»</span>
+                  <span>{tip}</span>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {sd.rule_mistakes?.length > 0 && (
+            <div className="pro-card">
+              <div className="pro-card-title">⚠️ COMMON ERRORS</div>
+              {sd.rule_mistakes.map((err, i) => (
+                <div key={i} className="mistake-item">{err}</div>
+              ))}
+            </div>
+          )}
+
+          <ConceptGlossary slug={slug} legacyKeywords={sd.keywords || []} />
+
+          <div className="pro-card">
+            <div className="pro-card-title">LINKS</div>
+            <ExternalLinks game={game} />
           </div>
         </div>
       </div>

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -42,12 +42,17 @@ async function mockGameApi(page, game = bigShot) {
 
 async function readLayout(page) {
   return page.evaluate(() => {
-    const sidebar = document.querySelector('.game-sidebar')?.getBoundingClientRect()
-    const main = document.querySelector('.game-main')?.getBoundingClientRect()
+    const sidebarEl = document.querySelector('.game-sidebar')
+    const mainEl = document.querySelector('.game-main')
+    const sidebar = sidebarEl?.getBoundingClientRect()
+    const main = mainEl?.getBoundingClientRect()
     const title = document.querySelector('.game-title')?.getBoundingClientRect()
     const tabs = document.querySelector('.rules-tabs')?.getBoundingClientRect()
+    const readingLine = document.querySelector('.markdown-content p')?.getBoundingClientRect()
 
-    if (!sidebar || !main || !title || !tabs) throw new Error('game detail layout nodes are missing')
+    if (!sidebarEl || !mainEl || !sidebar || !main || !title || !tabs || !readingLine) {
+      throw new Error('game detail layout nodes are missing')
+    }
 
     return {
       clientWidth: document.documentElement.clientWidth,
@@ -56,20 +61,24 @@ async function readLayout(page) {
       main: { x: main.x, y: main.y, width: main.width, height: main.height },
       titleX: title.x,
       tabsX: tabs.x,
+      readingLine: { x: readingLine.x, width: readingLine.width },
+      mainBeforeSidebar: Boolean(mainEl.compareDocumentPosition(sidebarEl) & Node.DOCUMENT_POSITION_FOLLOWING),
     }
   })
 }
 
-function expectSingleColumn(layout) {
+function expectSinglePrimaryFlow(layout) {
   expect(layout.scrollWidth).toBe(layout.clientWidth)
+  expect(layout.mainBeforeSidebar).toBe(true)
   expect(Math.abs(layout.sidebar.x - layout.main.x)).toBeLessThan(2)
   expect(Math.abs(layout.sidebar.width - layout.main.width)).toBeLessThan(2)
   expect(layout.sidebar.y).toBeGreaterThan(layout.main.y + layout.main.height - 2)
   expect(Math.abs(layout.titleX - layout.main.x)).toBeLessThan(2)
   expect(Math.abs(layout.tabsX - layout.main.x)).toBeLessThan(2)
+  expect(Math.abs(layout.readingLine.x - layout.main.x)).toBeLessThan(2)
 }
 
-test('game detail stays single-column at desktop and compact widths', async ({ page }) => {
+test('game detail keeps one primary flow and readable long-form measure', async ({ page }) => {
   await mockGameApi(page)
   await page.setViewportSize({ width: 1280, height: 900 })
   await page.goto('/games/big-shot')
@@ -78,12 +87,15 @@ test('game detail stays single-column at desktop and compact widths', async ({ p
   await expect(page.getByRole('tab', { name: /詳しいルール/ })).toBeVisible()
 
   const desktop = await readLayout(page)
-  expectSingleColumn(desktop)
+  expectSinglePrimaryFlow(desktop)
   expect(desktop.main.width).toBeGreaterThan(1000)
+  expect(desktop.readingLine.width).toBeLessThan(900)
+  expect(desktop.readingLine.width).toBeLessThan(desktop.main.width)
 
   await page.setViewportSize({ width: 800, height: 900 })
   const compact = await readLayout(page)
-  expectSingleColumn(compact)
+  expectSinglePrimaryFlow(compact)
+  expect(compact.readingLine.width).toBeLessThanOrEqual(compact.main.width)
   await expect(page.getByText('検証済みの要約はまだありません')).toBeVisible()
 })
 
@@ -111,7 +123,7 @@ test('quick rules flatten to one row on wide desktop inside the single-column pa
   const ys = boxes.map(box => box.y)
   expect(Math.max(...ys) - Math.min(...ys)).toBeLessThan(2)
   expect(boxes.every(box => box.width > 0)).toBe(true)
-  expectSingleColumn(await readLayout(page))
+  expectSinglePrimaryFlow(await readLayout(page))
 })
 
 test('game detail uses one navigation row after quick rules', async ({ page }) => {


### PR DESCRIPTION
## Outcome

Re-evaluate the game-detail layout against current 2026 design-system guidance instead of treating “one column” as sufficient by itself.

### Decision
- keep one primary page flow; do **not** restore the old permanent metadata/glossary sidebar because that rail was not navigation
- stop rendering long-form rules at the full desktop canvas width
- preserve wide space for scan-heavy Quick Rules cards
- make DOM order match visual/reading order: primary game content first, supplementary game information after it

### Evidence applied
- USWDS: readable text measure is generally 45–90 characters, with ~66 a good long-text target
- GOV.UK: desktop text should usually stay around <=75 characters per line rather than stretching to full viewport width
- Apple HIG: sidebars consume substantial horizontal space and are primarily a navigation pattern
- Google documentation accessibility guidance: visual positioning/order should reflect DOM reading order

### Changes
- remove CSS `order` reordering from `.game-main` / `.game-sidebar`
- move `.game-main` before `.game-sidebar` in the DOM
- cap long-form Markdown headings/copy, coach mode, persona reviews and supplementary text at `72ch`
- keep `.game-layout` structurally single-column and keep Quick Rules responsive 4/2/1 columns
- strengthen Playwright geometry contract to verify semantic main-before-supplementary order and readable prose width

No rule data, tab information architecture, Quick Rules semantics, or canonical source content changes.