### PR TITLE
Separate registered sources from external links

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -105,6 +105,7 @@ jobs:
           tests/auth.spec.js
           tests/generated-game-images.spec.js
           tests/text_to_speech.spec.js
+          tests/source_links.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -12,10 +12,10 @@ const isValidUrl = (url) => {
 }
 
 const sourceLabel = (sourceTrust) => {
-  if (sourceTrust === 'official_publisher') return '出版社・公式一次情報'
-  if (sourceTrust === 'authorized_partner') return '認定パートナー情報'
-  if (sourceTrust === 'third_party') return '第三者情報源'
-  return '出典（未検証）'
+  if (sourceTrust === 'official_publisher') return '出版社のページ'
+  if (sourceTrust === 'authorized_partner') return '認定パートナーのページ'
+  if (sourceTrust === 'third_party') return '第三者の出典'
+  return '登録済み出典（未検証）'
 }
 
 export const ExternalLinks = ({ game }) => {
@@ -24,33 +24,55 @@ export const ExternalLinks = ({ game }) => {
   const amazon = affiliateAmazon || amazon_url
   const rakuten = affiliate_urls?.rakuten
   const yahoo = affiliate_urls?.yahoo
-
+  const source = isValidUrl(source_url)
+    ? { url: source_url, label: sourceLabel(source_trust), class: 'source', sponsored: false }
+    : null
   const links = [
     { url: amazon, label: 'Amazon', class: 'amazon', sponsored: Boolean(affiliateAmazon) },
     { url: rakuten, label: '楽天で見る', class: 'rakuten', sponsored: true },
     { url: yahoo, label: 'Yahoo!で見る', class: 'yahoo', sponsored: true },
-    { url: source_url, label: sourceLabel(source_trust), class: 'source', sponsored: false },
     { url: bgg_url, label: 'BoardGameGeek', class: 'bgg', sponsored: false },
     { url: game.bga_url, label: 'Board Game Arena', class: 'bga', sponsored: false },
   ].filter((link) => isValidUrl(link.url))
 
-  if (links.length === 0) return null
+  if (!source && links.length === 0) return null
 
   return (
     <div className="info-section">
-      <div className="external-links-grid">
-        {links.map((link) => (
-          <a
-            key={`${link.class}:${link.url}`}
-            href={link.url}
-            target="_blank"
-            rel={link.sponsored ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
-            className={`link-button ${link.class}`}
-          >
-            {link.label}
-          </a>
-        ))}
-      </div>
+      {source && (
+        <div aria-label="登録済み出典">
+          <div className="game-empty-note">登録済み出典</div>
+          <div className="external-links-grid">
+            <a
+              href={source.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link-button source"
+            >
+              {source.label}
+            </a>
+          </div>
+        </div>
+      )}
+
+      {links.length > 0 && (
+        <div aria-label="その他のリンク">
+          <div className="game-empty-note">その他のリンク</div>
+          <div className="external-links-grid">
+            {links.map((link) => (
+              <a
+                key={`${link.class}:${link.url}`}
+                href={link.url}
+                target="_blank"
+                rel={link.sponsored ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
+                className={`link-button ${link.class}`}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/tests/source_links.spec.js
+++ b/frontend/tests/source_links.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 'source-links-game',
+  slug: 'source-links-game',
+  title: 'Source Links Game',
+  title_ja: '出典リンクテスト',
+  min_players: 2,
+  max_players: 4,
+  play_time: 30,
+  min_age: 8,
+  published_year: 2025,
+  summary: '出典リンク表示のテスト用ゲーム。',
+  description: 'Source link test game',
+  rules_content: '# Rules',
+  source_url: 'https://publisher.example/rules',
+  source_trust: 'official_publisher',
+  content_review_status: 'review_required',
+  identity_status: 'verified',
+  bgg_url: 'https://boardgamegeek.com/boardgame/1/example',
+  bga_url: 'https://boardgamearena.com/gamepanel?game=example',
+  structured_data: {},
+}
+
+async function mockGameApi(page, value = game) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${value.slug}`) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game: value }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('registered source is separate from community and play links', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/source-links-game')
+
+  const sourceGroup = page.locator('[aria-label="登録済み出典"]')
+  const otherGroup = page.locator('[aria-label="その他のリンク"]')
+
+  await expect(sourceGroup.getByRole('link', { name: '出版社のページ' })).toHaveAttribute('href', game.source_url)
+  await expect(sourceGroup.getByRole('link', { name: 'BoardGameGeek' })).toHaveCount(0)
+  await expect(sourceGroup.getByRole('link', { name: 'Board Game Arena' })).toHaveCount(0)
+  await expect(otherGroup.getByRole('link', { name: 'BoardGameGeek' })).toHaveAttribute('href', game.bgg_url)
+  await expect(otherGroup.getByRole('link', { name: 'Board Game Arena' })).toHaveAttribute('href', game.bga_url)
+  await expect(page.getByText('REVIEW REQUIRED', { exact: true })).toBeVisible()
+})
+
+test('missing registered source does not create an empty source group', async ({ page }) => {
+  const withoutSource = { ...game, source_url: null, source_trust: 'unknown' }
+  await mockGameApi(page, withoutSource)
+  await page.goto('/games/source-links-game')
+
+  await expect(page.locator('[aria-label="登録済み出典"]')).toHaveCount(0)
+  await expect(page.locator('[aria-label="その他のリンク"]')).toBeVisible()
+})


### PR DESCRIPTION
## Summary
- separate the registered source from shopping/community/play links on GamePage
- use narrower source labels so a publisher URL does not imply that all displayed rules were publisher-reviewed
- keep `REVIEW REQUIRED` visible and add deterministic Playwright coverage for source present/missing states

## Evidence
- current production `/api/games/pili-pili` returns `source_url=https://atmgaming.com/product/pili-pili`, `source_trust=official_publisher`, and `content_review_status=review_required`, while its rules explicitly use the Board Game Arena implementation as the play/rule reference
- ATM Gaming is the publisher source; Board Game Arena separately identifies ATM Gaming as publisher and its own current Pili Pili implementation/release

## Scope
Frontend presentation only. No API/schema/data/storage/dependency changes.

Related: #192