### PR TITLE
Show verification state on directory cards

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,12 @@ function comparisonPlayTime(game) {
   return Number.isFinite(game.play_time) && game.play_time > 0 ? `${game.play_time}分` : '不明'
 }
 
+function directoryTrustLabel(game) {
+  if (game.identity_status !== 'verified') return '未検証'
+  if (['review_required', 'ai_draft', 'unknown'].includes(game.content_review_status)) return '内容要確認'
+  return null
+}
+
 function Filters({
   activePlayers,
   activeTime,
@@ -400,6 +406,7 @@ function App() {
               const selected = compareList.some((candidate) => candidate.id === game.id)
               const limitReached = compareList.length >= 3 && !selected
               const title = game.title_ja || game.title || 'このゲーム'
+              const trustLabel = directoryTrustLabel(game)
               const firstVisibleGame = game === filteredGames[0]
               return (
                 <div key={game.id} className="asset-card-shell">
@@ -418,6 +425,7 @@ function App() {
                     <div className="asset-info">
                       <div className="asset-title">{title}</div>
                       <div className="asset-meta">
+                        {trustLabel && <span className="meta-item">{trustLabel}</span>}
                         {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
                         {game.play_time && <span className="meta-item">⏳ {game.play_time}分</span>}
                         {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -266,3 +266,28 @@ test('directory prioritizes only the first visible game image', async ({ page })
   await expect(images.nth(1)).toHaveAttribute('loading', 'lazy')
   await expect(images.nth(1)).toHaveAttribute('fetchpriority', 'auto')
 })
+
+test('directory labels unverified and review-required games without warning reviewed games', async ({ page }) => {
+  const games = [
+    { id: '1', slug: 'unverified', title_ja: '未検証ゲーム', identity_status: 'unverified', content_review_status: 'unknown' },
+    { id: '2', slug: 'review', title_ja: '要確認ゲーム', identity_status: 'verified', content_review_status: 'review_required' },
+    { id: '3', slug: 'reviewed', title_ja: '確認済みゲーム', identity_status: 'verified', content_review_status: 'human_reviewed' },
+  ]
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+
+  await page.goto('/')
+
+  const unverified = page.locator('.asset-card-shell').filter({ hasText: '未検証ゲーム' })
+  const review = page.locator('.asset-card-shell').filter({ hasText: '要確認ゲーム' })
+  const reviewed = page.locator('.asset-card-shell').filter({ hasText: '確認済みゲーム' })
+  await expect(unverified.getByText('未検証', { exact: true })).toBeVisible()
+  await expect(review.getByText('内容要確認', { exact: true })).toBeVisible()
+  await expect(reviewed.getByText('未検証', { exact: true })).toHaveCount(0)
+  await expect(reviewed.getByText('内容要確認', { exact: true })).toHaveCount(0)
+})


### PR DESCRIPTION
Partial implementation of #267.

## What changed
- show `未検証` when `identity_status` is not `verified`
- show `内容要確認` when identity is verified but content is `review_required`, `ai_draft`, or `unknown`
- leave human/publisher-reviewed cards unlabelled rather than adding unnecessary warnings
- reuse the existing game API fields; no new trust state or schema
- add the regression to the existing `navigation.spec.js` Playwright suite

## Production evidence before change
Current production/main SHA: `b56c197bb42e6b388c36157b658c322007ab5da0`.
Current production catalog distribution includes 180/189 games as `unverified / unknown / unknown`, so the current Directory hides a material decision-relevant state for most cards.

## Scope
- 2 existing frontend files
- +33 / -0
- dependencies: 0
- CSS/config/schema/API/data/storage changes: 0

## Verification
Run the existing exact-head frontend/browser CI. Merge only after the relevant checks succeed, then verify the exact merge SHA reaches the READY Vercel production deployment.