### PR TITLE
Hide unavailable Quick Rules on game pages

### DIFF
--- a/frontend/src/components/game/QuickRulesPanel.jsx
+++ b/frontend/src/components/game/QuickRulesPanel.jsx
@@ -2,17 +2,7 @@ import { ScoringBreakdown } from './ScoringBreakdown'
 import './rule-guide.css'
 
 export function QuickRulesPanel({ guide }) {
-  if (!guide) {
-    return (
-      <section className="quick-rules-panel quick-rules-unavailable" aria-label="すぐ遊ぶ">
-        <div className="quick-rules-kicker">QUICK RULES</div>
-        <div className="quick-rules-title">検証済みの要約はまだありません</div>
-        <p style={{ marginTop: '0.55rem', lineHeight: 1.6 }}>
-          未確認内容は推測表示しません。詳しいルールと出典を確認してください。
-        </p>
-      </section>
-    )
-  }
+  if (!guide) return null
 
   return (
     <section className="quick-rules-panel" aria-label="すぐ遊ぶ" data-testid="quick-rules-panel">

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -96,7 +96,7 @@ test('game detail keeps one primary flow and readable long-form measure', async 
   const compact = await readLayout(page)
   expectSinglePrimaryFlow(compact)
   expect(compact.readingLine.width).toBeLessThanOrEqual(compact.main.width)
-  await expect(page.getByText('検証済みの要約はまだありません')).toBeVisible()
+  await expect(page.locator('.quick-rules-panel')).toHaveCount(0)
 })
 
 test('quick rules flatten to one row on wide desktop inside the single-column page', async ({ page }) => {


### PR DESCRIPTION
## What changed

When a game has no reviewed Quick Rules guide, do not render a prominent empty Quick Rules panel ahead of the existing detailed rule content.

- `QuickRulesPanel` now renders nothing when no reviewed guide is available.
- the existing Big Shot browser fixture now verifies that no empty Quick Rules panel is inserted.
- games with reviewed guides, such as the existing Skull King fixture, keep the same four Quick Rules cards and source link.

This is a presentation-only reduction: no rule content, source data, schema, dependency, or configuration changes.

Related existing work: #158.

## Production evidence

Current production `/games/big-shot` already has summary, metadata, and detailed rule content. The client currently adds an unavailable Quick Rules block before that content when no reviewed guide is present.

## Verification

Run the existing frontend build/lint and `frontend/tests/game_layout.spec.js`. Do not merge unless exact-head CI passes. After merge, verify on production that Big Shot reaches its existing detailed information without the unavailable Quick Rules panel, while Skull King still shows its reviewed Quick Rules.