### PR TITLE
Remove duplicate Links heading on GamePage

### DIFF
--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -38,7 +38,6 @@ export const ExternalLinks = ({ game }) => {
 
   return (
     <div className="info-section">
-      <h3>Links</h3>
       <div className="external-links-grid">
         {links.map((link) => (
           <a


### PR DESCRIPTION
Closes one small presentation slice of #192.

## Change
- remove the nested `Links` heading from `ExternalLinks`
- keep the existing GamePage `LINKS` card title as the single visible section label
- preserve all existing source, store, BoardGameGeek, and Board Game Arena links and trust labels

## Scope
- 1 existing frontend file
- no dependencies, CSS, configuration, schema, API, data, or storage changes

## Verification
Use the existing frontend build/lint/browser checks on the exact PR head. After merge, verify the Vercel production deployment reports the merge SHA and smoke a representative GamePage.