### PR TITLE
Return 503 when list storage is temporarily unavailable

### DIFF
--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Literal
 from uuid import UUID
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -76,12 +77,22 @@ def _system_list_conflict() -> HTTPException:
     return HTTPException(status_code=status.HTTP_409_CONFLICT, detail="System lists cannot be renamed or deleted")
 
 
+def _list_storage_unavailable() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail="リストを一時的に取得できません。時間をおいて再試行してください。",
+    )
+
+
 @router.get("/lists")
 async def list_user_lists(
     user: dict = Depends(get_current_user),
     service: ListService = Depends(get_list_service),
 ):
-    return {"lists": await service.list_lists(_owner_id(user))}
+    try:
+        return {"lists": await service.list_lists(_owner_id(user))}
+    except httpx.TransportError as exc:
+        raise _list_storage_unavailable() from exc
 
 
 @router.post("/lists", status_code=status.HTTP_201_CREATED)

--- a/backend/tests/test_list_upstream_unavailable.py
+++ b/backend/tests/test_list_upstream_unavailable.py
@@ -1,0 +1,22 @@
+import httpx
+import pytest
+
+from app.routers import lists
+
+
+USER = {"id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"}
+
+
+class FailingListService:
+    async def list_lists(self, owner_id):
+        assert owner_id == USER["id"]
+        raise httpx.RemoteProtocolError("Server disconnected")
+
+
+@pytest.mark.asyncio
+async def test_list_index_returns_503_for_transport_failure():
+    with pytest.raises(lists.HTTPException) as exc:
+        await lists.list_user_lists(user=USER, service=FailingListService())
+
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "リストを一時的に取得できません。時間をおいて再試行してください。"


### PR DESCRIPTION
Closes a focused part of #91.

## Problem

Vercel runtime errors show an authenticated `GET /api/lists` request exhausting the Supabase/PostgREST client retry path and ending in `httpx.RemoteProtocolError: Server disconnected`. The router currently lets that transport exception become an unhandled 5xx.

## Change

- catch HTTPX `TransportError` only at the list-index read endpoint
- return HTTP 503 with a stable Japanese message
- keep the existing Supabase/PostgREST retry behavior; do not add another retry loop
- add a focused regression using `RemoteProtocolError`

## Scope

- no database or storage changes
- no dependency or configuration changes
- no change to empty-list semantics
- no change to other list operations

## Verification

- focused backend test asserts 503 and the public error message
- repository CI must pass at the exact PR head before merge
- after merge, verify the deployed Git SHA and re-check production runtime errors; an induced upstream network failure in production is not required