### PR TITLE
Keep unknown play times last in directory sorting

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -205,7 +205,11 @@ function App() {
       }
       if (sortOption === 'title') return (a.title_ja || a.title || '').localeCompare(b.title_ja || b.title || '')
       if (sortOption === 'year') return (b.published_year || 0) - (a.published_year || 0)
-      if (sortOption === 'play_time') return (a.play_time || 0) - (b.play_time || 0)
+      if (sortOption === 'play_time') {
+        const aTime = Number.isFinite(a.play_time) && a.play_time > 0 ? a.play_time : Number.POSITIVE_INFINITY
+        const bTime = Number.isFinite(b.play_time) && b.play_time > 0 ? b.play_time : Number.POSITIVE_INFINITY
+        return aTime - bTime
+      }
       return 0
     })
 

--- a/frontend/tests/japanese_directory_copy.spec.js
+++ b/frontend/tests/japanese_directory_copy.spec.js
@@ -25,6 +25,18 @@ const GAMES = [
     strategy_tier: 'B',
     structured_data: { mechanics: ['Drafting'] },
   },
+  {
+    id: '33333333-3333-4333-8333-333333333333',
+    slug: 'game-unknown-time',
+    title: 'Unknown Time Game',
+    title_ja: '時間未確認ゲーム',
+    summary: 'プレイ時間は未確認',
+    min_players: 2,
+    max_players: 4,
+    play_time: null,
+    strategy_tier: null,
+    structured_data: { mechanics: [] },
+  },
 ]
 
 async function mockDirectory(page) {
@@ -42,8 +54,8 @@ test('directory and comparison use Japanese action, status, and section labels',
   await page.goto('/')
 
   await expect(page.locator('html')).toHaveAttribute('lang', 'ja')
-  await expect(page.getByText('2件のゲーム', { exact: true })).toBeVisible()
-  await expect(page.getByText('2件', { exact: true })).toBeVisible()
+  await expect(page.getByText('3件のゲーム', { exact: true })).toBeVisible()
+  await expect(page.getByText('3件', { exact: true })).toBeVisible()
   await expect(page.getByRole('button', { name: '未登録ゲームをAIで追加' })).toHaveCount(0)
 
   await page.getByRole('button', { name: 'ゲーム1を比較に追加' }).click()
@@ -73,4 +85,14 @@ test('directory and comparison use Japanese action, status, and section labels',
   ]) {
     await expect(page.getByText(legacyText, { exact: true })).toHaveCount(0)
   }
+})
+
+test('play-time sorting keeps unknown durations after known games', async ({ page }) => {
+  await mockDirectory(page)
+  await page.goto('/')
+
+  await page.getByLabel('ゲームの並び順').selectOption('play_time')
+
+  const titles = await page.locator('.asset-title').allTextContents()
+  expect(titles).toEqual(['ゲーム1', 'ゲーム2', '時間未確認ゲーム'])
 })

--- a/frontend/tests/japanese_directory_copy.spec.js
+++ b/frontend/tests/japanese_directory_copy.spec.js
@@ -25,18 +25,6 @@ const GAMES = [
     strategy_tier: 'B',
     structured_data: { mechanics: ['Drafting'] },
   },
-  {
-    id: '33333333-3333-4333-8333-333333333333',
-    slug: 'game-unknown-time',
-    title: 'Unknown Time Game',
-    title_ja: '時間未確認ゲーム',
-    summary: 'プレイ時間は未確認',
-    min_players: 2,
-    max_players: 4,
-    play_time: null,
-    strategy_tier: null,
-    structured_data: { mechanics: [] },
-  },
 ]
 
 async function mockDirectory(page) {
@@ -54,8 +42,8 @@ test('directory and comparison use Japanese action, status, and section labels',
   await page.goto('/')
 
   await expect(page.locator('html')).toHaveAttribute('lang', 'ja')
-  await expect(page.getByText('3件のゲーム', { exact: true })).toBeVisible()
-  await expect(page.getByText('3件', { exact: true })).toBeVisible()
+  await expect(page.getByText('2件のゲーム', { exact: true })).toBeVisible()
+  await expect(page.getByText('2件', { exact: true })).toBeVisible()
   await expect(page.getByRole('button', { name: '未登録ゲームをAIで追加' })).toHaveCount(0)
 
   await page.getByRole('button', { name: 'ゲーム1を比較に追加' }).click()
@@ -85,14 +73,4 @@ test('directory and comparison use Japanese action, status, and section labels',
   ]) {
     await expect(page.getByText(legacyText, { exact: true })).toHaveCount(0)
   }
-})
-
-test('play-time sorting keeps unknown durations after known games', async ({ page }) => {
-  await mockDirectory(page)
-  await page.goto('/')
-
-  await page.getByLabel('ゲームの並び順').selectOption('play_time')
-
-  const titles = await page.locator('.asset-title').allTextContents()
-  expect(titles).toEqual(['ゲーム1', 'ゲーム2', '時間未確認ゲーム'])
 })

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -176,3 +176,23 @@ test('homepage links to a JSON Web App Manifest', async ({ page, request }) => {
     display: 'standalone',
   })
 })
+
+test('play-time sorting keeps unknown durations after known games', async ({ page }) => {
+  const games = [
+    { id: '1', slug: 'short', title_ja: '30分ゲーム', min_players: 2, max_players: 4, play_time: 30 },
+    { id: '2', slug: 'medium', title_ja: '45分ゲーム', min_players: 2, max_players: 4, play_time: 45 },
+    { id: '3', slug: 'unknown', title_ja: '時間未確認ゲーム', min_players: 2, max_players: 4, play_time: null },
+  ]
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+
+  await page.goto('/')
+  await page.getByLabel('ゲームの並び順').selectOption('play_time')
+
+  await expect(page.locator('.asset-title')).toHaveText(['30分ゲーム', '45分ゲーム', '時間未確認ゲーム'])
+})


### PR DESCRIPTION
## What changed

Fix the Directory `プレイ時間順` sort so games without a confirmed `play_time` do not sort as if they were 0-minute games.

Current production data contains 19 games with `play_time IS NULL`. The previous comparator used `(game.play_time || 0)`, which placed those records before every known positive duration.

The new comparator:
- sorts positive finite `play_time` values ascending;
- places null, zero, non-finite, or otherwise unavailable values after known durations;
- does not invent a duration for unknown games.

This is the smallest presentation fix compatible with existing #242. It does not replace the planned duration-range work.

## Tests

Adds the regression to the existing `navigation.spec.js` suite because that file is explicitly executed by the current UI/UX regression workflow.

Fixture order after selecting `プレイ時間順`:
1. 30 minutes
2. 45 minutes
3. unknown duration

## Scope

- 2 files
- no dependency, schema, configuration, or production-data changes
- no change to time-filter range semantics
