### PR TITLE
Tighten Slide 01-2024 rulebook review state

### DIFF
--- a/data/curated-games/slide.json
+++ b/data/curated-games/slide.json
@@ -35,7 +35,7 @@
     "generated_from_source_revision": "gigamic-slide-rulebook-01-2024-attachment-548-accessed-2026-08-17",
     "source_trust": "official_publisher",
     "identity_status": "verified",
-    "content_review_status": "ai_draft"
+    "content_review_status": "review_required"
   },
   "guide": {
     "reviewed": true,
@@ -83,7 +83,7 @@
         },
         {
           "label": "トーナメント",
-          "detail": "累計得点が100点以上になったプレイヤーが出たら終了し、累計得点が最も少ないプレイヤーが勝つ。"
+          "detail": "累計得点が100点以上になったプレイヤーが出たら終了し、累計得点が最も少ないプレイヤーが勝つ。各ゲームの開始前にファーストプレイヤーを変更する。"
         }
       ]
     },
@@ -125,6 +125,10 @@
       "equals": 16
     },
     {
+      "path": "facts.tournamentEndScore",
+      "equals": 100
+    },
+    {
       "path": "quick.turnSteps",
       "contains": "ファーストプレイヤー"
     },
@@ -139,6 +143,14 @@
     {
       "path": "scoring.rules",
       "contains": "同点"
+    },
+    {
+      "path": "scoring.rules",
+      "contains": "100点以上"
+    },
+    {
+      "path": "scoring.rules",
+      "contains": "ファーストプレイヤーを変更"
     }
   ]
 }


### PR DESCRIPTION
Progresses #207.

- keep the Gigamic `01-2024` rulebook / attachment 548 as the rule authority
- change Slide content review state from `ai_draft` to `review_required`; do not claim human review from an automated source audit
- include the rulebook's tournament First Player change in the existing curated guide
- add assertions for tournament threshold `100+`, tournament First Player change, and the existing 100-point fact

Verified primary source: https://en.gigamic.com/index.php?controller=attachment&id_attachment=548

The current Gigamic product page says the lowest revealed number starts, while the `01-2024` rulebook says to decide the First Player during setup. This PR keeps the rulebook as the detailed-rule authority and does not merge the product-page discrepancy into the rules.

No dependencies, schema, workflow, README, or generated-file changes.