### PR TITLE
Keep verification state visible in comparison

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -283,6 +283,7 @@ function App() {
               <div className="pro-card comparison-game-card">
                 <img src={gameImageUrl(game)} onError={handleGameImageError} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
                 <div className="pro-stat-value">{game.title_ja || game.title}</div>
+                {directoryTrustLabel(game) && <div className="meta-item">{directoryTrustLabel(game)}</div>}
                 {game.strategy_tier && <div className="tier-badge comparison-tier">戦略ティア {game.strategy_tier}</div>}
               </div>
 

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -290,4 +290,17 @@ test('directory labels unverified and review-required games without warning revi
   await expect(review.getByText('内容要確認', { exact: true })).toBeVisible()
   await expect(reviewed.getByText('未検証', { exact: true })).toHaveCount(0)
   await expect(reviewed.getByText('内容要確認', { exact: true })).toHaveCount(0)
+
+  await page.getByRole('button', { name: '未検証ゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '要確認ゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '確認済みゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '比較する' }).click()
+
+  const comparedUnverified = page.locator('.battle-col').filter({ hasText: '未検証ゲーム' })
+  const comparedReview = page.locator('.battle-col').filter({ hasText: '要確認ゲーム' })
+  const comparedReviewed = page.locator('.battle-col').filter({ hasText: '確認済みゲーム' })
+  await expect(comparedUnverified.getByText('未検証', { exact: true })).toBeVisible()
+  await expect(comparedReview.getByText('内容要確認', { exact: true })).toBeVisible()
+  await expect(comparedReviewed.getByText('未検証', { exact: true })).toHaveCount(0)
+  await expect(comparedReviewed.getByText('内容要確認', { exact: true })).toHaveCount(0)
 })


### PR DESCRIPTION
Refs #260

## What changed

- reuse the existing Directory verification label in the comparison card header
- keep `未検証` visible for unverified game identity
- keep `内容要確認` visible for verified identity with `review_required`, `ai_draft`, or `unknown` content
- leave reviewed games unlabelled rather than adding a new status
- extend the existing `navigation.spec.js` fixture so the same three states remain consistent after entering comparison

## Why

Directory cards now expose verification state, but the comparison screen drops it and presents the same summaries/basic facts without that context. This is a small current slice of #260; it does not attempt field-level evidence or RuleSet projection.

## Scope

- 2 existing frontend files
- no dependency, CSS, config, schema, API, database, or storage changes
- no new trust classification or helper

## Verification

Run the existing exact-head frontend/browser checks. Merge only after the relevant checks succeed, then verify the exact merge SHA reaches the READY Vercel production deployment.