### PR TITLE
Add breadcrumb metadata to GamePage SSR

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -75,6 +75,25 @@ async def generate_seo_html(slug: str) -> str | None:
     if game.get("play_time"):
         structured_data["timeRequired"] = f"PT{game.get('play_time')}M"
 
+    breadcrumb_data = {
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {
+                "@type": "ListItem",
+                "position": 1,
+                "name": "ゲーム一覧",
+                "item": f"{BASE_URL}/",
+            },
+            {
+                "@type": "ListItem",
+                "position": 2,
+                "name": title,
+                "item": game_url,
+            },
+        ],
+    }
+
     root = Path(os.getenv("LAMBDA_TASK_ROOT", Path(__file__).resolve().parent.parent.parent.parent))
     possible_paths = [
         root / "frontend" / "dist" / "index.html",
@@ -118,7 +137,15 @@ async def generate_seo_html(slug: str) -> str | None:
 
     json_ld = _safe_json_script(structured_data)
     script_tag = f'<script type="application/ld+json" data-game-seo="true">{json_ld}</script>'
-    html_content = html_content.replace("</head>", f"  {script_tag}\n</head>", 1)
+    breadcrumb_json_ld = _safe_json_script(breadcrumb_data)
+    breadcrumb_script_tag = (
+        f'<script type="application/ld+json" data-breadcrumb-seo="true">{breadcrumb_json_ld}</script>'
+    )
+    html_content = html_content.replace(
+        "</head>",
+        f"  {script_tag}\n  {breadcrumb_script_tag}\n</head>",
+        1,
+    )
 
     safe_title = html.escape(title)
     safe_summary = html.escape(str(game.get("summary") or ""))
@@ -136,8 +163,11 @@ async def generate_seo_html(slug: str) -> str | None:
 
     ssr_content = f"""<div id="root">
   <article itemscope itemtype="https://schema.org/Game" data-ssr-game="true">
-    <nav aria-label="ゲーム一覧へのナビゲーション">
-      <a href="/">ゲーム一覧</a>
+    <nav aria-label="パンくずリスト">
+      <ol>
+        <li><a href="/">ゲーム一覧</a></li>
+        <li aria-current="page">{safe_title}</li>
+      </ol>
     </nav>
     <h1 itemprop="name">{safe_title}</h1>
     <section>

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -76,8 +76,14 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert 'href="https://bodoge-no-mikata.vercel.app/games/safe-game"' in rendered
     assert 'property="og:url" content="https://bodoge-no-mikata.vercel.app/games/safe-game"' in rendered
     assert 'data-game-seo="true"' in rendered
+    assert 'data-breadcrumb-seo="true"' in rendered
+    assert '"@type":"BreadcrumbList"' in rendered
+    assert '"name":"ゲーム一覧","item":"https://bodoge-no-mikata.vercel.app/"' in rendered
+    assert '"item":"https://bodoge-no-mikata.vercel.app/games/safe-game"' in rendered
     assert 'data-ssr-game="true"' in rendered
+    assert '<nav aria-label="パンくずリスト">' in rendered
     assert '<a href="/">ゲーム一覧</a>' in rendered
+    assert 'aria-current="page"' in rendered
     assert '<script>alert("title")</script>' not in rendered
     assert '<script>alert("rules")</script>' not in rendered
     assert '<img src=x onerror=alert("summary")>' not in rendered


### PR DESCRIPTION
## What changed

- add a visible two-level breadcrumb to server-rendered GamePage HTML: `ゲーム一覧 > current game`
- add matching Schema.org `BreadcrumbList` JSON-LD using the existing canonical game URL
- extend the existing SEO renderer regression test for the breadcrumb markup, canonical URLs, and escaping

This continues #200 without adding a second hierarchy, new dependency, or separate SEO generator.

## Why

Current production GamePage HTML has a crawlable link back to the game directory but no breadcrumb structured data. Google Search currently supports `BreadcrumbList` and recommends crawlable internal links with descriptive anchor text so users and Google can understand site structure.

Primary references:
- https://developers.google.com/search/docs/appearance/structured-data/breadcrumb
- https://developers.google.com/search/docs/crawling-indexing/links-crawlable

## Verification

Run the existing backend SEO renderer tests and repository CI at the exact PR head. After merge, verify the Vercel production deployment Git SHA and re-fetch a representative raw GamePage HTML before considering production complete.

No dependency, configuration, schema, API, database, or storage changes.