### PR TITLE
docs: replace custom process terminology with plain language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,52 +1,50 @@
 # AGENTS.md
 
-This is the canonical operating contract for any coding or repository agent working in `KAFKA2306/rule-scribe-games`.
+This is the operating contract for coding and repository agents working in `KAFKA2306/rule-scribe-games`.
 
-Keep this file short, stable, and operational. Do not duplicate mutable architecture, model versions, schemas, or vendor details here. Use the referenced project docs and the code as the source of truth for those details.
+Keep this file short, stable, and operational. Do not duplicate mutable architecture, schemas, model versions, or vendor details here. Use the referenced project documentation and code for those details.
 
 ## 1. Mission
 
 Improve **ボドゲのミカタ** through small, evidence-backed, production-safe changes.
 
-Optimize for:
+Priorities:
 
 1. correctness and provenance;
-2. one canonical work line;
-3. the smallest safe change set;
-4. targeted verification before broad verification;
-5. merge-to-fixed-point completion;
-6. no stale branches, PRs, temporary files, or superseded work;
-7. a short post-success retrospective that removes repeatable waste without removing safety gates.
+2. one existing issue, pull request, or branch per task;
+3. the smallest safe change;
+4. focused verification before broad verification;
+5. completion through merge and production verification when applicable;
+6. cleanup of stale branches, pull requests, temporary files, and superseded work.
 
-## 2. Source-of-truth order
+## 2. Sources of truth
 
-When instructions or implementation details conflict, use this order:
+When implementation details conflict, use this order:
 
 1. current repository code and tests;
-2. `Taskfile.yml` for established operator commands;
+2. `Taskfile.yml` for established commands;
 3. `docs/CURATED_GAME_FAST_PATH.md` for curated-game additions;
 4. `docs/PROJECT_MASTER_GUIDE.md` for product, schema, API, and UX architecture;
-5. other current docs adjacent to the subsystem being changed.
+5. other current documentation next to the subsystem being changed.
 
-Do not copy mutable facts from those documents into this file unless they are stable operating rules.
-
-## 3. Start every task from current state
+## 3. Start from current state
 
 Before creating work:
 
 - fetch current `main`;
-- inspect open PRs and relevant branches/issues;
-- continue the existing canonical PR/branch if one already represents the task;
-- do not create a replacement branch or PR merely because the existing work is imperfect;
-- keep the task to one issue or one clearly bounded outcome at a time.
+- read this file;
+- inspect open pull requests, relevant issues, branches, CI, data, and production state;
+- continue an existing pull request or branch when it already represents the task;
+- do not create a replacement branch or pull request just because existing work is imperfect;
+- keep one task to one issue or one clearly bounded outcome.
 
-If `main` moves during the task, reconcile with the latest `main` before opening or merging the PR. Prefer a clean canonical history over speculative parallel branches.
+If `main` moves, reconcile with the latest `main` before opening or merging a pull request.
 
-## 4. Command policy
+## 4. Commands
 
-Use `Taskfile.yml` for established workflows.
+Use `Taskfile.yml` when it already provides the operation.
 
-Common entry points include:
+Common commands:
 
 ```bash
 task setup
@@ -60,149 +58,119 @@ task game:verify GAME=<slug>
 task game:release-check
 ```
 
-Do not invent a second script or manual sequence when a Taskfile path already owns that operation.
-
-Direct `uv`, `npm`, `node`, `python`, or shell commands are acceptable only for narrowly scoped diagnostics or when no canonical task exists. If a direct command becomes repeated deterministic work, promote it into the Taskfile or the owning workflow instead of repeating it manually.
+Direct `uv`, `npm`, `node`, `python`, or shell commands are appropriate for focused diagnostics or when no Taskfile command exists. If a direct command becomes repeated deterministic work, add it to the existing command interface instead of maintaining a second procedure.
 
 ## 5. Evidence and provenance
 
 For rules, editions, product facts, and other externally verifiable game data:
 
-- prefer current first-party publisher/designer documentation;
-- record source URL and revision/version evidence in the canonical structured source;
-- stop searching once a sufficient primary source is locked unless contradictory evidence appears;
-- do not substitute community summaries for available primary sources;
-- fail closed when canonical identity or source provenance is ambiguous.
+- prefer current first-party publisher or designer documentation;
+- record source URL and revision or version evidence in the structured source;
+- inspect relevant PDF pages rather than relying on snippets or metadata;
+- do not substitute community summaries when a suitable primary source exists;
+- do not infer missing facts;
+- stop a write when game identity, edition, source, or revision is ambiguous.
 
