### PR TITLE
fix: stop asserting unverified Vercel deployment source

### DIFF
--- a/scripts/verify_vercel_git_deployment.py
+++ b/scripts/verify_vercel_git_deployment.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify that Vercel Git integration deployed the expected GitHub SHA.
+"""Verify that Vercel has a READY production deployment for the expected GitHub SHA.
 
 This script is read-only: it never creates or retries a Vercel deployment.
 """
@@ -92,7 +92,7 @@ def verify(*, token: str, team_id: str, project_id: str, expected_sha: str, time
                     return match
                 if match.state in TERMINAL_FAILURE_STATES:
                     raise RuntimeError(
-                        f"Vercel Git deployment {match.deployment_id} for {expected_sha} ended in {match.state}"
+                        f"Vercel production deployment {match.deployment_id} for {expected_sha} ended in {match.state}"
                     )
         except RuntimeError:
             raise
@@ -103,7 +103,7 @@ def verify(*, token: str, team_id: str, project_id: str, expected_sha: str, time
         if time.monotonic() >= deadline:
             detail = f"; last API error: {last_error}" if last_error else ""
             raise TimeoutError(
-                f"Vercel Git production deployment for {expected_sha} was not READY within "
+                f"Vercel production deployment for {expected_sha} was not READY within "
                 f"{timeout_seconds}s (last state: {last_state}){detail}"
             )
         time.sleep(poll_seconds)
@@ -148,7 +148,7 @@ def main() -> int:
         f"- GitHub SHA: `{match.commit_sha}`\n"
         f"- Deployment: `{match.deployment_id}`\n"
         f"- URL: {deployment_url}\n"
-        "- Deployment source: Vercel Git integration (GitHub Actions did not create a second deployment)"
+        "- Deployment source: not asserted by this verifier"
     )
     append_summary(message)
     print(message)


### PR DESCRIPTION
Closes #284.

## Change
- keep exact Git SHA + production target + READY verification unchanged
- stop reporting a READY deployment as `Vercel Git integration` when the verifier cannot distinguish Git integration from the Actions CLI fallback
- make verifier wording source-neutral instead of inventing provenance

## Why this is the smaller solution
The workflow already records when it executes the one-shot fallback. The verifier only needs to answer whether a production deployment for the exact SHA is READY. Adding a second provenance inference layer would create another authority over information the verifier does not observe.

## Delta
- changed files: 1
- dependencies: +0
- workflow/command count: unchanged
- runtime capability: exact-SHA READY verification unchanged
- false provenance claim: 1 -> 0
- new fallback/retry paths: 0

Exact-head CI and read-back are required before merge.