### PR TITLE
fix: enlarge comparison tray remove buttons

### DIFF
--- a/frontend/src/uiux-accessibility.css
+++ b/frontend/src/uiux-accessibility.css
@@ -151,6 +151,13 @@
   object-fit: cover;
 }
 
+.compare-item button {
+  width: 24px;
+  height: 24px;
+  min-width: 24px;
+  min-height: 24px;
+}
+
 .battle-start-button {
   padding: 6px 16px;
   border-radius: var(--ks-radius-pill);


### PR DESCRIPTION
Addresses the concrete mobile pointer-target finding under #211.

Current production source sets each comparison-tray remove button to 14×14 CSS px. This change raises the authored target to 24×24 CSS px without changing comparison behavior or adding dependencies.

Primary reference: WCAG 2.2 SC 2.5.8 Target Size (Minimum): https://www.w3.org/TR/WCAG22/#target-size-minimum
Understanding document: https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum

Scope:
- `frontend/src/uiux-accessibility.css` only
- no JS, data, dependency, or config changes
- no claim that automated checks alone establish WCAG conformance

Production verification after merge: on a narrow viewport, add at least one game to comparison and confirm the remove control remains usable without introducing tray overflow/regression.