### PR TITLE
Simplify the game not-found page

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,7 +79,6 @@ def game_not_found_html() -> str:
   </head>
   <body>
     <main style="max-width:42rem;margin:10vh auto;padding:2rem;font-family:system-ui,sans-serif;line-height:1.7">
-      <p style="font-weight:700;letter-spacing:.08em">404 · GAME NOT FOUND</p>
       <h1>ゲームが見つかりません</h1>
       <p>指定されたゲームは登録されていないか、URLが変更されています。</p>
       <p><a href="/">ゲーム一覧へ戻る</a></p>

--- a/backend/tests/test_web_not_found.py
+++ b/backend/tests/test_web_not_found.py
@@ -16,6 +16,7 @@ def test_missing_web_game_returns_user_facing_html_404(monkeypatch):
     assert response.headers["content-type"].startswith("text/html")
     assert "ゲームが見つかりません" in response.text
     assert "ゲーム一覧へ戻る" in response.text
+    assert "GAME NOT FOUND" not in response.text
     assert 'name="robots" content="noindex, nofollow"' in response.text
     assert 'rel="canonical"' not in response.text
     assert 'application/json' not in response.headers["content-type"]


### PR DESCRIPTION
Follow-up to #135.

- remove the redundant English `GAME NOT FOUND` line from the Japanese server-rendered 404 page
- keep the HTTP 404, `noindex, nofollow`, Japanese explanation, and game-list recovery link unchanged
- extend the existing 404 regression test to prevent the retired English copy from returning

No dependency, schema, configuration, frontend bundle, database, or storage changes.