### PR TITLE
Remove unavailable public AI generation action

### DIFF
--- a/frontend/scripts/check-uiux-accessibility-contracts.mjs
+++ b/frontend/scripts/check-uiux-accessibility-contracts.mjs
@@ -10,7 +10,6 @@ const requirements = [
   ['mobile filter toggle', files.app, /aria-controls="directory-filters"/],
   ['explicit directory search label', files.app, /htmlFor="game-directory-search"/],
   ['explicit sort label', files.app, /htmlFor="game-sort"/],
-  ['explicit AI generation CTA', files.app, /未登録ゲームをAIで追加/],
   ['compare pressed state', files.app, /aria-pressed=\{selected\}/],
   ['compare limit state', files.app, /比較できるゲームは3件まで/],
   ['tab right-arrow keyboard support', files.shell, /ArrowRight/],
@@ -25,10 +24,19 @@ const requirements = [
   ['explicit modal field labels', files.modal, /htmlFor="edit-game-title"/],
 ]
 
-const failures = requirements.filter(([, source, pattern]) => !pattern.test(source)).map(([name]) => name)
+const prohibited = [
+  ['public AI generation CTA', files.app, /未登録ゲームをAIで追加/],
+  ['public generate=true search mutation', files.app, /generate:\s*true/],
+]
+
+const failures = [
+  ...requirements.filter(([, source, pattern]) => !pattern.test(source)).map(([name]) => name),
+  ...prohibited.filter(([, source, pattern]) => pattern.test(source)).map(([name]) => name),
+]
+
 if (failures.length > 0) {
   console.error(`UI/UX accessibility contract failures:\n- ${failures.join('\n- ')}`)
   process.exit(1)
 }
 
-console.log(`UI/UX accessibility contracts: ${requirements.length} checks passed`)
+console.log(`UI/UX accessibility contracts: ${requirements.length + prohibited.length} checks passed`)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import { api } from './lib/api'
 
 const PLAYER_FILTERS = ['1', '2', '3', '4', '5+']
@@ -97,13 +97,11 @@ function Filters({
 
 function App() {
   const [searchParams, setSearchParams] = useSearchParams()
-  const navigate = useNavigate()
 
   const [initialGames, setInitialGames] = useState([])
   const [totalGamesCount, setTotalGamesCount] = useState(0)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
-  const [generating, setGenerating] = useState(false)
 
   const [query, setQuery] = useState(searchParams.get('q') || '')
   const [activePlayers, setActivePlayers] = useState(null)
@@ -224,32 +222,6 @@ function App() {
 
   const handleDirectorySearch = (event) => {
     event.preventDefault()
-    // Filtering is intentionally local. AI generation is a separate explicit action.
-  }
-
-  const handleGenerateGame = async () => {
-    const normalized = query.trim()
-    if (!normalized || generating) return
-
-    setGenerating(true)
-    setError(null)
-    try {
-      const data = await api.post('/api/search', { query: normalized, generate: true })
-      const list = Array.isArray(data) ? data : data.games || []
-      if (list.length === 0) {
-        setError('未登録ゲームを生成できませんでした。名称を確認してください。')
-        return
-      }
-
-      const newGame = list[0]
-      setInitialGames((current) => current.some((game) => game.slug === newGame.slug) ? current : [newGame, ...current])
-      navigate(`/games/${newGame.slug}`)
-    } catch (err) {
-      console.error(err)
-      setError('AI生成リクエストに失敗しました。')
-    } finally {
-      setGenerating(false)
-    }
   }
 
   const clearFilters = () => {
@@ -351,14 +323,6 @@ function App() {
             value={query}
             onChange={(event) => setQuery(event.target.value)}
           />
-          <button
-            type="button"
-            className="filter-btn generate-game-button"
-            disabled={!query.trim() || generating}
-            onClick={handleGenerateGame}
-          >
-            {generating ? '生成中…' : '未登録ゲームをAIで追加'}
-          </button>
         </form>
 
         <div className="db-status" aria-label={loading ? 'ゲーム一覧を同期中' : `${totalGamesCount}件のゲーム`}>
@@ -411,7 +375,6 @@ function App() {
         </div>
 
         {error && <div className="app-feedback app-feedback--error" role="alert">{error}</div>}
-        {generating && <div className="app-feedback app-feedback--progress" role="status">未登録ゲームの情報を生成しています…</div>}
         {compareNotice && <div className="app-feedback compare-feedback" role="status">{compareNotice}</div>}
 
         {loading ? (

--- a/frontend/tests/japanese_directory_copy.spec.js
+++ b/frontend/tests/japanese_directory_copy.spec.js
@@ -44,6 +44,7 @@ test('directory and comparison use Japanese action, status, and section labels',
   await expect(page.locator('html')).toHaveAttribute('lang', 'ja')
   await expect(page.getByText('2件のゲーム', { exact: true })).toBeVisible()
   await expect(page.getByText('2件', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: '未登録ゲームをAIで追加' })).toHaveCount(0)
 
   await page.getByRole('button', { name: 'ゲーム1を比較に追加' }).click()
   await page.getByRole('button', { name: 'ゲーム2を比較に追加' }).click()

--- a/frontend/tests/uiux_a11y_regression.spec.js
+++ b/frontend/tests/uiux_a11y_regression.spec.js
@@ -17,7 +17,7 @@ async function mockDirectory(page, counters = { generated: 0 }) {
     }
     if (url.pathname === '/api/search' && request.method() === 'POST') {
       counters.generated += 1
-      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [games[0]] }) })
+      await route.fulfill({ status: 403, contentType: 'application/json', body: JSON.stringify({ detail: 'Catalog generation is not available from public search' }) })
       return
     }
     await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'not mocked' }) })
@@ -91,17 +91,17 @@ test('directory keeps search local, labels controls, exposes mobile filters, and
   await expect(page.getByText('比較トレイ · 3/3')).toBeVisible()
 })
 
-test('AI generation only runs from its explicit CTA', async ({ page }) => {
+test('public directory search never exposes or sends catalog generation', async ({ page }) => {
   const counters = { generated: 0 }
   await mockDirectory(page, counters)
   await page.goto('/')
   const search = page.getByLabel('ゲームを検索')
   await search.fill('未登録タイトル')
   await search.press('Enter')
-  expect(counters.generated).toBe(0)
 
-  await page.getByRole('button', { name: '未登録ゲームをAIで追加' }).click()
-  await expect.poll(() => counters.generated).toBe(1)
+  await expect(page.getByText('条件に一致するゲームが見つかりません。')).toBeVisible()
+  await expect(page.getByRole('button', { name: '未登録ゲームをAIで追加' })).toHaveCount(0)
+  expect(counters.generated).toBe(0)
 })
 
 test('game detail tabs implement the APG keyboard and tabpanel relationship', async ({ page }) => {


### PR DESCRIPTION
Implements the smallest directly executable slice of #198.

## Finding

The Directory still showed `未登録ゲームをAIで追加` and posted `{ generate: true }` to `/api/search`, while the current backend deliberately returns HTTP 403 for public generation requests. This exposed a primary action that cannot succeed for public users.

## Change

- remove the public AI-generation button
- remove its client-only state, handler, progress message, and now-unused navigation dependency
- keep registered-game search/filter behavior unchanged
- update existing Playwright coverage to assert zero-result state, absence of the unavailable button, and zero public generation POSTs
- update the existing source-contract check so it rejects a public generation CTA or `generate: true` mutation instead of requiring the obsolete CTA

## Scope

- 4 frontend files
- no dependency, schema, CSS, configuration, or data changes
- no change to editor-authorized catalog mutation paths

## Verification

Run existing frontend build/browser checks. After merge, verify the production Directory no longer exposes the unavailable action and that `/api/games` remains healthy.