### PR TITLE
fix: use Japanese labels in directory and comparison

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -79,7 +79,7 @@ function Filters({
                 aria-pressed={activeTier === tier}
                 onClick={() => setActiveTier(activeTier === tier ? null : tier)}
               >
-                Tier {tier}
+                戦略ティア {tier}
               </button>
             ))}
           </div>
@@ -280,8 +280,8 @@ function App() {
     return (
       <div className="game-detail-content comparison-page">
         <div className="comparison-page__header">
-          <h1 className="game-title">COMPARISON BATTLE</h1>
-          <button type="button" className="filter-btn" onClick={() => setIsBattleMode(false)}>CLOSE BATTLE</button>
+          <h1 className="game-title">ゲーム比較</h1>
+          <button type="button" className="filter-btn" onClick={() => setIsBattleMode(false)}>比較を閉じる</button>
         </div>
 
         <div className="battle-grid">
@@ -290,32 +290,32 @@ function App() {
               <div className="pro-card comparison-game-card">
                 <img src={gameImageUrl(game)} onError={handleGameImageError} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
                 <div className="pro-stat-value">{game.title_ja || game.title}</div>
-                {game.strategy_tier && <div className="tier-badge comparison-tier">TIER {game.strategy_tier}</div>}
+                {game.strategy_tier && <div className="tier-badge comparison-tier">戦略ティア {game.strategy_tier}</div>}
               </div>
 
               <div className="battle-attr">
-                <div className="battle-attr-label">Synopsis</div>
-                <div className="comparison-summary">{game.summary || 'No summary available.'}</div>
+                <div className="battle-attr-label">概要</div>
+                <div className="comparison-summary">{game.summary || '概要はまだありません。'}</div>
               </div>
 
               <div className="battle-attr">
-                <div className="battle-attr-label">Specs</div>
+                <div className="battle-attr-label">基本情報</div>
                 <div className="pro-stats-grid comparison-specs">
-                  <div className="pro-stat-card"><div className="pro-stat-label">P</div><div className="pro-stat-value comparison-stat">{game.min_players}-{game.max_players}</div></div>
-                  <div className="pro-stat-card"><div className="pro-stat-label">T</div><div className="pro-stat-value comparison-stat">{game.play_time}m</div></div>
+                  <div className="pro-stat-card"><div className="pro-stat-label">人数</div><div className="pro-stat-value comparison-stat">{game.min_players}-{game.max_players}</div></div>
+                  <div className="pro-stat-card"><div className="pro-stat-label">時間</div><div className="pro-stat-value comparison-stat">{game.play_time}分</div></div>
                 </div>
               </div>
 
               {game.structured_data?.mechanics && (
                 <div className="battle-attr">
-                  <div className="battle-attr-label">Mechanics</div>
+                  <div className="battle-attr-label">メカニクス</div>
                   <div className="tag-list">
                     {game.structured_data.mechanics.slice(0, 5).map((mechanic) => <span key={mechanic} className="tag-item">{mechanic}</span>)}
                   </div>
                 </div>
               )}
 
-              <Link to={`/games/${game.slug}`} className="filter-btn comparison-detail-link">VIEW FULL ANALYSIS</Link>
+              <Link to={`/games/${game.slug}`} className="filter-btn comparison-detail-link">詳しい情報を見る</Link>
             </div>
           ))}
         </div>
