### PR TITLE
Track actual speech synthesis lifecycle

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -104,6 +104,7 @@ jobs:
           tests/mobile_game_scroll.spec.js
           tests/auth.spec.js
           tests/generated-game-images.spec.js
+          tests/text_to_speech.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/components/game/TextToSpeech.jsx
+++ b/frontend/src/components/game/TextToSpeech.jsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react'
 
 export const TextToSpeech = ({ text }) => {
-  const [speaking, setSpeaking] = useState(false)
+  const [speechState, setSpeechState] = useState('idle')
   const [supported] = useState(() => typeof window !== 'undefined' && 'speechSynthesis' in window)
+  const active = speechState !== 'idle'
 
   useEffect(() => {
     return () => {
@@ -15,9 +16,9 @@ export const TextToSpeech = ({ text }) => {
   const handleSpeak = () => {
     if (!supported) return
 
-    if (speaking) {
+    if (active) {
       window.speechSynthesis.cancel()
-      setSpeaking(false)
+      setSpeechState('idle')
       return
     }
 
@@ -25,11 +26,12 @@ export const TextToSpeech = ({ text }) => {
     utterance.lang = 'ja-JP'
     utterance.rate = 0.9
     utterance.pitch = 1.0
-    utterance.onend = () => setSpeaking(false)
-    utterance.onerror = () => setSpeaking(false)
+    utterance.onstart = () => setSpeechState('speaking')
+    utterance.onend = () => setSpeechState('idle')
+    utterance.onerror = () => setSpeechState('idle')
 
     window.speechSynthesis.speak(utterance)
-    setSpeaking(true)
+    setSpeechState('queued')
   }
 
   if (!supported) return null
@@ -37,12 +39,12 @@ export const TextToSpeech = ({ text }) => {
   return (
     <button
       onClick={handleSpeak}
-      className={`share-btn ${speaking ? 'speaking' : ''}`}
-      title={speaking ? '要点の読み上げを停止' : 'ページの要点を読み上げ'}
-      aria-label={speaking ? '要点の読み上げを停止' : 'ページの要点を読み上げ'}
-      aria-pressed={speaking}
+      className={`share-btn ${speechState === 'speaking' ? 'speaking' : ''}`}
+      title={active ? '要点の読み上げを停止' : 'ページの要点を読み上げ'}
+      aria-label={active ? '要点の読み上げを停止' : 'ページの要点を読み上げ'}
+      aria-pressed={active}
     >
-      {speaking ? '⏹️ 停止' : '🔊 要点'}
+      {active ? '⏹️ 停止' : '🔊 要点'}
     </button>
   )
 }

--- a/frontend/tests/text_to_speech.spec.js
+++ b/frontend/tests/text_to_speech.spec.js
@@ -43,7 +43,8 @@ test('GamePage speech state follows utterance lifecycle', async ({ page }) => {
 
   await page.goto('/games/game-one')
 
-  const button = page.getByRole('button', { name: 'ページの要点を読み上げ' })
+  const button = page.locator('.header-actions button[aria-pressed]')
+  await expect(button).toHaveAccessibleName('ページの要点を読み上げ')
   await button.click()
 
   await expect(button).toHaveAccessibleName('要点の読み上げを停止')

--- a/frontend/tests/text_to_speech.spec.js
+++ b/frontend/tests/text_to_speech.spec.js
@@ -1,0 +1,60 @@
+import { test, expect } from '@playwright/test'
+
+test('GamePage speech state follows utterance lifecycle', async ({ page }) => {
+  await page.addInitScript(() => {
+    class FakeSpeechSynthesisUtterance {
+      constructor(text) {
+        this.text = text
+      }
+    }
+
+    Object.defineProperty(window, 'SpeechSynthesisUtterance', {
+      configurable: true,
+      value: FakeSpeechSynthesisUtterance,
+    })
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: {
+        speak(utterance) {
+          window.__lastUtterance = utterance
+        },
+        cancel() {
+          window.__speechCancelled = true
+        },
+      },
+    })
+  })
+
+  await page.route('**/api/games/game-one', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: '11111111-1111-4111-8111-111111111111',
+        slug: 'game-one',
+        title: 'Game One',
+        title_ja: 'ゲーム1',
+        summary: 'ゲームの要点です。',
+        rules_content: '詳細ルール',
+        structured_data: {},
+      }),
+    })
+  })
+
+  await page.goto('/games/game-one')
+
+  const button = page.getByRole('button', { name: 'ページの要点を読み上げ' })
+  await button.click()
+
+  await expect(button).toHaveAccessibleName('要点の読み上げを停止')
+  await expect(button).toHaveAttribute('aria-pressed', 'true')
+  await expect(button).not.toHaveClass(/speaking/)
+
+  await page.evaluate(() => window.__lastUtterance.onstart())
+  await expect(button).toHaveClass(/speaking/)
+
+  await page.evaluate(() => window.__lastUtterance.onend())
+  await expect(button).toHaveAccessibleName('ページの要点を読み上げ')
+  await expect(button).toHaveAttribute('aria-pressed', 'false')
+  await expect(button).not.toHaveClass(/speaking/)
+})


### PR DESCRIPTION
## Summary
- distinguish queued speech from actual speaking state
- set the visual `speaking` state only from the Web Speech API `start` event
- return to idle on `end`, `error`, or user cancellation
- add a Playwright regression test for queue → start → end

## Evidence
The Web Speech API defines `start` as the event fired when an utterance has begun to be spoken; `end` and `error` end that utterance lifecycle. `SpeechSynthesis.cancel()` removes queued utterances and stops current speech.

Related: #32

No dependencies, API/schema, config, database, or storage changes.