### PR TITLE
Clarify GamePage preparation flow label

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -195,7 +195,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
               詳しいルール
             </button>
             <button type="button" aria-pressed={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>
-              セットアップ
+              準備・流れ・終了
             </button>
             <button type="button" aria-pressed={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>
               戦略

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -145,21 +145,21 @@ test('game detail uses one native button group after quick rules', async ({ page
   await expect(page.getByRole('group', { name: 'ゲーム詳細表示' })).toHaveCount(1)
 
   const rulesButton = page.getByRole('button', { name: '詳しいルール', exact: true })
-  const setupButton = page.getByRole('button', { name: 'セットアップ', exact: true })
+  const flowButton = page.getByRole('button', { name: '準備・流れ・終了', exact: true })
   await expect(rulesButton).toHaveAttribute('aria-pressed', 'true')
-  await expect(setupButton).toHaveAttribute('aria-pressed', 'false')
+  await expect(flowButton).toHaveAttribute('aria-pressed', 'false')
   await expect(page.getByRole('button', { name: '図で見る', exact: true })).toHaveCount(1)
 
-  await setupButton.click()
+  await flowButton.click()
   await expect(rulesButton).toHaveAttribute('aria-pressed', 'false')
-  await expect(setupButton).toHaveAttribute('aria-pressed', 'true')
+  await expect(flowButton).toHaveAttribute('aria-pressed', 'true')
   await expect(page.getByRole('link', { name: /公式出典:/ })).toHaveCount(1)
 })
 
-test('setup view shows only game-specific summaries and fails closed when missing', async ({ page }) => {
+test('preparation flow and end view shows only game-specific summaries and fails closed when missing', async ({ page }) => {
   await mockGameApi(page)
   await page.goto('/games/big-shot')
-  await page.getByRole('button', { name: 'セットアップ', exact: true }).click()
+  await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
 
   await expect(page.getByText(bigShot.setup_summary)).toBeVisible()
   await expect(page.getByText(bigShot.gameplay_summary)).toBeVisible()
@@ -179,7 +179,7 @@ test('setup view shows only game-specific summaries and fails closed when missin
   await page.unrouteAll({ behavior: 'wait' })
   await mockGameApi(page, missing)
   await page.reload()
-  await page.getByRole('button', { name: 'セットアップ', exact: true }).click()
+  await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
 
   await expect(page.getByText('このゲーム固有のセットアップ要約は未確認です。')).toBeVisible()
   await expect(page.getByText('このゲーム固有のゲーム進行要約は未確認です。')).toBeVisible()

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -133,7 +133,7 @@ test('every game-detail view avoids legacy dark surfaces', async ({ page }, test
   await page.goto('/games/palette-audit')
   await expect(page.getByRole('heading', { name: '配色監査' })).toBeVisible()
 
-  await page.getByRole('button', { name: 'セットアップ', exact: true }).click()
+  await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
   const coachSteps = page.locator('.coach-step')
   await expect(coachSteps).toHaveCount(3)
   for (let index = 0; index < 3; index += 1) {

--- a/frontend/tests/uiux_a11y_regression.spec.js
+++ b/frontend/tests/uiux_a11y_regression.spec.js
@@ -114,7 +114,7 @@ test('game detail secondary views use native buttons with pressed state', async 
   await expect(page.getByRole('group', { name: 'ゲーム詳細表示' })).toHaveCount(1)
 
   const rulesButton = page.getByRole('button', { name: '詳しいルール', exact: true })
-  const setupButton = page.getByRole('button', { name: 'セットアップ', exact: true })
+  const setupButton = page.getByRole('button', { name: '準備・流れ・終了', exact: true })
   const relatedButton = page.getByRole('button', { name: '関連ゲーム', exact: true })
   await expect(rulesButton).toHaveAttribute('aria-pressed', 'true')
   await expect(setupButton).toHaveAttribute('aria-pressed', 'false')


### PR DESCRIPTION
Refs #158. Renames the existing GamePage view control from `セットアップ` to `準備・流れ・終了` because that view already contains setup, gameplay, and end summaries. Updates the existing Playwright test. No data, dependency, configuration, CSS, or schema changes.