@@ -363,7 +363,7 @@ function App() {
 
         <div className="db-status" aria-label={loading ? 'ゲーム一覧を同期中' : `${totalGamesCount}件のゲーム`}>
           <div className="status-dot connected"></div>
-          {loading ? 'SYNCING...' : `${totalGamesCount} GAMES`}
+          {loading ? '同期中…' : `${totalGamesCount}件のゲーム`}
         </div>
       </header>
 
@@ -395,10 +395,10 @@ function App() {
             >
               フィルター
             </button>
-            <span className="results-count">{filteredGames.length} RESULTS</span>
+            <span className="results-count">{filteredGames.length}件</span>
             {activePlayers && <div className="filter-chip">人数: {activePlayers} <button type="button" aria-label="人数フィルターを解除" onClick={() => setActivePlayers(null)}>×</button></div>}
             {activeTime && <div className="filter-chip">時間: {activeTime} <button type="button" aria-label="時間フィルターを解除" onClick={() => setActiveTime(null)}>×</button></div>}
-            {activeTier && <div className="filter-chip">Tier: {activeTier} <button type="button" aria-label="戦略Tierフィルターを解除" onClick={() => setActiveTier(null)}>×</button></div>}
+            {activeTier && <div className="filter-chip">戦略ティア: {activeTier} <button type="button" aria-label="戦略ティアフィルターを解除" onClick={() => setActiveTier(null)}>×</button></div>}
           </div>
 
           <label htmlFor="game-sort" className="sr-only">ゲームの並び順</label>
@@ -415,7 +415,7 @@ function App() {
         {compareNotice && <div className="app-feedback compare-feedback" role="status">{compareNotice}</div>}
 
         {loading ? (
-          <div className="app-loading-state" role="status">ARCHIVE INITIALIZING...</div>
+          <div className="app-loading-state" role="status">ゲーム一覧を読み込み中…</div>
         ) : (
           <div className="asset-grid">
             {filteredGames.map((game) => {
@@ -426,14 +426,14 @@ function App() {
                 <div key={game.id} className="asset-card-shell">
                   <Link to={`/games/${game.slug}`} className="asset-card asset-card-link">
                     <div className="asset-thumb-container">
-                      {game.strategy_tier && <div className="tier-badge">Tier {game.strategy_tier}</div>}
+                      {game.strategy_tier && <div className="tier-badge">戦略ティア {game.strategy_tier}</div>}
                       <img src={gameImageUrl(game)} onError={handleGameImageError} alt={title} className="asset-thumb" loading="lazy" />
                     </div>
                     <div className="asset-info">
                       <div className="asset-title">{title}</div>
                       <div className="asset-meta">
                         {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
-                        {game.play_time && <span className="meta-item">⏳ {game.play_time}m</span>}
+                        {game.play_time && <span className="meta-item">⏳ {game.play_time}分</span>}
                         {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}
                       </div>
                       <div className="asset-summary">{game.summary || game.description}</div>
@@ -448,7 +448,7 @@ function App() {
                     title={limitReached ? '比較は3件までです' : undefined}
                     onClick={() => toggleCompare(game)}
                   >
-                    {selected ? 'READY' : limitReached ? 'MAX 3' : 'COMPARE'}
+                    {selected ? '追加済み' : limitReached ? '上限3件' : '比較に追加'}
                   </button>
                 </div>
               )
@@ -468,7 +468,7 @@ function App() {
 
       {compareList.length > 0 && (
         <div className="comparison-tray" role="region" aria-label={`比較トレイ ${compareList.length}/3`}>
-          <div className="comparison-tray__label">BATTLE TRAY · {compareList.length}/3</div>
+          <div className="comparison-tray__label">比較トレイ · {compareList.length}/3</div>
           {compareList.map((game) => {
             const title = game.title_ja || game.title || 'ゲーム'
             return (
@@ -480,7 +480,7 @@ function App() {
           })}
           {compareList.length >= 2 && (
             <button type="button" className="filter-btn active battle-start-button" onClick={() => setIsBattleMode(true)}>
-              BATTLE START
+              比較する
             </button>
           )}
         </div>

--- a/frontend/tests/japanese_directory_copy.spec.js
+++ b/frontend/tests/japanese_directory_copy.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+
+const GAMES = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    slug: 'game-one',
+    title: 'Game One',
+    title_ja: 'ゲーム1',
+    summary: '概要1',
+    min_players: 2,
+    max_players: 4,
+    play_time: 30,
+    strategy_tier: 'A',
+    structured_data: { mechanics: ['Trick-taking'] },
+  },
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    slug: 'game-two',
+    title: 'Game Two',
+    title_ja: 'ゲーム2',
+    summary: null,
+    min_players: 3,
+    max_players: 5,
+    play_time: 45,
+    strategy_tier: 'B',
+    structured_data: { mechanics: ['Drafting'] },
+  },
+]
+
+async function mockDirectory(page) {
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games: GAMES, total: GAMES.length }),
+    })
+  })
+}
+
+test('directory and comparison use Japanese action, status, and section labels', async ({ page }) => {
+  await mockDirectory(page)
+  await page.goto('/')
+
+  await expect(page.locator('html')).toHaveAttribute('lang', 'ja')
+  await expect(page.getByText('2件のゲーム', { exact: true })).toBeVisible()
+  await expect(page.getByText('2件', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: 'ゲーム1を比較に追加' }).click()
+  await page.getByRole('button', { name: 'ゲーム2を比較に追加' }).click()
+
+  await expect(page.getByText('比較トレイ · 2/3', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: '比較する' })).toBeVisible()
+  await page.getByRole('button', { name: '比較する' }).click()
+
+  await expect(page.getByRole('heading', { name: 'ゲーム比較' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '比較を閉じる' })).toBeVisible()
+  await expect(page.getByText('概要', { exact: true })).toHaveCount(2)
+  await expect(page.getByText('基本情報', { exact: true })).toHaveCount(2)
+  await expect(page.getByText('メカニクス', { exact: true })).toHaveCount(2)
+  await expect(page.getByText('概要はまだありません。', { exact: true })).toBeVisible()
+  await expect(page.getByRole('link', { name: '詳しい情報を見る' })).toHaveCount(2)
+
+  for (const legacyText of [
+    'COMPARISON BATTLE',
+    'CLOSE BATTLE',
+    'Synopsis',
+    'Specs',
+    'Mechanics',
+    'VIEW FULL ANALYSIS',
+    'BATTLE TRAY',
+    'BATTLE START',
+  ]) {
+    await expect(page.getByText(legacyText, { exact: true })).toHaveCount(0)
+  }
+})

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -174,7 +174,7 @@ test('directory empty state and comparison tray use the same light palette', asy
 
   await page.getByRole('button', { name: '配色監査を比較に追加' }).click()
   await page.getByRole('button', { name: '配色監査2を比較に追加' }).click()
-  await expect(page.getByRole('button', { name: 'BATTLE START' })).toBeVisible()
+  await expect(page.getByRole('button', { name: '比較する' })).toBeVisible()
   await expectLightSurface(page.locator('.comparison-tray'), 'comparison tray')
 
   const search = page.getByLabel('ゲームを検索')

--- a/frontend/tests/rule_guide.spec.js
+++ b/frontend/tests/rule_guide.spec.js
@@ -103,7 +103,7 @@ test('new user can search IPSO and reach quick rules, scoring, diagram and sourc
   await page.goto('/')
   await expect(page.getByText('イプソ (IPSO)', { exact: true }).first()).toBeVisible()
   await page.getByLabel('ゲームを検索').fill('IPSO')
-  await expect(page.getByText('1 RESULTS')).toBeVisible()
+  await expect(page.getByText('1件', { exact: true })).toBeVisible()
   await page.screenshot({ path: testInfo.outputPath(`new-user-home-${testInfo.project.name}.png`), animations: 'disabled' })
 
   await page.getByRole('link', { name: /イプソ \(IPSO\)/ }).first().click()

--- a/frontend/tests/ui_ux_regression.spec.js
+++ b/frontend/tests/ui_ux_regression.spec.js
@@ -269,7 +269,7 @@ test('anonymous directory -> game detail stays error-free and SPA-local', async 
   const finishAudit = await installRuntimeAudit(page)
 
   await page.goto('/')
-  await expect(page.getByText('ARCHIVE INITIALIZING...')).toBeVisible()
+  await expect(page.getByText('ゲーム一覧を読み込み中…')).toBeVisible()
   await expect(page.getByText('ゲーム1', { exact: true }).first()).toBeVisible()
   await assertViewportSafe(page)
 

--- a/frontend/tests/uiux_a11y_regression.spec.js
+++ b/frontend/tests/uiux_a11y_regression.spec.js
@@ -88,7 +88,7 @@ test('directory keeps search local, labels controls, exposes mobile filters, and
   }
   await expect(page.getByRole('region', { name: '比較トレイ 3/3' })).toBeVisible()
   await expect(page.getByRole('button', { name: 'ゲーム4を比較に追加' })).toBeDisabled()
-  await expect(page.getByText('BATTLE TRAY · 3/3')).toBeVisible()
+  await expect(page.getByText('比較トレイ · 3/3')).toBeVisible()
 })
 
 test('AI generation only runs from its explicit CTA', async ({ page }) => {


### PR DESCRIPTION
Closes #268.

## Change
- replace English action, status, and section labels in the Japanese directory/comparison UI with Japanese text
- replace `P` / `T` abbreviations with `人数` / `時間`
- keep game titles and mechanic names unchanged because they are content, not UI labels
- add a focused Playwright regression for the Japanese directory/comparison labels
- update four existing UI regression expectations that intentionally asserted the old English copy

## Accessibility basis
WCAG 2.2 SC 3.1.2 requires the language of passages or phrases to be programmatically determinable, with exceptions such as proper names and technical terms. Since this product declares Japanese as the page language, Japanese UI text avoids unnecessary language switching for these controls and headings.

Primary source:
- https://www.w3.org/WAI/WCAG22/Understanding/language-of-parts
- https://www.w3.org/TR/WCAG22/#language-of-parts

## Scope
- 6 files
- no dependency changes
- no API/schema/config/workflow changes
- no i18n framework

Production verification will be performed after exact-head CI and merge.