### PR TITLE
Keep client GamePage title aligned with available content

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -122,7 +122,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const hasRuleFlow = Boolean(ruleGuide?.flow?.length)
   const hasInfographics = hasRuleFlow || legacyInfographicsVerified
 
-  const pageTitle = `「${title}」のルール・戦略・インスト要約 | ボドゲのミカタ`
+  const pageTitle = `「${title}」のルール${sd.strategy_analysis ? '・戦略' : ''}・インスト要約 | ボドゲのミカタ`
   const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
   const gameUrl = `${BASE_URL}/games/${slug}`
   const imageUrl = game.image_url || `${BASE_URL}/assets/no-image.webp`

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -99,6 +99,27 @@ test('game detail keeps one primary flow and readable long-form measure', async 
   await expect(page.locator('.quick-rules-panel')).toHaveCount(0)
 })
 
+test('game page title only advertises strategy when strategy content exists', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+  await expect(page).toHaveTitle('「ビッグショット」のルール・戦略・インスト要約 | ボドゲのミカタ')
+
+  const withoutStrategy = {
+    ...bigShot,
+    slug: 'no-strategy',
+    title_ja: '戦略なしゲーム',
+    structured_data: {
+      ...bigShot.structured_data,
+      strategy_analysis: null,
+    },
+  }
+
+  await page.unrouteAll({ behavior: 'wait' })
+  await mockGameApi(page, withoutStrategy)
+  await page.goto('/games/no-strategy')
+  await expect(page).toHaveTitle('「戦略なしゲーム」のルール・インスト要約 | ボドゲのミカタ')
+})
+
 test('quick rules flatten to one row on wide desktop inside the single-column page', async ({ page }) => {
   const skullKing = {
     ...bigShot,


### PR DESCRIPTION
Closes #137

## What changed

- make the React Helmet GamePage title include `戦略` only when `structured_data.strategy_analysis` exists
- match the content-availability rule already used by the server SEO renderer
- add the regression to the existing GamePage Playwright suite for both strategy-present and strategy-absent records

## Why

Production `/games/skull-king` currently renders the correct raw HTML title without `戦略`, because its strategy content is absent. The client GamePage still used an unconditional title and could replace that title after client takeover.

Google Search Central recommends descriptive page titles and specifically recommends adding content labels only when the corresponding content exists: https://developers.google.com/search/docs/appearance/title-link

## Scope

- 2 existing frontend files
- no dependency, config, schema, CSS, or data changes
- no new helper or test file

## Verification

Run the existing exact-head frontend/browser checks. After merge, verify the Vercel production deployment SHA and re-read `/games/skull-king`.