### PR TITLE
Add Slide from Gigamic 01-2024 rulebook

### DIFF
--- a/data/curated-games/slide.json
+++ b/data/curated-games/slide.json
@@ -1,0 +1,144 @@
+{
+  "schema_version": "1",
+  "slug": "slide",
+  "work": {
+    "canonical_title": "Slide",
+    "identity_status": "verified"
+  },
+  "source": {
+    "url": "https://en.gigamic.com/index.php?controller=attachment&id_attachment=548",
+    "rule_version": "gigamic-slide-01-2024",
+    "revision": "gigamic-slide-rulebook-01-2024-attachment-548-accessed-2026-08-17"
+  },
+  "game": {
+    "slug": "slide",
+    "title": "Slide",
+    "title_ja": "スライド",
+    "title_en": "Slide",
+    "description": "数字カードを4×4のグリッドへスライドして配置し、同じ数字を上下左右に隣接させて取り除きながら、最後に残る数字の合計を小さくするカードゲーム。",
+    "summary": "16枚のカードを裏向きの4×4に並べ、毎ラウンド1枚ずつ同時公開。ファーストプレイヤーから公開カードを選び、行か列の外側からスライドして4×4を復元します。16ラウンド後、上下左右に隣接する同じ数字を取り除き、残った数字の合計が最も少ない人が勝ちます。",
+    "rules_content": "# Slide\n\n## 目的\n16ラウンド終了後にグリッドへ残る数字の合計をできるだけ小さくします。得点が最も少ないプレイヤーが勝ちます。\n\n## 準備\nカードをシャッフルし、各プレイヤーに16枚ずつ裏向きで配ります。各自は4×4のグリッドに並べ、余ったカードは箱へ戻します。最初のファーストプレイヤーを決め、ファーストプレイヤーカウンターを渡します。\n\n## ラウンド\nゲームは16ラウンドです。毎ラウンド、全員が自分のグリッドから裏向きカードを1枚選び、中央へ同時に表向きで出します。\n\nファーストプレイヤーから時計回りに、中央のカードを1枚ずつ選びます。選んだカードは、自分のグリッドにできた空きマスと同じ行または列の外側から押し込み、4×4を復元します。斜めにはスライドできず、空きマスへ直接置くこともできません。\n\n全員が配置したら、ファーストプレイヤーカウンターを左隣のプレイヤーへ渡して次のラウンドを始めます。\n\n## ゲーム終了と得点\n16枚すべてが表向きになったらゲーム終了です。上下左右に隣接している同じ数字のカードをすべて取り除きます。斜めに隣接しているだけのカードは取り除きません。\n\n残ったカードの数字を合計し、最も少ないプレイヤーが勝ちます。同点の場合は、グリッドに残ったカード枚数が少ないプレイヤーが勝ちます。それも同じなら、そのプレイヤーたちは勝利を分け合います。\n\n## トーナメント形式\n複数ゲームを続けて遊ぶ場合、いずれかのプレイヤーの累計得点が100点以上になった時点で終了します。累計得点が最も少ないプレイヤーが勝ちます。トーナメントでは各ゲームの開始前にファーストプレイヤーを変更します。",
+    "setup_summary": "各プレイヤーに16枚を裏向きで配り、4×4のグリッドに並べます。余りは箱へ戻し、最初のファーストプレイヤーを決めてカウンターを渡します。",
+    "gameplay_summary": "16ラウンド。毎ラウンド全員が裏向きカードを1枚同時公開し、ファーストプレイヤーから時計回りに中央のカードを選びます。選んだカードを空きマスと同じ行または列の外側からスライドして4×4を復元し、ラウンド後にファーストプレイヤーカウンターを左へ渡します。",
+    "end_game_summary": "16枚すべてが表向きになったら、上下左右に隣接する同じ数字を取り除き、残った数字の合計を比べます。最少得点が勝利。同点なら残りカード枚数が少ない方、それも同じなら同率勝利です。",
+    "min_players": 2,
+    "max_players": 6,
+    "play_time": 15,
+    "min_age": 7,
+    "published_year": 2024,
+    "edition_label": "Gigamic English rulebook 01-2024",
+    "language_code": "ja",
+    "publisher": "Gigamic",
+    "official_url": "https://en.gigamic.com/family-games/1211-slide.html",
+    "source_url": "https://en.gigamic.com/index.php?controller=attachment&id_attachment=548",
+    "source_revision": "gigamic-slide-rulebook-01-2024-attachment-548-accessed-2026-08-17",
+    "generated_from_source_revision": "gigamic-slide-rulebook-01-2024-attachment-548-accessed-2026-08-17",
+    "source_trust": "official_publisher",
+    "identity_status": "verified",
+    "content_review_status": "ai_draft"
+  },
+  "guide": {
+    "reviewed": true,
+    "ruleVersion": "gigamic-slide-01-2024",
+    "source": {
+      "label": "Gigamic official Slide rulebook",
+      "url": "https://en.gigamic.com/index.php?controller=attachment&id_attachment=548",
+      "ruleVersion": "gigamic-slide-01-2024"
+    },
+    "facts": {
+      "cardsPerPlayer": 16,
+      "gridRows": 4,
+      "gridColumns": 4,
+      "rounds": 16,
+      "tournamentEndScore": 100
+    },
+    "quick": {
+      "win": "16ラウンド後に同じ数字の隣接カードを取り除き、残った数字の合計を最も少なくする。",
+      "actions": [
+        "自分の裏向きカードを1枚選び、全員同時に中央へ公開する。",
+        "ファーストプレイヤーから時計回りに中央のカードを1枚選ぶ。",
+        "選んだカードを空きマスと同じ行または列の外側からスライドして4×4を復元する。"
+      ],
+      "turnSteps": [
+        "全員が裏向きカードを1枚選び、中央へ同時公開する。",
+        "ファーストプレイヤーから時計回りに公開カードを1枚ずつ選ぶ。",
+        "選んだカードを行または列の外側からスライドして4×4を復元する。"
+      ],
+      "turnEndChecks": [
+        "空きマスへ直接置いたり、斜めにスライドしたりしていないか確認する。",
+        "全員の配置後、ファーストプレイヤーカウンターを左隣へ渡す。"
+      ],
+      "end": "16枚すべてが表向きになったら終了。上下左右に隣接する同じ数字を取り除き、残った数字の合計を比べる。"
+    },
+    "scoring": {
+      "summary": "上下左右に隣接する同じ数字を取り除いた後、残ったカードの数字を合計する。最少得点が勝利する。",
+      "rules": [
+        {
+          "label": "基本得点",
+          "detail": "上下左右に隣接する同じ数字のカードを取り除き、残ったカードの数字を合計する。"
+        },
+        {
+          "label": "同点",
+          "detail": "同点なら残りカード枚数が少ないプレイヤーが勝つ。それも同じなら勝利を分け合う。"
+        },
+        {
+          "label": "トーナメント",
+          "detail": "累計得点が100点以上になったプレイヤーが出たら終了し、累計得点が最も少ないプレイヤーが勝つ。"
+        }
+      ]
+    },
+    "flow": [
+      {
+        "id": "reveal",
+        "kind": "step",
+        "label": "全員が裏向きカードを1枚選び、中央へ同時公開する"
+      },
+      {
+        "id": "choose",
+        "kind": "step",
+        "label": "ファーストプレイヤーから時計回りに中央のカードを1枚ずつ選ぶ"
+      },
+      {
+        "id": "slide",
+        "kind": "step",
+        "label": "選んだカードを行または列の外側からスライドして4×4を復元する"
+      },
+      {
+        "id": "next-round",
+        "kind": "check",
+        "label": "ファーストプレイヤーカウンターを左へ渡し、16枚すべて表向きか確認する"
+      },
+      {
+        "id": "score",
+        "kind": "end",
+        "label": "隣接する同じ数字を取り除き、残った数字の合計を比べる"
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "path": "facts.rounds",
+      "equals": 16
+    },
+    {
+      "path": "facts.cardsPerPlayer",
+      "equals": 16
+    },
+    {
+      "path": "quick.turnSteps",
+      "contains": "ファーストプレイヤー"
+    },
+    {
+      "path": "quick.turnEndChecks",
+      "contains": "左隣"
+    },
+    {
+      "path": "quick.end",
+      "contains": "16枚"
+    },
+    {
+      "path": "scoring.rules",
+      "contains": "同点"
+    }
+  ]
+}


### PR DESCRIPTION
Refs #207

## What changed

Add `data/curated-games/slide.json` using Gigamic's official Slide rulebook (attachment 548, document footer `01-2024`) as the detailed rule source.

This pins the rule revision and corrects two current production gaps:
- tournament play ends when a player reaches **or exceeds** 100 points;
- the First Player changes before each new tournament game.

The physical-game rules keep the rulebook's setup: decide the initial First Player, then pass the counter left after each round. The shorter product-page wording that says the lowest initially revealed number starts is not imported into the detailed rules.

## Source

- Product page: https://en.gigamic.com/family-games/1211-slide.html
- Official rulebook: https://en.gigamic.com/index.php?controller=attachment&id_attachment=548

## Scope

- one new curated-game JSON file
- no dependency, configuration, schema, frontend, or generated-output changes
- production data is not written from this PR

## Verification

Use the repository's existing curated-game validation/publish checks. After merge, verify the exact deployed SHA and re-read `/api/games/slide` for the pinned source revision, 16-round base-game end, tie-break, `>=100` tournament end, and next-game First Player change.

#207 remains open until the product-page/rulebook discrepancy is represented in source evidence and production verification is complete.