### PR TITLE
fix: report link-copy failures accurately

### DIFF
--- a/frontend/src/components/game/ShareButtons.jsx
+++ b/frontend/src/components/game/ShareButtons.jsx
@@ -1,25 +1,40 @@
 import { useState } from 'react'
 
 export const ShareButton = ({ slug }) => {
-  const [copied, setCopied] = useState(false)
+  const [status, setStatus] = useState('idle')
 
   const handleShare = async () => {
     const url = `https://bodoge-no-mikata.vercel.app/games/${slug}`
-    if (navigator.clipboard && navigator.clipboard.writeText) {
-      await navigator.clipboard.writeText(url)
+
+    if (!navigator.clipboard?.writeText) {
+      setStatus('error')
+      return
     }
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
+
+    try {
+      await navigator.clipboard.writeText(url)
+      setStatus('copied')
+      setTimeout(() => setStatus('idle'), 2000)
+    } catch (error) {
+      console.error('Failed to copy game URL:', error)
+      setStatus('error')
+    }
   }
+
+  const label = status === 'copied'
+    ? 'コピーしました'
+    : status === 'error'
+      ? 'コピーできませんでした'
+      : 'リンクをコピー'
 
   return (
     <button
       onClick={handleShare}
-      className={`share-btn ${copied ? 'copied' : ''}`}
-      title={copied ? 'コピーしました' : 'リンクをコピー'}
-      aria-label="Share this game"
+      className={`share-btn ${status === 'copied' ? 'copied' : ''}`}
+      title={label}
+      aria-label={label}
     >
-      {copied ? '✓ 完了' : '🔗 コピー'}
+      {status === 'copied' ? '✓ 完了' : status === 'error' ? 'コピー失敗' : '🔗 コピー'}
     </button>
   )
 }


### PR DESCRIPTION
Related to #221.

## Finding
`ShareButton` reported `✓ 完了` even when the Clipboard API was unavailable or `navigator.clipboard.writeText()` rejected. That gives users a false success state on a sharing action.

The current W3C Clipboard API specifies `writeText()` as a Promise that can reject, including with `NotAllowedError`, so success must only be shown after the Promise resolves.

Primary source:
- https://www.w3.org/TR/clipboard-apis/#dom-clipboard-writetext

## Change
- show copied state only after `writeText()` resolves
- show an explicit failure state when Clipboard API is unavailable or copying rejects
- make the accessible name match the visible state in Japanese
- do not add a new dependency or sharing framework

## Verification
- source read-back completed on commit `091e73ba5848eaccd3180fc5e5efccc09dc8cead`
- repository CI and deployment checks remain to be observed on this exact PR head

## Scope
1 file only: `frontend/src/components/game/ShareButtons.jsx`.

This does not implement the broader Web Share API work in #221; it only removes the false-success behavior from the existing copy-link fallback.