### PR TITLE
Remove obsolete Google Search metadata

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,10 +8,6 @@
       name="description"
       content="ボドゲのミカタは、登録済みのボードゲーム情報を検索し、ルール、セットアップ、ゲーム進行、終了条件などを確認するための補助ツールです。AI生成・要約を含む情報は公式資料と区別して確認してください。"
     />
-    <meta
-      name="keywords"
-      content="ボードゲーム, ルール, セットアップ, 遊び方, ボドゲ, 検索, インスト, ゲーム情報"
-    />
     <meta name="theme-color" content="#FBFAF7" />
     <meta name="color-scheme" content="light" />
     <meta name="robots" content="index, follow" />
@@ -57,15 +53,7 @@
             "url": "https://bodoge-no-mikata.vercel.app/",
             "name": "ボドゲのミカタ",
             "description": "登録済みのボードゲーム情報とルール確認を支援するWebサイト",
-            "inLanguage": "ja",
-            "potentialAction": {
-              "@type": "SearchAction",
-              "target": {
-                "@type": "EntryPoint",
-                "urlTemplate": "https://bodoge-no-mikata.vercel.app/?q={search_term_string}"
-              },
-              "query-input": "required name=search_term_string"
-            }
+            "inLanguage": "ja"
           },
           {
             "@type": "WebApplication",


### PR DESCRIPTION
Closes the verified cleanup slice in #214.

## What changed
- remove the `meta keywords` tag from the public HTML template because Google Search does not use it for indexing or ranking
- remove the obsolete `WebSite.potentialAction` sitelinks-search-box `SearchAction`
- preserve the supported `WebSite` structured data used for site identity

## Evidence
- Google Search Central: https://developers.google.com/search/docs/crawling-indexing/special-tags
- Google Search Central: https://developers.google.com/search/blog/2024/10/sitelinks-search-box

## Scope
- 1 existing HTML file
- no dependencies, config, schema, API, DB, storage, or application behavior changes

## Verification
Build the frontend at the exact PR head and confirm generated HTML contains the remaining canonical/robots/OG/WebSite/WebApplication metadata but no `meta keywords` or `SearchAction`.