### PR TITLE
Use s-maxage for Vercel CDN caching

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
 
 BROWSER_REVALIDATE = "public, max-age=0, must-revalidate"
-VERCEL_PUBLIC_READ_CACHE = "public, max-age=60"
+VERCEL_PUBLIC_READ_CACHE = "public, s-maxage=60"
 
 
 def is_public_game_read_path(path: str) -> bool:

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -141,7 +141,7 @@ def test_public_game_reads_revalidate_in_browser_and_cache_at_vercel_cdn():
         for response in (detail, listing):
             assert response.status_code == 200
             assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
-            assert response.headers["vercel-cdn-cache-control"] == "public, max-age=60"
+            assert response.headers["vercel-cdn-cache-control"] == "public, s-maxage=60"
     finally:
         production_app.dependency_overrides.clear()
 


### PR DESCRIPTION
## What changed

Correct the CDN directive added in #303 after production verification showed two consecutive cache misses.

- change `Vercel-CDN-Cache-Control` from `public, max-age=60` to `public, s-maxage=60`
- keep browser `Cache-Control: public, max-age=0, must-revalidate`
- update the existing backend regression test only

## Production evidence

After #303 reached exact production SHA `126a722423d8e9fcdc8882aecc7eaba30905b5fc`, two consecutive requests to `/api/games/skull-king` from the same observed Vercel region both returned `x-vercel-cache: MISS`.

Vercel documents `s-maxage` as the directive for caching Vercel Function responses and shows `Vercel-CDN-Cache-Control` with `s-maxage`:
https://vercel.com/docs/caching/cache-control-headers
https://vercel.com/docs/caching/cdn-cache

Existing issue: #255

## Scope

- 2 existing Python files
- 1 production directive change plus matching test expectation
- no dependency, schema, data, storage, frontend, or config changes

## Verification

- catalog-integrity CI must pass
- after merge, verify exact production SHA
- request the same public game API twice and require observed CDN reuse before calling this complete