-For PDFs, inspect the actual relevant pages; do not rely only on search snippets or metadata.
+Keep official facts distinct from generated summaries, translations, interpretations, and recommendations.
 
-## 6. Curated-game fast path
+## 6. Adding a curated game
 
-For a normal curated game addition, the only Git-tracked game-specific source should be:
+For a normal curated-game addition, the only game-specific Git source should be:
 
 `data/curated-games/<slug>.json`
 
-Routine operator command:
+Use:
 
 ```bash
 task game:add GAME=<slug>
 ```
 
-`game:add` is **prepare-only**. It must not write production. Its job is to validate the structured source, source reachability, canonical identity, generated runtime artifacts, and assertions so the JSON is PR-ready.
+`game:add` prepares and validates the source. It must not write production data.
 
-The normal lifecycle is:
+The expected sequence is:
 
-`official source -> one structured JSON -> prepare-only check -> one PR -> focused CI -> merge to main -> main-only catalog publish -> catalog fixed point -> independent frontend deploy -> release-manifest fixed point`
+`official source -> structured JSON -> validation -> pull request -> merge -> catalog publication -> production verification`
 
-### Curated source contract
+The source filename, `GAME`, and canonical slug must match.
 
-- filename, `GAME`, and canonical slug must match;
-- game-specific regression facts belong in the structured `assertions` data;
-- do not create game-specific importer scripts or test files when the generic contract can express the requirement;
-- generated curated artifacts are build outputs, not source files.
+Game-specific regression facts belong in the structured `assertions` data. Do not create game-specific importer scripts or test files when the generic schema and tests can express the requirement.
 
-Never hand-edit or commit:
+Generated files must not be hand-edited or committed:
 
 - `frontend/src/lib/generatedCuratedRuleGuides.js`
 - `frontend/public/curated-guides-manifest.json`
 
-They are regenerated from structured source by the canonical generator.
+Production catalog writes occur only after the reviewed source reaches `main`. Pull requests must not contain production database write steps.
 
-### Production write boundary
+## 7. Change discipline
 
-Pull requests must not write the production catalog.
+Prefer the minimum change that satisfies the completion conditions.
 
-Production publication belongs to the main-only curated workflow after focused validation. The internal publish path rechecks live source and canonical identity immediately before the idempotent write and verifies the catalog fixed point afterward.
-
-Do not bypass this boundary for convenience.
-
-## 7. Change-set discipline
-
-Prefer the minimum change that satisfies the acceptance criteria.
-
-During a focused task, do not:
+Do not:
 
 - redesign unrelated schemas or UI;
 - repair unrelated deployment infrastructure;
-- broaden a content addition into a platform refactor;
-- repeatedly search repository-wide after canonical paths are known;
+- broaden a content change into a platform refactor;
 - create duplicate helpers, importers, workflows, or abstractions;
 - commit generated output when reproducible source exists;
-- silently delete or deprecate production data through absence of a source file.
+- silently delete or deprecate production data because a source file is absent.
 
-If an unrelated blocker is discovered, create or link a separate issue and keep the current work line intact.
+Record unrelated problems separately and keep the current change focused.
 
-## 8. Test and CI policy
+## 8. Tests and CI
 
-Run the narrowest meaningful verification first.
+Run the narrowest meaningful verification first:
 
-Order of preference:
+1. subsystem or unit tests;
+2. focused integration or path-scoped workflow;
+3. build, lint, or type checks relevant to changed code;
+4. broader regression suites when the change can affect them or repository CI requires them.
 
-1. subsystem/unit contract tests;
-2. path-scoped workflow or focused integration test;
-3. build/lint relevant to changed code;
-4. broader regression suites only when the change can affect them or repository gates require them.
+For curated-game source changes, use the existing path-scoped validation rather than making the full browser suite a prerequisite unless frontend behavior changed.
 
-For curated-game changes, the `Curated game fast path` workflow is the primary gate. Do not make the full browser/UI suite a prerequisite for a source-only curated-game change unless frontend behavior itself changed.
+A flaky failed CI job may be rerun once after inspecting the failure. If it fails again without new evidence, stop retrying and record the blocker.
 
