### PR TITLE
Fix Vercel caching for public game reads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
 
 BROWSER_REVALIDATE = "public, max-age=0, must-revalidate"
-VERCEL_PUBLIC_READ_CACHE = "public, s-maxage=60"
+VERCEL_PUBLIC_READ_CACHE = "public, max-age=60"
 
 
 def is_public_game_read_path(path: str) -> bool:

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -141,7 +141,7 @@ def test_public_game_reads_revalidate_in_browser_and_cache_at_vercel_cdn():
         for response in (detail, listing):
             assert response.status_code == 200
             assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
-            assert response.headers["vercel-cdn-cache-control"] == "public, s-maxage=60"
+            assert response.headers["vercel-cdn-cache-control"] == "public, max-age=60"
     finally:
         production_app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Finding

Production `GET /api/games/skull-king` returned `x-vercel-cache: MISS` on consecutive requests while the app was setting `Vercel-CDN-Cache-Control: public, s-maxage=60` internally. Vercel's current cache-control documentation uses `max-age` for `Vercel-CDN-Cache-Control`; `s-maxage` is documented for ordinary `Cache-Control` shared-cache directives.

## Change

- keep browser behavior as `Cache-Control: public, max-age=0, must-revalidate`
- set the Vercel-specific CDN header to `Vercel-CDN-Cache-Control: public, max-age=60`
- update the existing backend regression test

No dependency, configuration, schema, frontend, or data changes.

## Verification

Run the existing backend test workflow at the exact PR head. After merge, verify the exact production deployment SHA and request the same public game API twice to confirm Vercel reports a cache hit within the 60-second freshness window.