### PR TITLE
Keep X share copy factual

### DIFF
--- a/frontend/src/components/game/ShareButtons.jsx
+++ b/frontend/src/components/game/ShareButtons.jsx
@@ -64,7 +64,7 @@ export const ShareButton = ({ slug }) => {
 
 export const TwitterShareButton = ({ slug, title }) => {
   const handleTwitterShare = () => {
-    const text = `ボードゲーム「${title}」が気になる！ルールや魅力を3分でチェック！`
+    const text = `ボードゲーム「${title}」のルールを見る`
     const url = `https://bodoge-no-mikata.vercel.app/games/${slug}`
     const hashtags = 'ボドゲのミカタ,ボードゲーム'
     const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}&hashtags=${hashtags}`
@@ -75,8 +75,8 @@ export const TwitterShareButton = ({ slug, title }) => {
     <button
       onClick={handleTwitterShare}
       className="share-btn twitter"
-      title="X(Twitter)でシェア"
-      aria-label="Share on X"
+      title="Xで共有"
+      aria-label="Xで共有"
     >
       𝕏 共有
     </button>

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -247,6 +247,25 @@ test('game share copies canonical URL when Web Share is unavailable', async ({ p
   await expect(page.getByRole('button', { name: 'コピーしました' })).toBeVisible()
 })
 
+test('X share copy stays factual and uses the canonical game URL', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__openedShareUrl = null
+    window.open = (url) => {
+      window.__openedShareUrl = url
+      return null
+    }
+  })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+
+  await page.getByRole('button', { name: 'Xで共有' }).click()
+  const shareUrl = await page.evaluate(() => window.__openedShareUrl)
+  const parsed = new URL(shareUrl)
+  expect(parsed.searchParams.get('text')).toBe('ボードゲーム「ビッグショット」のルールを見る')
+  expect(parsed.searchParams.get('url')).toBe('https://bodoge-no-mikata.vercel.app/games/big-shot')
+  expect(parsed.searchParams.get('text')).not.toContain('3分')
+})
+
 test('text-to-speech control identifies that it reads page highlights', async ({ page }) => {
   await page.addInitScript(() => {
     Object.defineProperty(window, 'speechSynthesis', {


### PR DESCRIPTION
## What changed

- remove the unverified `3分でチェック` timing claim from the X share text
- use the factual copy `ボードゲーム「…」のルールを見る`
- align the visible/accessible control name to `Xで共有`
- extend the existing GamePage Playwright suite to verify the generated share text, canonical game URL, and absence of the timing claim

## Scope

- 2 existing frontend files
- no dependency, CSS, config, schema, API, data, or storage changes
- no changes to the existing share endpoint or canonical game URL

Refs #221