### PR TITLE
Allow directory reload after initial API failure

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -396,7 +396,16 @@ function App() {
           </select>
         </div>
 
-        {error && <div className="app-feedback app-feedback--error" role="alert">{error}</div>}
+        {error && (
+          <div className="app-feedback app-feedback--error" role="alert">
+            <span>{error}</span>
+            {initialGames.length === 0 && (
+              <button type="button" className="filter-btn" onClick={loadAllGames}>
+                再読み込み
+              </button>
+            )}
+          </div>
+        )}
         {compareNotice && <div className="app-feedback compare-feedback" role="status">{compareNotice}</div>}
 
         {loading ? (
@@ -448,7 +457,7 @@ function App() {
                 </div>
               )
             })}
-            {filteredGames.length === 0 && !loading && <div className="app-empty-state">条件に一致するゲームが見つかりません。</div>}
+            {filteredGames.length === 0 && !loading && !error && <div className="app-empty-state">条件に一致するゲームが見つかりません。</div>}
           </div>
         )}
 

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -304,3 +304,29 @@ test('directory labels unverified and review-required games without warning revi
   await expect(comparedReviewed.getByText('未検証', { exact: true })).toHaveCount(0)
   await expect(comparedReviewed.getByText('内容要確認', { exact: true })).toHaveCount(0)
 })
+
+test('directory load failure stays distinct from empty results and can be retried', async ({ page }) => {
+  let requests = 0
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    requests += 1
+    if (requests === 1) {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ detail: 'unavailable' }) })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games: [{ id: '1', slug: 'retry-game', title_ja: '再読込ゲーム' }], total: 1 }),
+    })
+  })
+
+  await page.goto('/')
+
+  await expect(page.getByRole('alert')).toContainText('ゲームの読み込みに失敗しました。')
+  await expect(page.getByText('条件に一致するゲームが見つかりません。', { exact: true })).toHaveCount(0)
+  await page.getByRole('button', { name: '再読み込み' }).click()
+
+  await expect(page.getByRole('alert')).toHaveCount(0)
+  await expect(page.getByText('再読込ゲーム', { exact: true })).toBeVisible()
+  expect(requests).toBe(2)
+})


### PR DESCRIPTION
## What changed

- keep an initial directory API failure distinct from a legitimate zero-result state
- show a `再読み込み` action only when the initial catalog has not loaded
- suppress the zero-result message while the directory is in an error state
- add a Playwright regression covering `503 -> retry -> successful game list`

This is a small reliability/UX slice of #197. It does not change the existing full-catalog fetch or search/filter architecture.

## Verification

Run the existing frontend/browser checks at exact head. Merge only after required checks complete successfully; verify the deployed Git SHA after merge.

Refs #197