### PR TITLE
Cache public game reads at the Vercel CDN

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Response
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 
@@ -10,6 +10,29 @@ from app.services.sitemap import get_sitemap_xml
 
 setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
+
+BROWSER_REVALIDATE = "public, max-age=0, must-revalidate"
+VERCEL_PUBLIC_READ_CACHE = "public, max-age=60"
+
+
+def is_public_game_read_path(path: str) -> bool:
+    if path == "/api/games":
+        return True
+
+    segments = [segment for segment in path.split("/") if segment]
+    return len(segments) == 3 and segments[0] == "api" and segments[1] == "games" or (
+        len(segments) == 2 and segments[0] == "games"
+    )
+
+
+@app.middleware("http")
+async def cache_public_game_reads(request: Request, call_next):
+    response = await call_next(request)
+    if request.method == "GET" and response.status_code == 200 and is_public_game_read_path(request.url.path):
+        response.headers["Cache-Control"] = BROWSER_REVALIDATE
+        response.headers["Vercel-CDN-Cache-Control"] = VERCEL_PUBLIC_READ_CACHE
+    return response
+
 
 # Browser API access is same-origin in production. Explicit localhost origins are
 # retained for Vite development; arbitrary third-party origins are denied.

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from app.main import app as production_app
 from app.routers import games
 
 
@@ -32,6 +33,17 @@ class DBFirstService:
     async def create_game_from_query(self, query: str):
         self.created = True
         return {"id": "game-2", "slug": "generated", "title": query}
+
+
+class PublicReadService:
+    async def get_game_by_slug(self, slug: str):
+        return {"id": "game-1", "slug": slug, "title": "Example", "work_id": "work-1"}
+
+    async def list_recent_games(self, limit: int, offset: int):
+        return {
+            "data": [{"id": "game-1", "slug": "example", "title": "Example", "work_id": "work-1"}],
+            "total": 1,
+        }
 
 
 def _app_with_service(service):
@@ -116,3 +128,33 @@ def test_post_search_remains_read_only_for_legacy_clients():
     assert response.status_code == 200
     assert response.json()[0]["slug"] == "existing"
     assert service.created is False
+
+
+def test_public_game_reads_revalidate_in_browser_and_cache_at_vercel_cdn():
+    production_app.dependency_overrides[games.get_game_service] = lambda: PublicReadService()
+    try:
+        client = TestClient(production_app)
+
+        detail = client.get("/api/games/example")
+        listing = client.get("/api/games?limit=1&offset=0")
+
+        for response in (detail, listing):
+            assert response.status_code == 200
+            assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
+            assert response.headers["vercel-cdn-cache-control"] == "public, max-age=60"
+    finally:
+        production_app.dependency_overrides.clear()
+
+
+def test_cache_headers_do_not_apply_to_health_or_mutation_requests():
+    production_app.dependency_overrides[games.get_game_service] = lambda: MutableGameService()
+    try:
+        client = TestClient(production_app)
+
+        health = client.get("/api/health")
+        patch = client.patch("/api/games/example?regenerate=true")
+
+        assert "vercel-cdn-cache-control" not in health.headers
+        assert "vercel-cdn-cache-control" not in patch.headers
+    finally:
+        production_app.dependency_overrides.clear()


### PR DESCRIPTION
## What changed

Add a short CDN cache for public game reads without making browser caches stale.

- keep browser `Cache-Control` at `public, max-age=0, must-revalidate`
- set `Vercel-CDN-Cache-Control: public, max-age=60` only for successful `GET /api/games`, `GET /api/games/{slug}`, and `GET /games/{slug}` responses
- do not apply the CDN cache header to health, auth/private routes, nested game APIs, or mutation methods
- add regression coverage to the existing backend router test file already executed by catalog-integrity CI

## Evidence

Before this change, production `GET /api/games/skull-king` returned `Cache-Control: public, max-age=0, must-revalidate` and `x-vercel-cache: MISS`.

Vercel documents `Vercel-CDN-Cache-Control` as a way to control the Vercel CDN independently of browser caching:
https://vercel.com/docs/caching/cache-control-headers

Existing issue: #255

## Scope

- 2 existing Python files
- no dependency, schema, data, storage, frontend, or configuration changes
- maximum CDN freshness window introduced here: 60 seconds

## Verification

- catalog-integrity CI must run the existing `backend/tests/test_games_router.py`
- preview/build checks must pass
- after merge, verify exact deployed Git SHA and fetch the same public API twice to inspect production cache behavior
