### PR TITLE
Remove unavailable regeneration guidance from GamePage

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -266,7 +266,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
                   <ReactMarkdown>{sd.strategy_analysis}</ReactMarkdown>
                 ) : (
                   <div className="game-empty-state" role="status">
-                    戦略解説はまだ登録されていません。必要に応じて再生成してください。
+                    戦略解説はまだ登録されていません。
                   </div>
                 )}
               </div>
@@ -289,7 +289,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
                   </div>
                 )) : (
                   <div className="game-empty-state" role="status">
-                    レビューはまだ登録されていません。必要に応じて再生成してください。
+                    レビューはまだ登録されていません。
                   </div>
                 )}
               </div>

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -210,6 +210,29 @@ test('preparation flow and end view shows only game-specific summaries and fails
   await expect(page.getByText('このゲーム固有の終了条件要約は未確認です。')).toBeVisible()
 })
 
+test('empty strategy and review states do not suggest unavailable regeneration actions', async ({ page }) => {
+  const withoutOptionalContent = {
+    ...bigShot,
+    slug: 'empty-optional-content',
+    structured_data: {
+      ...bigShot.structured_data,
+      strategy_analysis: null,
+      persona_reviews: [],
+    },
+  }
+
+  await mockGameApi(page, withoutOptionalContent)
+  await page.goto('/games/empty-optional-content')
+
+  await page.getByRole('button', { name: '戦略', exact: true }).click()
+  await expect(page.getByText('戦略解説はまだ登録されていません。', { exact: true })).toBeVisible()
+  await expect(page.getByText(/再生成してください/)).toHaveCount(0)
+
+  await page.getByRole('button', { name: 'レビュー', exact: true }).click()
+  await expect(page.getByText('レビューはまだ登録されていません。', { exact: true })).toBeVisible()
+  await expect(page.getByText(/再生成してください/)).toHaveCount(0)
+})
+
 test('game share uses Web Share when available', async ({ page }) => {
   await page.addInitScript(() => {
     window.__shared = null


### PR DESCRIPTION
## What changed

Remove stale public guidance that told users to regenerate missing strategy/review content even though public catalog/content generation is not available.

- strategy empty state now only says the content is not registered
- review empty state now only says the content is not registered
- existing GamePage Playwright suite verifies neither view suggests regeneration

## Scope

- 2 existing frontend files
- no dependency, CSS, config, schema, API, or data changes
- no new generation path or editor affordance

## Verification

Run the existing frontend/browser checks on the exact PR head. Merge only after the relevant checks succeed; then verify the exact merge SHA in Vercel production.