-A flaky failed CI job may be rerun once after checking the failure. If it fails again without new evidence, stop retrying and preserve the canonical branch/PR with the blocker recorded.
+For a GitHub write or host-side safety rejection:
 
-For host-side GitHub write/safety rejection:
+1. refetch the current state;
+2. retry the same action once;
+3. if it is rejected again, do not create alternate branches or repeat the write.
 
-1. refetch the current canonical state;
-2. retry the same canonical action once;
-3. if it is rejected again, do not create duplicate branches/PRs or loop retries; record the blocker and stop that write path.
+## 9. Merge and production verification
 
-## 9. Merge and completion fixed point
+Do not treat code written or a green local test as completion.
 
-Do not equate "code written" with completion.
+Complete as far as safely possible through:
 
-For a normal issue, complete as far as safely possible through:
+`implementation -> focused tests -> pull request -> CI -> merge -> issue close -> cleanup -> production verification`
 
-`implementation -> targeted tests -> PR -> CI -> merge -> issue close -> cleanup -> production verification when applicable`
+For curated games, verify both:
 
-For curated games, distinguish two production fixed points:
+- the intended catalog record and source provenance are live;
+- after deployment, the generated revision manifest matches the deployed source revision.
 
-- **catalog fixed point**: canonical production record/source provenance is live and verified;
-- **frontend release fixed point**: the deployed curated revision manifest matches the expected source revision contract.
+A deployment failure is an infrastructure problem unless the requested catalog content itself is unavailable.
 
-A Vercel deployment failure is a separate infrastructure blocker unless the requested catalog content itself is unavailable.
-
-## 10. Cleanup is part of done
+## 10. Cleanup
 
 After merge:
 
-- confirm the issue is closed when appropriate;
-- remove the merged work branch;
-- close superseded or duplicate PRs created by the task;
-- remove temporary files/artifacts introduced by the task;
-- verify no task-specific stale branch or PR remains;
-- do not claim cleanup occurred unless it was checked.
+- close the issue when appropriate;
+- remove merged task branches;
+- close superseded or duplicate pull requests created by the task;
+- remove temporary files or artifacts introduced by the task;
+- verify the cleanup rather than assuming it occurred.
 
-## 11. Success retrospective
+## 11. Communication
 
-After a successful task, perform one short efficiency review.
+Report concrete state:
 
-Identify searches, tool calls, retries, branches, checks, or manual edits that did not affect the outcome. Remove repeatable deterministic waste from the next run by improving the canonical workflow.
-
-Do **not** remove source, identity, semantic, CI, merge, production, or cleanup gates merely to make the path shorter.
-
-If the improvement is reusable but not trivial, make it a separate issue/PR rather than expanding the completed task indefinitely.
-
-Stop when there is no further reusable reduction.
-
-## 12. Communication
-
-Report concrete state, not activity theater.
-
-A completion report should state, as applicable:
-
-- issue/PR URL;
+- issue or pull request URL;
 - what changed;
-- tests and CI result;
-- merge commit;
-- production fixed-point result;
-- cleanup result;
-- blocker only if something remains incomplete.
+- tests and CI;
+- merge commit when merged;
+- production verification when applicable;
+- files, lines, dependencies, or configuration changed when material;
+- only real remaining blockers or risks.
 
-Do not claim a deployment, production write, branch deletion, CI success, or other fixed point unless it was actually verified.
+Do not claim a deployment, production write, branch deletion, CI success, or other external state unless it was directly verified.

--- a/docs/CURATED_GAME_FAST_PATH.md
+++ b/docs/CURATED_GAME_FAST_PATH.md
@@ -1,14 +1,10 @@
-# Curated Game Fast Path
+# Adding a Curated Game
 
-Status: canonical operator workflow for source-grounded game additions.
+This document describes the supported procedure for adding a source-backed game to ボドゲのミカタ.
 
-## Goal
+## Source file
 
-Add one verified game to ボドゲのミカタ with one canonical source file, fail-closed evidence/identity checks, and production writes only after reviewed source reaches `main`.
-
-## Routine operator path
-
-Create or update exactly one Git-tracked source file:
+Create or update one Git-tracked source file:
 
 `data/curated-games/<slug>.json`
 
