### PR TITLE
Exclude unknown player ranges from directory filters

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -189,8 +189,9 @@ function App() {
     if (activePlayers) {
       const playerCount = Number.parseInt(activePlayers, 10)
       result = result.filter((game) => {
-        const min = game.min_players || 1
-        const max = game.max_players || 99
+        const min = game.min_players
+        const max = game.max_players
+        if (!Number.isFinite(min) || min <= 0 || !Number.isFinite(max) || max <= 0) return false
         if (activePlayers === '5+') return max >= 5
         return playerCount >= min && playerCount <= max
       })

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -197,6 +197,26 @@ test('play-time sorting keeps unknown durations after known games', async ({ pag
   await expect(page.locator('.asset-title')).toHaveText(['30分ゲーム', '45分ゲーム', '時間未確認ゲーム'])
 })
 
+test('player filters exclude games with unknown player bounds', async ({ page }) => {
+  const games = [
+    { id: '1', slug: 'known', title_ja: '2人対応ゲーム', min_players: 2, max_players: 4, play_time: 30 },
+    { id: '2', slug: 'unknown', title_ja: '人数未確認ゲーム', min_players: null, max_players: null, play_time: null },
+  ]
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: '2人', exact: true }).click()
+
+  await expect(page.locator('.asset-title')).toHaveText(['2人対応ゲーム'])
+  await expect(page.getByText('人数未確認ゲーム', { exact: true })).toHaveCount(0)
+})
+
 test('comparison renders missing player count and duration as unknown', async ({ page }) => {
   const games = [
     { id: '1', slug: 'known', title_ja: '既知ゲーム', min_players: 2, max_players: 4, play_time: 30 },


### PR DESCRIPTION
## What changed

Fix the existing Directory player filters so missing player-count metadata is not treated as positive compatibility.

- require finite positive `min_players` and `max_players` before a game can match a player-count filter
- keep known ranges unchanged, including `5+`
- add a Playwright regression in the existing navigation suite showing a 2–4 player game remains while a game with unknown bounds is excluded by the 2-player filter

## Why

Current production data has 16 of 189 games with both player bounds missing. The old client fallback converted missing bounds to `1..99`, so those games matched every player-count filter.

This is the smallest client-side correction already recorded in #197. It does not attempt the larger server-side search/filter/pagination migration.

## Scope

- 2 existing frontend files
- no dependency, CSS, config, schema, API, database, or storage changes

## Verification

Use the existing browser CI at the exact PR head. After merge, verify the Vercel production deployment SHA and the Directory filter behavior.