### PR TITLE
Fix mobile game detail scrolling

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -101,6 +101,7 @@ jobs:
           tests/navigation.spec.js
           tests/performance.spec.js
           tests/game_layout.spec.js
+          tests/mobile_game_scroll.spec.js
           tests/auth.spec.js
           tests/generated-game-images.spec.js
           --project=chromium

--- a/frontend/src/layout.css
+++ b/frontend/src/layout.css
@@ -184,6 +184,25 @@ body {
   #root > aside {
     display: none;
   }
+
+  /* Game detail pages should use the browser's document scroll on touch-sized viewports. */
+  body:has(.game-detail-content) {
+    height: auto;
+    min-height: 100dvh;
+    overflow-y: auto;
+  }
+
+  body:has(.game-detail-content) #root {
+    display: block;
+    height: auto;
+    min-height: 100dvh;
+  }
+
+  body:has(.game-detail-content) .game-detail-content {
+    height: auto;
+    min-height: 100dvh;
+    overflow-y: visible;
+  }
 }
 
 @media (max-width: 700px) {

--- a/frontend/tests/mobile_game_scroll.spec.js
+++ b/frontend/tests/mobile_game_scroll.spec.js
@@ -62,23 +62,27 @@ test('game detail uses document scrolling on a touch viewport', async ({ browser
         detailOverflowY: getComputedStyle(detail).overflowY,
         viewportHeight: window.innerHeight,
         pageHeight: document.documentElement.scrollHeight,
+        maxTouchPoints: navigator.maxTouchPoints,
       }
     })
 
+    expect(state.maxTouchPoints).toBeGreaterThan(0)
     expect(state.bodyOverflowY).toBe('auto')
     expect(state.detailOverflowY).toBe('visible')
     expect(state.pageHeight).toBeGreaterThan(state.viewportHeight)
 
-    const client = await context.newCDPSession(page)
-    await client.send('Input.synthesizeScrollGesture', {
-      x: 195,
-      y: 650,
-      yDistance: -600,
-      speed: 800,
-      gestureSourceType: 'touch',
+    await page.getByRole('heading', { name: 'Section 60' }).scrollIntoViewIfNeeded()
+
+    const scrollState = await page.evaluate(() => {
+      const detail = document.querySelector('.game-detail-content')
+      return {
+        windowY: window.scrollY,
+        detailY: detail?.scrollTop ?? -1,
+      }
     })
 
-    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+    expect(scrollState.windowY).toBeGreaterThan(0)
+    expect(scrollState.detailY).toBe(0)
   } finally {
     await context.close()
   }

--- a/frontend/tests/mobile_game_scroll.spec.js
+++ b/frontend/tests/mobile_game_scroll.spec.js
@@ -42,7 +42,10 @@ async function mockGameApi(page) {
 test('game detail uses document scrolling on a touch viewport', async ({ browser }, testInfo) => {
   test.skip(testInfo.project.name !== 'chromium', 'Run once with an explicit mobile touch context.')
 
-  const context = await browser.newContext({ ...devices['Pixel 5'] })
+  const context = await browser.newContext({
+    ...devices['Pixel 5'],
+    baseURL: testInfo.project.use.baseURL,
+  })
   const page = await context.newPage()
 
   try {

--- a/frontend/tests/mobile_game_scroll.spec.js
+++ b/frontend/tests/mobile_game_scroll.spec.js
@@ -1,0 +1,82 @@
+import { devices, expect, test } from '@playwright/test'
+
+const relativeSpace = {
+  id: 9999,
+  slug: 'relative-space',
+  title: 'Relative Space',
+  title_ja: 'Relative Space',
+  min_players: 2,
+  max_players: 4,
+  play_time: 30,
+  min_age: 8,
+  published_year: 2026,
+  summary: 'Mobile scroll regression fixture.',
+  description: 'Mobile scroll regression fixture.',
+  rules_content: Array.from(
+    { length: 60 },
+    (_, index) => `## Section ${index + 1}\n\nScrollable rule text for the mobile regression test.`,
+  ).join('\n\n'),
+  structured_data: {},
+}
+
+async function mockGameApi(page) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/relative-space') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ game: relativeSpace }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games: [] }),
+    })
+  })
+}
+
+test('game detail uses document scrolling on a touch viewport', async ({ browser }, testInfo) => {
+  test.skip(testInfo.project.name !== 'chromium', 'Run once with an explicit mobile touch context.')
+
+  const context = await browser.newContext({ ...devices['Pixel 5'] })
+  const page = await context.newPage()
+
+  try {
+    await mockGameApi(page)
+    await page.goto('/games/relative-space')
+    await expect(page.getByRole('heading', { name: 'Relative Space' })).toBeVisible()
+
+    const state = await page.evaluate(() => {
+      const detail = document.querySelector('.game-detail-content')
+      if (!detail) throw new Error('game detail container is missing')
+
+      return {
+        bodyOverflowY: getComputedStyle(document.body).overflowY,
+        detailOverflowY: getComputedStyle(detail).overflowY,
+        viewportHeight: window.innerHeight,
+        pageHeight: document.documentElement.scrollHeight,
+      }
+    })
+
+    expect(state.bodyOverflowY).toBe('auto')
+    expect(state.detailOverflowY).toBe('visible')
+    expect(state.pageHeight).toBeGreaterThan(state.viewportHeight)
+
+    const client = await context.newCDPSession(page)
+    await client.send('Input.synthesizeScrollGesture', {
+      x: 195,
+      y: 650,
+      yDistance: -600,
+      speed: 800,
+      gestureSourceType: 'touch',
+    })
+
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+  } finally {
+    await context.close()
+  }
+})


### PR DESCRIPTION
## Summary
- use normal document scrolling for game detail pages at mobile/tablet widths instead of locking the body and relying on the nested `.game-detail-content` scroller
- keep the existing fixed directory layout unchanged
- add a Playwright regression test using a Pixel 5 mobile/touch context
- run the regression test in the existing UI UX GitHub Actions gate

## Why
`/games/relative-space` was reported as not scrollable on a smartphone. The shared layout sets `body { overflow: hidden }`; CSS Overflow Level 3 specifies that `overflow: hidden` must not allow direct user scrolling such as touch dragging. The mobile game-detail route now restores viewport/document scrolling.

## Verification
- Pixel 5 context reports touch support and a page taller than the viewport
- regression test asserts `body` is vertically scrollable and `.game-detail-content` no longer owns the vertical scroller on mobile
- scrolling the final rule section into view moves `window.scrollY` while `.game-detail-content.scrollTop` remains zero, proving the document owns vertical scrolling
- UI UX regression workflow passes all build, lint, accessibility, responsive, rule-guide and palette gates
- Vercel Deployment workflow passes for the PR