### PR TITLE
Include GamePage title in native share data

### DIFF
--- a/frontend/src/components/game/ShareButtons.jsx
+++ b/frontend/src/components/game/ShareButtons.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-export const ShareButton = ({ slug }) => {
+export const ShareButton = ({ slug, title }) => {
   const [status, setStatus] = useState('idle')
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function'
 
@@ -22,10 +22,11 @@ export const ShareButton = ({ slug }) => {
 
   const handleShare = async () => {
     const url = `https://bodoge-no-mikata.vercel.app/games/${slug}`
+    const text = `ボードゲーム「${title}」のルールを見る`
 
     if (canNativeShare) {
       try {
-        await navigator.share({ url })
+        await navigator.share({ title, text, url })
         setStatus('shared')
         setTimeout(() => setStatus('idle'), 2000)
         return

--- a/frontend/src/components/game/ShareButtons.jsx
+++ b/frontend/src/components/game/ShareButtons.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-export const ShareButton = ({ slug, title }) => {
+export const ShareButton = ({ slug }) => {
   const [status, setStatus] = useState('idle')
   const canNativeShare = typeof navigator !== 'undefined' && typeof navigator.share === 'function'
 
@@ -22,11 +22,11 @@ export const ShareButton = ({ slug, title }) => {
 
   const handleShare = async () => {
     const url = `https://bodoge-no-mikata.vercel.app/games/${slug}`
-    const text = `ボードゲーム「${title}」のルールを見る`
+    const title = typeof document !== 'undefined' ? document.title : ''
 
     if (canNativeShare) {
       try {
-        await navigator.share({ title, text, url })
+        await navigator.share({ title, url })
         setStatus('shared')
         setTimeout(() => setStatus('idle'), 2000)
         return

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -246,6 +246,7 @@ test('game share uses Web Share when available', async ({ page }) => {
 
   await page.getByRole('button', { name: '共有', exact: true }).click()
   expect(await page.evaluate(() => window.__shared)).toEqual({
+    title: '「ビッグショット」のルール・戦略・インスト要約 | ボドゲのミカタ',
     url: 'https://bodoge-no-mikata.vercel.app/games/big-shot',
   })
   await expect(page.getByRole('button', { name: '共有しました' })).toBeVisible()


### PR DESCRIPTION
Closes part of #221.

## Finding
The GamePage generic share button currently sends only the canonical URL to `navigator.share`, while the X-specific share action includes game context. The Web Share specification defines `title`, `text`, and `url` as standard `ShareData` members.

## Change
- keep the existing canonical `/games/{slug}` URL
- add the current GamePage document title to the native share payload
- keep the existing clipboard fallback unchanged
- do not add a dependency or another sharing helper

## Verification
- exact-head Vercel/GitHub CI must pass before merge
- production verification after merge should confirm the deployed Git SHA and successful GamePage response
- actual native share-sheet rendering remains device/browser-dependent and should not be claimed without an executable browser/device layer

Primary specification: https://w3c.github.io/web-share/