### PR TITLE
ci: verify Mechanical DNA production contract

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,14 @@ jobs:
         run: |
           echo "Production still does not match the exact main SHA after verification/fallback." >> "$GITHUB_STEP_SUMMARY"
           exit 1
+      - name: Verify Mechanical DNA production contract
+        if: >-
+          steps.budget.outputs.state == 'current' ||
+          steps.git_verification.outcome == 'success' ||
+          steps.push_fallback.outputs.deployed == 'true'
+        run: >-
+          python backend/app/scripts/verify_production_contract.py
+          --base-url https://bodoge-no-mikata.vercel.app
 
   Production-Catch-Up:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -214,3 +222,8 @@ jobs:
           --team-id "${VERCEL_ORG_ID}"
           --timeout-seconds 180
           --poll-seconds 5
+      - name: Verify Mechanical DNA production contract
+        if: steps.budget.outputs.state == 'current' || steps.catchup.outputs.deployed == 'true'
+        run: >-
+          python backend/app/scripts/verify_production_contract.py
+          --base-url https://bodoge-no-mikata.vercel.app

--- a/.github/workflows/test-mechanical-dna.yml
+++ b/.github/workflows/test-mechanical-dna.yml
@@ -7,7 +7,9 @@ on:
       - "backend/app/models/mechanical_dna.py"
       - "backend/app/routers/mechanical_dna.py"
       - "backend/app/services/mechanical_dna.py"
+      - "backend/app/scripts/verify_production_contract.py"
       - "backend/tests/test_mechanical_dna.py"
+      - "backend/tests/test_production_contract.py"
       - "frontend/src/pages/GamePage.jsx"
       - ".github/workflows/test-mechanical-dna.yml"
   push:
@@ -17,7 +19,9 @@ on:
       - "backend/app/models/mechanical_dna.py"
       - "backend/app/routers/mechanical_dna.py"
       - "backend/app/services/mechanical_dna.py"
+      - "backend/app/scripts/verify_production_contract.py"
       - "backend/tests/test_mechanical_dna.py"
+      - "backend/tests/test_production_contract.py"
       - "frontend/src/pages/GamePage.jsx"
       - ".github/workflows/test-mechanical-dna.yml"
 
@@ -43,12 +47,16 @@ jobs:
           backend/app/models/mechanical_dna.py
           backend/app/services/mechanical_dna.py
           backend/app/routers/mechanical_dna.py
+          backend/app/scripts/verify_production_contract.py
           backend/app/main.py
 
       - name: Run Mechanical DNA contract tests
         env:
           PYTHONPATH: backend
-        run: uv run pytest -q backend/tests/test_mechanical_dna.py
+        run: >-
+          uv run pytest -q
+          backend/tests/test_mechanical_dna.py
+          backend/tests/test_production_contract.py
 
       - name: Gate canonical connection source path
         run: |

--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+from urllib.request import Request, urlopen
+
+MECHANICAL_DNA_PATH = "/api/games/skull-king/connections?limit=8"
+
+
+def validate_mechanical_dna_payload(payload: Any) -> int:
+    if not isinstance(payload, dict):
+        raise ValueError("Mechanical DNA response must be a JSON object")
+
+    expected = {
+        "schema_version": "1.0",
+        "algorithm_version": "mechanical-dna-concept-v1",
+        "status": "available",
+        "slug": "skull-king",
+    }
+    for key, value in expected.items():
+        if payload.get(key) != value:
+            raise ValueError(f"unexpected {key}: {payload.get(key)!r}; expected {value!r}")
+
+    connections = payload.get("connections")
+    if not isinstance(connections, list):
+        raise ValueError("connections must be a JSON array")
+
+    return len(connections)
+
+
+def verify_production(base_url: str, timeout_seconds: float = 20.0) -> int:
+    url = f"{base_url.rstrip('/')}{MECHANICAL_DNA_PATH}"
+    request = Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "rule-scribe-games-production-contract/1.0",
+        },
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+        if response.status != 200:
+            raise RuntimeError(f"Mechanical DNA production endpoint returned HTTP {response.status}")
+        payload = json.load(response)
+
+    return validate_mechanical_dna_payload(payload)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Verify canonical production API contracts")
+    parser.add_argument(
+        "--base-url",
+        default="https://bodoge-no-mikata.vercel.app",
+        help="Canonical production origin",
+    )
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    args = parser.parse_args()
+
+    connection_count = verify_production(args.base_url, args.timeout_seconds)
+    print(
+        "Mechanical DNA production contract: OK "
+        f"(algorithm=mechanical-dna-concept-v1, status=available, connections={connection_count})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -1,0 +1,51 @@
+import pytest
+
+from app.scripts.verify_production_contract import validate_mechanical_dna_payload
+
+
+def test_validate_mechanical_dna_payload_accepts_canonical_contract():
+    payload = {
+        "schema_version": "1.0",
+        "algorithm_version": "mechanical-dna-concept-v1",
+        "status": "available",
+        "game_id": "game-id",
+        "slug": "skull-king",
+        "connections": [],
+    }
+
+    assert validate_mechanical_dna_payload(payload) == 0
+
+
+def test_validate_mechanical_dna_payload_allows_future_connections():
+    payload = {
+        "schema_version": "1.0",
+        "algorithm_version": "mechanical-dna-concept-v1",
+        "status": "available",
+        "slug": "skull-king",
+        "connections": [{"slug": "another-game"}],
+    }
+
+    assert validate_mechanical_dna_payload(payload) == 1
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("algorithm_version", "legacy-label-match"),
+        ("status", "not_available"),
+        ("slug", "other-game"),
+        ("connections", None),
+    ],
+)
+def test_validate_mechanical_dna_payload_fails_closed(field, value):
+    payload = {
+        "schema_version": "1.0",
+        "algorithm_version": "mechanical-dna-concept-v1",
+        "status": "available",
+        "slug": "skull-king",
+        "connections": [],
+    }
+    payload[field] = value
+
+    with pytest.raises(ValueError):
+        validate_mechanical_dna_payload(payload)


### PR DESCRIPTION
Closes the remaining production acceptance gap for #231 without changing Mechanical DNA scoring or frontend behavior.

Current production already returns HTTP 200 for `/api/games/skull-king/connections?limit=8` with `schema_version=1.0`, `algorithm_version=mechanical-dna-concept-v1`, `status=available`, and `slug=skull-king`. The previous 404 blocker was the Vercel Git deployment materialization path, which is now producing READY production deployments again.

This PR turns that observed production state into a canonical guard:
- adds a stdlib-only production contract verifier;
- fails closed on legacy algorithm/status/slug or a non-array connections payload;
- deliberately allows the connections array to grow as more canonical game mappings are added;
- runs the check only after production is confirmed current for the exact main SHA, including fallback/catch-up paths;
- adds focused unit tests for the payload contract.

No schema, ranking, Concept mapping, or deployment framework changes.