### PR TITLE
fix: include summaries in production game search

### DIFF
--- a/backend/app/core/supabase.py
+++ b/backend/app/core/supabase.py
@@ -120,6 +120,7 @@ async def search(query: str) -> List[Dict[str, Any]]:
                         f'title.ilike."{term}"',
                         f'title_ja.ilike."{term}"',
                         f'title_en.ilike."{term}"',
+                        f'summary.ilike."{term}"',
                         f'description.ilike."{term}"',
                     ]
                 )


### PR DESCRIPTION
Fixes one verified slice of #198.

Production currently misses games when the query appears only in `games.summary`: `Big Shot` contains `エリアマジョリティ` in `summary`, but production `/api/search?q=エリアマジョリティ` returns `[]`.

The local search path already includes `summary`; the Supabase path did not. This change adds `summary` to the existing PostgREST `or_` filter so cloud and local search cover the same user-facing field.

Scope: one filter entry only. No schema, dependency, configuration, ranking, alias, or frontend change.

Verification before change:
- production deployment SHA: `6f820954302e19f8d6b2ebd6a3f045fb78b1ff9d`
- `GET /api/games/big-shot`: summary contains `エリアマジョリティ`
- `GET /api/search?q=エリアマジョリティ`: HTTP 200, `[]`

After CI/deploy, verify the same query returns canonical `big-shot` without changing title/alias ranking behavior.