@@ -18,169 +14,163 @@ Then run:
 task game:add GAME=<slug>
 ```
 
-`GAME` is the only routine operator input. `game:add` is prepare-only: it validates the source contract, reaches the official source, performs a read-only live identity preflight, regenerates local runtime artifacts, and validates the runtime guide. It never writes the production catalog.
+`GAME` is the routine input. `game:add` validates the structured source, checks the official source, performs a read-only production identity check, regenerates local generated files, and validates the runtime guide. It does not write the production catalog.
 
-Filename, `GAME`, and `spec.slug` must match exactly.
+The filename, `GAME`, and `spec.slug` must match.
 
-## Final lifecycle
+## Pull request and publication
 
-1. create/update `data/curated-games/<slug>.json`;
-2. run `task game:add GAME=<slug>`;
-3. open one JSON-only PR;
-4. `Curated game fast path` validates the PR without production-write credentials;
-5. merge to `main`;
-6. the same focused workflow completes its validation on the `main` push;
-7. `publish-catalog` derives only added/modified curated JSON files from the push event;
-8. only when such files exist, it pulls the production environment from Vercel, exports the trusted Supabase server variables, and invokes the internal `publish` mode for those slugs;
-9. `publish` rechecks the primary source and live identity, performs one idempotent catalog write, then verifies the production API/page fixed point once;
-10. Vercel deployment remains independent; after a successful production deploy, `Curated game release verification` checks the deployed revision manifest.
+1. Create or update `data/curated-games/<slug>.json`.
+2. Run `task game:add GAME=<slug>`.
+3. Open one pull request containing the source JSON.
+4. GitHub Actions validates the pull request without production-write credentials.
+5. Merge to `main`.
+6. The same validation runs on the `main` push.
+7. `publish-catalog` identifies added or modified curated JSON files from the push.
+8. When a curated source changed, it obtains the production environment from Vercel and runs the internal publish command for those slugs.
+9. The publish command rechecks the primary source and live identity, performs an idempotent catalog write, and verifies the production API and page.
+10. After a successful Vercel deployment, release verification checks the deployed revision manifest.
 
-Production therefore cannot get ahead of canonical Git source through the normal game-add path.
+Production catalog data therefore cannot be published through this procedure before its source reaches `main`.
 
-## Prepare gate order
+## Validation order
 
-`task game:add GAME=<slug>` executes:
+`task game:add GAME=<slug>`:
 
-1. load the one canonical structured spec;
-2. validate schema/cross-field invariants and focused assertions;
-3. verify the primary source HTTP status with a streamed request without consuming the full body;
-4. preflight production `slug -> work -> edition/language` identity read-only;
-5. only after preflight succeeds, run the single Node artifact generator;
-6. verify the Node-generated deployment manifest against the Python revision contract;
-7. validate the runtime guide returned by `getCuratedRuleGuide(slug)`;
-8. report the one-file routine PR set and stop without a DB write.
+1. loads the structured source;
+2. validates schema, cross-field requirements, and assertions;
+3. verifies primary-source reachability;
+4. checks production `slug -> work -> edition/language` identity without writing;
+5. regenerates generated files;
+6. checks the generated deployment manifest against the source revision;
+7. validates the runtime guide returned by `getCuratedRuleGuide(slug)`;
+8. reports the expected pull-request files and stops without a database write.
 
-## Main-only publish gate
+## Publishing from `main`
 
-The internal CLI mode is:
+The internal command is:
 
 `curated_game_fast_path_v2.py publish --game <slug>`
 
-It is not exposed as the routine Taskfile command. The main workflow is its canonical caller.
+The GitHub Actions workflow is the supported caller. It is intentionally not exposed as the normal Taskfile command.
 
-Before every write it repeats source reachability, live identity preflight, artifact/runtime validation, then uses the resolved identity plan for the idempotent catalog write. A changed production identity between PR preparation and merge therefore fails closed instead of writing to another work/edition.
+Before writing, it repeats source reachability, production identity, generated-file validation, and runtime validation. If production identity changed between pull-request preparation and merge, publication stops rather than writing to a different work or edition.
 
-The publish job:
+`publish-catalog`:
 
-- runs only for a `push` to `refs/heads/main`;
-- requires the focused validation job to succeed first;
-- derives changed curated games from the GitHub push event rather than rewriting every curated game;
+- runs only on pushes to `main`;
+- waits for curated-game validation;
+- publishes only changed curated source files;
 - ignores schema-only changes;
-- refuses curated-game source deletion; deletion requires an explicit deprecation workflow;
-- skips uv/Vercel/environment setup entirely when no game spec changed;
-- uses `vercel pull --environment=production` only as the established credential retrieval route;
-- never invokes a Vercel deploy request.
+- refuses source deletion because removal requires an explicit deprecation change;
+- skips environment setup when no game source changed;
+- uses `vercel pull --environment=production` for the established production environment;
+- does not request a Vercel deployment.
 
-## Credential boundary
+## Credentials
 
-Pull-request validation has no production DB write step. Trusted server credentials are consumed only by the main-only `publish-catalog` job after focused validation.
+Pull-request validation has no production database write step.
 
-The required server variables are:
+The main-only publication job uses:
 
 - `SUPABASE_URL`
 - `SUPABASE_SERVICE_ROLE_KEY`
 
-They are loaded from Vercel's production environment and are never replaced by browser-safe anon/publishable keys.
+They are loaded from Vercel's production environment. Browser-safe anonymous or publishable keys are not substitutes for server credentials.
 
-## Routine PR shape
+## Pull request contents
 
 A normal game addition changes exactly one source file:
 
 `data/curated-games/<slug>.json`
 
-Do not commit game-specific generated JavaScript, deployment manifests, importer scripts, or test files. Game-specific regression facts belong in the structured `assertions` array; generic CI evaluates those assertions for every curated game.
+Do not commit game-specific generated JavaScript, deployment manifests, importer scripts, or separate test files. Put game-specific regression facts in the structured `assertions` array so generic tests can evaluate them.
 
-## Structured input contract
+## Structured input
 
-`data/curated-games/schema-v1.json` defines the external contract. Each file contains:
+`data/curated-games/schema-v1.json` defines the file format. Each game source contains:
 
-- `work`: canonical work title and identity status;
-- `source`: explicit HTTPS primary source, rule version, and source revision;
-- `game`: production catalog payload including source provenance;
-- `guide`: reviewed Quick Rules/scoring/flow object;
-- `assertions`: game-specific facts that must remain true.
+- `work`: work title and identity status;
+- `source`: HTTPS primary source, rule version, and source revision;
+- `game`: catalog fields including provenance;
+- `guide`: reviewed quick rules, scoring, and flow;
+- `assertions`: facts that generic validation must preserve.
 
-The workflow additionally enforces cross-field invariants such as slug equality, source URL equality, source revision equality, and guide/source rule-version equality.
+Validation also checks slug, source URL, source revision, and guide rule-version consistency.
 
-## Single generated-artifact boundary
+## Generated files
 
-`frontend/scripts/generate-curated-game-artifacts.mjs` is the only artifact generator. It derives both runtime artifacts from structured source:
+`frontend/scripts/generate-curated-game-artifacts.mjs` generates:
 
 - `frontend/src/lib/generatedCuratedRuleGuides.js`
 - `frontend/public/curated-guides-manifest.json`
 
-Both outputs are gitignored and must never be committed or hand-edited.
+Both outputs are gitignored. Do not commit or hand-edit them.
 
-Generation happens automatically through:
+Generation runs through:
 
 - `npm run dev` via `predev`;
 - `npm run build` via `prebuild`;
-- Vercel production/preview builds;
-- prepare/publish/check/release verification through the same Node generator.
+- Vercel production and preview builds;
+- curated-game prepare, publish, check, and release verification.
 
-The Python fast path does not implement a second guide generator. It invokes Node and checks that the resulting deployment manifest exactly matches the Python revision-contract calculation.
+The Python command calls the Node generator rather than maintaining a second generator.
 
-## Two production fixed points
+## Production verification
 
-### Catalog fixed point
+After catalog publication, verify the production API and `/games/<slug>`.
 
-The main-only publish job verifies the production API and `/games/<slug>` immediately after the idempotent DB write. Database-backed content can become live independently of a frontend deployment.
+After Vercel deployment, verify `curated-guides-manifest.json` against the deployed commit and expected source revision.
 
-### Frontend release fixed point
-
-After a successful Vercel production deployment, `Curated game release verification` checks the deployed `curated-guides-manifest.json` against the deployed commit.
-
-Manual diagnostics remain available:
+Manual diagnostics:
 
 ```bash
 task game:verify GAME=<slug>
 task game:release-check
 ```
 
-A generic deployment failure is a separate infrastructure blocker; it does not roll back an already-verified catalog publication or trigger deployment repair inside the game-add branch.
+A generic deployment failure does not undo a verified catalog publication and should not be repaired inside an unrelated game-content pull request.
 
 ## CI
 
-`Curated game fast path` is path-scoped and browser-free. From a clean checkout it:
+The curated-game GitHub Actions workflow is path-scoped and does not require a browser for source-only changes. From a clean checkout it:
 
-- runs generic workflow tests;
-- validates every structured assertion;
-- regenerates JS + manifest from source;
-- verifies Node/Python revision-contract agreement;
+- runs generic curated-game tests;
+- validates structured assertions;
+- regenerates generated files from source;
+- checks revision consistency;
 - validates runtime guide integration.
 
-On pull requests it stops there. On `main`, and only after that validation succeeds, the separate `publish-catalog` job may obtain production credentials and publish changed game specs.
+On pull requests it stops after validation. On `main`, `publish-catalog` may obtain production credentials and publish changed game sources after validation succeeds.
 
-Do not make the full UI suite or generic Vercel deploy request a prerequisite for catalog publication.
+Do not make the full UI suite or an unrelated deployment request a prerequisite for a source-only catalog publication.
 
-## Minimal completion evidence
+## Completion
 
-A curated game is fully released when:
+A curated game is released when:
 
-- exactly one canonical JSON source is merged to `main`;
-- source/identity/runtime focused CI passes;
-- main-only publish rechecks live source and identity;
-- production contains exactly one intended canonical work/edition identity;
-- catalog API/page fixed point is verified;
-- generated artifacts are reproducible from source;
-- post-deploy manifest verification confirms the frontend release fixed point.
+- its structured source is merged to `main`;
+- focused source, identity, and runtime checks pass;
+- publication rechecks the live source and identity;
+- production contains the intended work and edition;
+- the production API and page are verified;
+- generated files are reproducible from source;
+- after deployment, the revision manifest matches the expected source revision.
 
-## Scope guard
+## Scope
 
-During a game-add task, do not:
+During a game-addition task, do not:
 
-- write the production DB before merge;
-- repeat source research after the primary source/revision is locked unless contradictory evidence appears;
-- repeat repository-wide searches once canonical paths are known;
-- provide `SLUG`, `SOURCE_URL`, or `DATA` separately when they are already in the spec;
-- commit or hand-edit generated artifacts;
-- create a game-specific regression test when structured assertions can express the contract;
-- publish unchanged games on every main push;
+- write production data before merge;
+- repeat source research after a primary source and revision are established unless contradictory evidence appears;
+- repeat repository-wide searches after the relevant paths are known;
+- provide `SLUG`, `SOURCE_URL`, or `DATA` separately when they are already in the source file;
+- commit or hand-edit generated files;
+- create a game-specific regression test when structured assertions can express the requirement;
+- publish unchanged games on every `main` push;
 - silently delete a production game because its source JSON disappeared;
-- repair unrelated Vercel/CI infrastructure inside the game-add branch;
-- create replacement branches/PRs for the same task;
+- repair unrelated Vercel or CI infrastructure in the game-content branch;
+- create replacement branches or pull requests for the same task;
 - retry a failed job more than once without new evidence.
 
-## Success retrospective
-
-After a successful addition, review only the steps that affected the outcome. Remove repeated deterministic work from the next run, but keep source, identity, semantic, merge, catalog, and release fixed-point gates fail-closed. Stop once there is no reusable reduction left.
+After completion, remove repeatable deterministic work when doing so does not weaken source, identity, semantic, CI, merge, production, or cleanup checks.


### PR DESCRIPTION
Updates the central agent contract and curated-game instructions to use ordinary technical language instead of repository-specific process terms.

Changes:
- replace terms such as `work line`, `fast path`, `fixed point`, and named gates in the documentation with direct descriptions of the actual Git/GitHub/Vercel/Supabase actions
- remove duplicated completion and retrospective guidance from AGENTS.md
- keep existing file paths, Taskfile commands, and internal script names unchanged to avoid unrelated code churn

No runtime behavior, dependencies, database schema, or production data changes are included.

Verification:
- documentation read-back
- exact diff review
- GitHub Actions on the PR