### PR TITLE
Prioritize the first directory image

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -389,12 +389,20 @@ function App() {
               const selected = compareList.some((candidate) => candidate.id === game.id)
               const limitReached = compareList.length >= 3 && !selected
               const title = game.title_ja || game.title || 'このゲーム'
+              const firstVisibleGame = game === filteredGames[0]
               return (
                 <div key={game.id} className="asset-card-shell">
                   <Link to={`/games/${game.slug}`} className="asset-card asset-card-link">
                     <div className="asset-thumb-container">
                       {game.strategy_tier && <div className="tier-badge">戦略ティア {game.strategy_tier}</div>}
-                      <img src={gameImageUrl(game)} onError={handleGameImageError} alt={title} className="asset-thumb" loading="lazy" />
+                      <img
+                        src={gameImageUrl(game)}
+                        onError={handleGameImageError}
+                        alt={title}
+                        className="asset-thumb"
+                        loading={firstVisibleGame ? 'eager' : 'lazy'}
+                        fetchPriority={firstVisibleGame ? 'high' : 'auto'}
+                      />
                     </div>
                     <div className="asset-info">
                       <div className="asset-title">{title}</div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -401,7 +401,7 @@ function App() {
                         alt={title}
                         className="asset-thumb"
                         loading={firstVisibleGame ? 'eager' : 'lazy'}
-                        fetchPriority={firstVisibleGame ? 'high' : 'auto'}
+                        fetchpriority={firstVisibleGame ? 'high' : 'auto'}
                       />
                     </div>
                     <div className="asset-info">

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -401,7 +401,7 @@ function App() {
                         alt={title}
                         className="asset-thumb"
                         loading={firstVisibleGame ? 'eager' : 'lazy'}
-                        fetchpriority={firstVisibleGame ? 'high' : 'auto'}
+                        {...{ fetchpriority: firstVisibleGame ? 'high' : 'auto' }}
                       />
                     </div>
                     <div className="asset-info">

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -196,3 +196,26 @@ test('play-time sorting keeps unknown durations after known games', async ({ pag
 
   await expect(page.locator('.asset-title')).toHaveText(['30分ゲーム', '45分ゲーム', '時間未確認ゲーム'])
 })
+
+test('directory prioritizes only the first visible game image', async ({ page }) => {
+  const games = [
+    { id: '1', slug: 'first', title_ja: '最初のゲーム', image_url: '/first.webp' },
+    { id: '2', slug: 'second', title_ja: '次のゲーム', image_url: '/second.webp' },
+  ]
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+
+  await page.goto('/')
+
+  const images = page.locator('.asset-thumb')
+  await expect(images).toHaveCount(2)
+  await expect(images.nth(0)).toHaveAttribute('loading', 'eager')
+  await expect(images.nth(0)).toHaveAttribute('fetchpriority', 'high')
+  await expect(images.nth(1)).toHaveAttribute('loading', 'lazy')
+  await expect(images.nth(1)).toHaveAttribute('fetchpriority', 'auto')
+})


### PR DESCRIPTION
## What changed

- keep lazy loading for directory images after the first visible result
- make only the first visible directory image eager with high fetch priority
- add a Playwright regression to the existing navigation suite

## Why

The current Directory applies `loading="lazy"` to every game image. Google/web.dev recommends not lazy-loading an image that may be the LCP element because it adds resource load delay, and notes `fetchpriority="high"` as an appropriate hint for a likely LCP image.

Primary source: https://web.dev/articles/optimize-lcp

This does not claim the first card is measured as the production LCP. It removes the avoidable lazy-load delay from the first visible game image while leaving later images lazy.

## Scope

- 2 existing frontend files
- no dependencies, config, schema, data, or CSS changes
- no change to search/filter semantics

#197 remains the separate work item for replacing the initial full-catalog fetch with server-side pagination/filtering.