### PR TITLE
Remove obsolete GamePage tab event handlers

### DIFF
--- a/frontend/scripts/check-uiux-accessibility-contracts.mjs
+++ b/frontend/scripts/check-uiux-accessibility-contracts.mjs
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs'
 
 const files = {
   app: readFileSync(new URL('../src/App.jsx', import.meta.url), 'utf8'),
-  shell: readFileSync(new URL('../src/components/AppShell.jsx', import.meta.url), 'utf8'),
   modal: readFileSync(new URL('../src/components/EditGameModal.jsx', import.meta.url), 'utf8'),
 }
 
@@ -12,9 +11,6 @@ const requirements = [
   ['explicit sort label', files.app, /htmlFor="game-sort"/],
   ['compare pressed state', files.app, /aria-pressed=\{selected\}/],
   ['compare limit state', files.app, /比較できるゲームは3件まで/],
-  ['tab right-arrow keyboard support', files.shell, /ArrowRight/],
-  ['tab roving tabindex', files.shell, /tab\.tabIndex = tab === activeTab \? 0 : -1/],
-  ['tab panel semantics', files.shell, /setAttribute\('role', 'tabpanel'\)/],
   ['modal dialog role', files.modal, /role="dialog"/],
   ['modal aria-modal', files.modal, /aria-modal="true"/],
   ['modal labelledby', files.modal, /aria-labelledby="edit-game-dialog-title"/],

--- a/frontend/src/components/AppShell.jsx
+++ b/frontend/src/components/AppShell.jsx
@@ -16,49 +16,6 @@ function focusRouteContent() {
   return true
 }
 
-function syncGameTabs() {
-  const tablist = document.querySelector('.rules-tabs[role="tablist"]')
-  const panel = document.querySelector('.game-main .pro-main-col')
-  if (!tablist || !panel) return
-
-  const tabs = [...tablist.querySelectorAll('[role="tab"]')]
-  if (tabs.length === 0) return
-
-  const activeTab = tabs.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabs[0]
-  tabs.forEach((tab, index) => {
-    tab.id = `game-detail-tab-${index}`
-    tab.tabIndex = tab === activeTab ? 0 : -1
-    tab.setAttribute('aria-controls', 'game-detail-tabpanel')
-  })
-
-  panel.id = 'game-detail-tabpanel'
-  panel.setAttribute('role', 'tabpanel')
-  panel.setAttribute('aria-labelledby', activeTab.id)
-  panel.tabIndex = 0
-}
-
-function handleGameTabKeyDown(event) {
-  const current = event.target.closest?.('.rules-tabs [role="tab"]')
-  if (!current) return
-
-  const tabs = [...current.closest('[role="tablist"]').querySelectorAll('[role="tab"]')]
-  const index = tabs.indexOf(current)
-  if (index < 0) return
-
-  let nextIndex = null
-  if (event.key === 'ArrowRight') nextIndex = (index + 1) % tabs.length
-  if (event.key === 'ArrowLeft') nextIndex = (index - 1 + tabs.length) % tabs.length
-  if (event.key === 'Home') nextIndex = 0
-  if (event.key === 'End') nextIndex = tabs.length - 1
-  if (nextIndex === null) return
-
-  event.preventDefault()
-  const next = tabs[nextIndex]
-  next.focus()
-  next.click()
-  window.requestAnimationFrame(syncGameTabs)
-}
-
 export default function AppShell() {
   const location = useLocation()
   const navigate = useNavigate()
@@ -145,28 +102,6 @@ export default function AppShell() {
       positions.set(key, { x: window.scrollX, y: window.scrollY })
     }
   }, [location.key, navigationType])
-
-  useEffect(() => {
-    if (!location.pathname.startsWith('/games/')) return undefined
-
-    const root = document.getElementById('root') || document.body
-    const scheduleSync = () => window.requestAnimationFrame(syncGameTabs)
-    const onClick = (event) => {
-      if (event.target.closest?.('.rules-tabs [role="tab"]')) scheduleSync()
-    }
-
-    scheduleSync()
-    document.addEventListener('keydown', handleGameTabKeyDown)
-    document.addEventListener('click', onClick)
-    const observer = new MutationObserver(scheduleSync)
-    observer.observe(root, { childList: true, subtree: true })
-
-    return () => {
-      document.removeEventListener('keydown', handleGameTabKeyDown)
-      document.removeEventListener('click', onClick)
-      observer.disconnect()
-    }
-  }, [location.pathname])
 
   return (
     <>


### PR DESCRIPTION
## What changed

Remove the AppShell code that still managed the old ARIA Tabs implementation after GamePage moved to native button semantics.

- remove `syncGameTabs`
- remove the global Arrow/Home/End key handler for `[role="tab"]`
- remove the route-scoped MutationObserver/click listener that tried to add tabpanel relationships
- keep route focus, scroll restoration, navigation feedback, auth, and list portals unchanged

## Why

Current GamePage no longer renders `role="tablist"` or `role="tab"`; it uses native buttons with `aria-pressed`. The old AppShell code therefore has no intended target in production and adds global listeners/observers that can only become a future source of conflicting behavior.

## Scope

- 1 existing file
- 65 lines removed
- no dependencies, CSS, configuration, schema, API, or data changes

## Verification

Use the existing frontend/browser CI at the exact PR head. Merge only after the relevant checks complete successfully and then verify the production deployment SHA.