### PR TITLE
Meet minimum target size for filter chip removal

### DIFF
--- a/frontend/src/uiux-accessibility.css
+++ b/frontend/src/uiux-accessibility.css
@@ -43,6 +43,14 @@
   font-weight: 700;
 }
 
+.filter-chip button {
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .asset-card-shell {
   position: relative;
   min-width: 0;

--- a/frontend/tests/uiux_a11y_regression.spec.js
+++ b/frontend/tests/uiux_a11y_regression.spec.js
@@ -79,7 +79,11 @@ test('directory keeps search local, labels controls, exposes mobile filters, and
     await filterPanel.getByRole('button', { name: '2人' }).click()
     await filterPanel.getByRole('button', { name: 'フィルターを閉じる' }).click()
     await expect(page.getByText('人数: 2')).toBeVisible()
-    await page.getByRole('button', { name: '人数フィルターを解除' }).click()
+    const removePlayerFilter = page.getByRole('button', { name: '人数フィルターを解除' })
+    const removeTarget = await removePlayerFilter.boundingBox()
+    expect(removeTarget?.width).toBeGreaterThanOrEqual(24)
+    expect(removeTarget?.height).toBeGreaterThanOrEqual(24)
+    await removePlayerFilter.click()
     await expect(page.getByText('ゲーム2', { exact: true }).first()).toBeVisible()
   }
 


### PR DESCRIPTION
## Finding
On the Directory results view, active-filter removal buttons are rendered as a bare × with no minimum dimensions. WCAG 2.2 Success Criterion 2.5.8 requires pointer targets to be at least 24 by 24 CSS pixels unless an exception applies. This change gives the removal control an explicit 24×24 minimum without changing filter behavior.

## Change
- give `.filter-chip button` a 24×24 CSS px minimum target
- keep the existing label and filter state logic unchanged
- extend the existing responsive accessibility Playwright test to assert the rendered removal target dimensions

## Verification
CI must pass at the exact PR head before merge. After merge, verify the deployed commit identity on Vercel. Automated checks do not constitute complete WCAG conformance testing.

Related: #211