### PR TITLE
Show unknown comparison values explicitly

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,16 @@ function handleGameImageError(event) {
   if (!event.currentTarget.src.endsWith(NO_IMAGE_URL)) event.currentTarget.src = NO_IMAGE_URL
 }
 
+function comparisonPlayers(game) {
+  if (!Number.isFinite(game.min_players) || game.min_players <= 0) return '不明'
+  if (!Number.isFinite(game.max_players) || game.max_players <= 0) return `${game.min_players}人以上`
+  return game.min_players === game.max_players ? `${game.min_players}人` : `${game.min_players}-${game.max_players}人`
+}
+
+function comparisonPlayTime(game) {
+  return Number.isFinite(game.play_time) && game.play_time > 0 ? `${game.play_time}分` : '不明'
+}
+
 function Filters({
   activePlayers,
   activeTime,
@@ -277,8 +287,8 @@ function App() {
               <div className="battle-attr">
                 <div className="battle-attr-label">基本情報</div>
                 <div className="pro-stats-grid comparison-specs">
-                  <div className="pro-stat-card"><div className="pro-stat-label">人数</div><div className="pro-stat-value comparison-stat">{game.min_players}-{game.max_players}</div></div>
-                  <div className="pro-stat-card"><div className="pro-stat-label">時間</div><div className="pro-stat-value comparison-stat">{game.play_time}分</div></div>
+                  <div className="pro-stat-card"><div className="pro-stat-label">人数</div><div className="pro-stat-value comparison-stat">{comparisonPlayers(game)}</div></div>
+                  <div className="pro-stat-card"><div className="pro-stat-label">時間</div><div className="pro-stat-value comparison-stat">{comparisonPlayTime(game)}</div></div>
                 </div>
               </div>
 

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -197,6 +197,33 @@ test('play-time sorting keeps unknown durations after known games', async ({ pag
   await expect(page.locator('.asset-title')).toHaveText(['30分ゲーム', '45分ゲーム', '時間未確認ゲーム'])
 })
 
+test('comparison renders missing player count and duration as unknown', async ({ page }) => {
+  const games = [
+    { id: '1', slug: 'known', title_ja: '既知ゲーム', min_players: 2, max_players: 4, play_time: 30 },
+    { id: '2', slug: 'unknown', title_ja: '未確認ゲーム', min_players: null, max_players: null, play_time: null },
+  ]
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: '既知ゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '未確認ゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '比較する' }).click()
+
+  const known = page.locator('.battle-col').filter({ hasText: '既知ゲーム' })
+  const unknown = page.locator('.battle-col').filter({ hasText: '未確認ゲーム' })
+  await expect(known.getByText('2-4人', { exact: true })).toBeVisible()
+  await expect(known.getByText('30分', { exact: true })).toBeVisible()
+  await expect(unknown.getByText('不明', { exact: true })).toHaveCount(2)
+  await expect(page.getByText('null分', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('null-null', { exact: true })).toHaveCount(0)
+})
+
 test('directory prioritizes only the first visible game image', async ({ page }) => {
   const games = [
     { id: '1', slug: 'first', title_ja: '最初のゲーム', image_url: '/first.webp' },


### PR DESCRIPTION
## What changed

Fix the existing comparison view so missing numeric metadata is presented as unknown instead of leaking JavaScript values into the UI.

- render missing/invalid player counts as `不明`
- render missing/invalid play time as `不明`
- keep known values formatted as ordinary Japanese values
- add the regression to the existing `navigation.spec.js` Playwright suite

Refs #260.

## Why

Current production data includes games such as Skull King with `play_time = null`. The comparison renderer interpolated the raw field as `${game.play_time}分`, which can display `null分`. Missing player metadata could similarly produce `null-null`.

This change does not infer a replacement duration or player count and does not introduce a separate comparison data model. The planned duration-range work in #242 remains the source for future range display.

## Scope

- 2 existing frontend files
- no dependency, CSS, configuration, schema, API, database, or storage changes
- no new test file or tooling