### PR TITLE
Add a crawlable game-list link to SSR game pages

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -136,6 +136,9 @@ async def generate_seo_html(slug: str) -> str | None:
 
     ssr_content = f"""<div id="root">
   <article itemscope itemtype="https://schema.org/Game" data-ssr-game="true">
+    <nav aria-label="ゲーム一覧へのナビゲーション">
+      <a href="/">ゲーム一覧</a>
+    </nav>
     <h1 itemprop="name">{safe_title}</h1>
     <section>
       <h2>要約</h2>

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -77,6 +77,7 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert 'property="og:url" content="https://bodoge-no-mikata.vercel.app/games/safe-game"' in rendered
     assert 'data-game-seo="true"' in rendered
     assert 'data-ssr-game="true"' in rendered
+    assert '<a href="/">ゲーム一覧</a>' in rendered
     assert '<script>alert("title")</script>' not in rendered
     assert '<script>alert("rules")</script>' not in rendered
     assert '<img src=x onerror=alert("summary")>' not in rendered


### PR DESCRIPTION
## What changed

Add one ordinary `<a href="/">ゲーム一覧</a>` link to the server-rendered GamePage fallback and assert it in the existing SEO renderer test.

This is the smallest directly executable part of #200. Hydrated React already provides a route back to the directory; this change ensures the raw server-rendered page also contains a crawlable internal link before JavaScript runs.

## Evidence

- Current production `/games/skull-king` raw SSR contains the game content but no internal `<a href="/">` link.
- Google Search Central recommends crawlable `<a href>` links and says pages that matter should be linked from another findable page: https://developers.google.com/search/docs/crawling-indexing/links-crawlable

## Scope

- `backend/app/services/seo_renderer.py`
- existing `backend/tests/test_seo_renderer.py`
- no data, schema, dependency, CSS, or workflow changes

## Verification

- existing SEO renderer test must assert the game-list anchor in generated SSR
- exact-head CI must pass before merge
- after merge, verify the Vercel production deployment SHA and fetch `/games/skull-king` raw HTML to confirm the anchor is deployed

Refs #200