### PR TITLE
fix: make game SEO titles match available content

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -31,6 +31,13 @@ def _safe_json_script(data: dict) -> str:
     return payload.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
 
 
+def _page_title(game: dict, title: str) -> str:
+    structured_data = game.get("structured_data")
+    has_strategy = isinstance(structured_data, dict) and bool(structured_data.get("strategy_analysis"))
+    strategy_label = "・戦略" if has_strategy else ""
+    return f"「{title}」のルール{strategy_label}・インスト要約 | ボドゲのミカタ"
+
+
 async def generate_seo_html(slug: str) -> str | None:
     game = await get_by_slug(slug)
     if not game:
@@ -43,7 +50,7 @@ async def generate_seo_html(slug: str) -> str | None:
         image_url = f"{BASE_URL}{image_url}"
 
     game_url = f"{BASE_URL}/games/{slug}"
-    page_title = f"「{title}」のルール・戦略・インスト要約 | ボドゲのミカタ"
+    page_title = _page_title(game, title)
     seo_description = description or f"「{title}」の登録済みルール要約と出典情報を確認できます。"
 
     structured_data: dict[str, object] = {

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -5,6 +5,18 @@ import pytest
 from app.services import seo_renderer
 
 
+def test_page_title_omits_strategy_when_unavailable() -> None:
+    game = {"structured_data": {"strategy_analysis": None}}
+
+    assert seo_renderer._page_title(game, "スカルキング") == "「スカルキング」のルール・インスト要約 | ボドゲのミカタ"
+
+
+def test_page_title_includes_strategy_when_available() -> None:
+    game = {"structured_data": {"strategy_analysis": "終盤では得点状況を見てビッドを調整する。"}}
+
+    assert seo_renderer._page_title(game, "Example") == "「Example」のルール・戦略・インスト要約 | ボドゲのミカタ"
+
+
 @pytest.mark.asyncio
 async def test_missing_game_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     async def missing(_slug: str):


### PR DESCRIPTION
## Finding
Production `/games/skull-king` currently emits `「スカルキング」のルール・戦略・インスト要約 | ボドゲのミカタ` in `<title>`, `og:title`, and `twitter:title`, while the same production game record has `structured_data.strategy_analysis = null`.

Google Search Central recommends descriptive, concise page titles and specifically recommends including content labels only when that content is actually present.

Primary reference: https://developers.google.com/search/docs/appearance/title-link

## Change
- include `・戦略` in game page metadata only when `structured_data.strategy_analysis` is present
- keep existing title format for games that do contain strategy analysis
- add focused regression tests for both cases

## Verification
- `backend/tests/test_seo_renderer.py` covers strategy-present and strategy-absent titles
- production verification after merge: `/games/skull-king` should no longer advertise strategy in `<title>`, `og:title`, or `twitter:title`

## Scope
2 existing files only. No dependency, configuration, schema, database, storage, or frontend changes.