### PR TITLE
Label generic GamePage summaries accurately

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -180,7 +180,9 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
 
           <div className="pro-card pro-card--synopsis">
-            <div className="pro-card-title">30秒でわかる「{title}」</div>
+            <div className="pro-card-title">
+              {ruleGuide?.quick ? `30秒でわかる「${title}」` : `「${title}」のゲーム概要`}
+            </div>
             <div className="summary-text">{game.summary || game.description}</div>
           </div>
 

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -84,6 +84,8 @@ test('game detail keeps one primary flow and readable long-form measure', async 
   await page.goto('/games/big-shot')
 
   await expect(page.getByRole('heading', { name: 'ビッグショット' })).toBeVisible()
+  await expect(page.getByText('「ビッグショット」のゲーム概要', { exact: true })).toBeVisible()
+  await expect(page.getByText('30秒でわかる「ビッグショット」', { exact: true })).toHaveCount(0)
   await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toBeVisible()
 
   const desktop = await readLayout(page)
@@ -133,6 +135,7 @@ test('quick rules flatten to one row on wide desktop inside the single-column pa
   await page.setViewportSize({ width: 1280, height: 900 })
   await page.goto('/games/skull-king')
 
+  await expect(page.getByText('30秒でわかる「スカルキング」', { exact: true })).toBeVisible()
   const cards = page.locator('.quick-rule-card')
   await expect(cards).toHaveCount(4)
 


### PR DESCRIPTION
## What changed

- keep `30秒でわかる「…」` only when the game has the existing curated quick-rule guide
- label the same summary as `「…」のゲーム概要` when no curated quick guide exists
- add Playwright regression coverage for both non-curated Big Shot and curated Skull King

## Why

Current GamePage presents every `summary` under `30秒でわかる`, even when the page has no curated quick-rule guide. That overstates what a generic summary guarantees. The change does not generate or duplicate any rule content; it only makes the heading match the available presentation data.

## Scope

- 2 existing frontend files
- no dependency, CSS, config, schema, API, data, or storage changes
- continues existing Issue #158

## Verification

Run the existing frontend/browser checks at the exact PR head. Merge only after the relevant checks pass, then verify the exact merge SHA in the production Vercel deployment.