### PR TITLE
Use standard Cache-Control for public game reads

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -11,8 +11,7 @@ from app.services.sitemap import get_sitemap_xml
 setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
 
-BROWSER_REVALIDATE = "public, max-age=0, must-revalidate"
-VERCEL_PUBLIC_READ_CACHE = "public, max-age=60"
+PUBLIC_GAME_READ_CACHE = "public, max-age=0, s-maxage=60, must-revalidate"
 
 
 def is_public_game_read_path(path: str) -> bool:
@@ -29,8 +28,7 @@ def is_public_game_read_path(path: str) -> bool:
 async def cache_public_game_reads(request: Request, call_next):
     response = await call_next(request)
     if request.method == "GET" and response.status_code == 200 and is_public_game_read_path(request.url.path):
-        response.headers["Cache-Control"] = BROWSER_REVALIDATE
-        response.headers["Vercel-CDN-Cache-Control"] = VERCEL_PUBLIC_READ_CACHE
+        response.headers["Cache-Control"] = PUBLIC_GAME_READ_CACHE
     return response
 
 

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -130,7 +130,7 @@ def test_post_search_remains_read_only_for_legacy_clients():
     assert service.created is False
 
 
-def test_public_game_reads_revalidate_in_browser_and_cache_at_vercel_cdn():
+def test_public_game_reads_use_standard_shared_cache_control():
     production_app.dependency_overrides[games.get_game_service] = lambda: PublicReadService()
     try:
         client = TestClient(production_app)
@@ -140,8 +140,8 @@ def test_public_game_reads_revalidate_in_browser_and_cache_at_vercel_cdn():
 
         for response in (detail, listing):
             assert response.status_code == 200
-            assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
-            assert response.headers["vercel-cdn-cache-control"] == "public, max-age=60"
+            assert response.headers["cache-control"] == "public, max-age=0, s-maxage=60, must-revalidate"
+            assert "vercel-cdn-cache-control" not in response.headers
     finally:
         production_app.dependency_overrides.clear()
 
@@ -154,7 +154,7 @@ def test_cache_headers_do_not_apply_to_health_or_mutation_requests():
         health = client.get("/api/health")
         patch = client.patch("/api/games/example?regenerate=true")
 
-        assert "vercel-cdn-cache-control" not in health.headers
-        assert "vercel-cdn-cache-control" not in patch.headers
+        assert "s-maxage" not in health.headers.get("cache-control", "")
+        assert "s-maxage" not in patch.headers.get("cache-control", "")
     finally:
         production_app.dependency_overrides.clear()


### PR DESCRIPTION
## Why

Vercel's current Function caching documentation recommends `Cache-Control: max-age=0, s-maxage=...` for server-rendered/public responses and states that Vercel consumes `s-maxage` before forwarding the header to browsers. This lets one standard header express both browser revalidation and the shared-cache TTL.

The previous targeted-header change in #311 reached production, but authenticated Vercel fetches still report `MISS`, so that fetch path cannot be used as proof of public cache hits.

## Change

- replace the two cache-control constants with one standard `Cache-Control` value: `public, max-age=0, s-maxage=60, must-revalidate`
- remove `Vercel-CDN-Cache-Control` from the middleware
- update the existing backend regression test

This reduces one response header and one configuration constant while following Vercel's documented Function caching pattern.

## Verification

Run the existing backend checks at the exact PR head. After merge, verify exact deployed SHA. Public cache-hit verification remains separate from authenticated connector requests because requests containing authorization are not cacheable by Vercel's CDN.