### PR TITLE
Reorder GamePage information around play decisions

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -156,6 +156,34 @@ export default function GamePage({ slug: propSlug, initialGame }) {
             )}
           </div>
 
+          <div className="pro-stats-grid" aria-label="ゲーム基本情報">
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">PLAYERS</div>
+              <div className="pro-stat-value">
+                {game.min_players != null
+                  ? `${game.min_players}${game.max_players != null && game.max_players !== game.min_players ? `-${game.max_players}` : ''}`
+                  : 'N/A'}
+              </div>
+            </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">TIME</div>
+              <div className="pro-stat-value">{game.play_time != null ? `${game.play_time}m` : 'N/A'}</div>
+            </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">AGE</div>
+              <div className="pro-stat-value">{game.min_age != null ? `${game.min_age}+` : 'N/A'}</div>
+            </div>
+            <div className="pro-stat-card">
+              <div className="pro-stat-label">YEAR</div>
+              <div className="pro-stat-value">{game.published_year || 'N/A'}</div>
+            </div>
+          </div>
+
+          <div className="pro-card pro-card--synopsis">
+            <div className="pro-card-title">30秒でわかる「{title}」</div>
+            <div className="summary-text">{game.summary || game.description}</div>
+          </div>
+
           <QuickRulesPanel
             guide={ruleGuide}
             onShowFlow={hasInfographics ? () => setActiveTab('infographics') : null}
@@ -347,35 +375,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
         </div>
 
-        <div className="game-sidebar" aria-label="ゲーム基本情報">
-          <div className="pro-stats-grid">
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">PLAYERS</div>
-              <div className="pro-stat-value">
-                {game.min_players != null
-                  ? `${game.min_players}${game.max_players != null && game.max_players !== game.min_players ? `-${game.max_players}` : ''}`
-                  : 'N/A'}
-              </div>
-            </div>
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">TIME</div>
-              <div className="pro-stat-value">{game.play_time != null ? `${game.play_time}m` : 'N/A'}</div>
-            </div>
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">AGE</div>
-              <div className="pro-stat-value">{game.min_age != null ? `${game.min_age}+` : 'N/A'}</div>
-            </div>
-            <div className="pro-stat-card">
-              <div className="pro-stat-label">YEAR</div>
-              <div className="pro-stat-value">{game.published_year || 'N/A'}</div>
-            </div>
-          </div>
-
-          <div className="pro-card pro-card--synopsis">
-            <div className="pro-card-title">30秒でわかる「{title}」</div>
-            <div className="summary-text">{game.summary || game.description}</div>
-          </div>
-
+        <div className="game-sidebar" aria-label="補足情報">
           <div className="pro-card" aria-label="データ信頼状態">
             <div className="pro-card-title">TRUST &amp; PROVENANCE</div>
             <div className="game-empty-note">{identityLabel}</div>


### PR DESCRIPTION
## What changed

Reorder the existing GamePage information without adding new data or UI concepts.

New reading order:
1. game title
2. players / time / age / year
3. 30-second summary
4. Quick Rules
5. detailed rule / setup / strategy / review / related-game views
6. provenance, tips, common errors, glossary, and external links

This keeps the current single-column layout and existing interactions, but moves the information needed to decide and start playing ahead of long-form/reference material.

## Scope

- one existing React file
- no schema, dependency, CSS, or data changes
- no change to canonical rule content

## Verification

- existing frontend build / browser checks should exercise the same GamePage components and single-column layout
- verify the GamePage DOM and visual order on desktop and mobile preview before merge