### PR TITLE
Remove fabricated legacy confidence scores

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 
 IdentityStatus = Literal["unverified", "verified", "needs_review"]
 SourceTrust = Literal["unknown", "official_publisher", "authorized_partner", "third_party"]
@@ -79,13 +79,9 @@ class GameDetail(BaseSchema):
     description: str | None = None
     rules_content: str | None = None
     rules_summary: str | None = None
-    rules_confidence: float = 0.5
     setup_summary: str | None = None
-    setup_confidence: float = 0.5
     gameplay_summary: str | None = None
-    gameplay_confidence: float = 0.5
     end_game_summary: str | None = None
-    end_game_confidence: float = 0.5
     image_url: str | None = None
     summary: str | None = None
     structured_data: StructuredData | None = None
@@ -122,13 +118,9 @@ class GameUpdate(BaseSchema):
     description: str | None = None
     summary: str | None = None
     rules_summary: str | None = None
-    rules_confidence: float | None = Field(None, ge=0, le=1)
     setup_summary: str | None = None
-    setup_confidence: float | None = Field(None, ge=0, le=1)
     gameplay_summary: str | None = None
-    gameplay_confidence: float | None = Field(None, ge=0, le=1)
     end_game_summary: str | None = None
-    end_game_confidence: float | None = Field(None, ge=0, le=1)
     min_players: int | None = None
     max_players: int | None = None
     play_time: int | None = None

--- a/backend/tests/test_catalog_trust_contract.py
+++ b/backend/tests/test_catalog_trust_contract.py
@@ -30,6 +30,21 @@ def test_game_api_exposes_separate_trust_axes_without_legacy_official_fields():
     assert "official_url" not in GameDetail.model_fields
 
 
+def test_game_api_does_not_fabricate_legacy_confidence_scores():
+    game = GameDetail(id="game-1", slug="example", title="Example")
+    payload = game.model_dump()
+    legacy_confidence_fields = {
+        "rules_confidence",
+        "setup_confidence",
+        "gameplay_confidence",
+        "end_game_confidence",
+    }
+
+    assert legacy_confidence_fields.isdisjoint(payload)
+    assert legacy_confidence_fields.isdisjoint(GameDetail.model_fields)
+    assert legacy_confidence_fields.isdisjoint(GameUpdate.model_fields)
+
+
 def test_trust_enums_fail_closed_on_unknown_values():
     with pytest.raises(ValidationError):
         GameDetail(id="game-1", title="Example", source_trust="official")


### PR DESCRIPTION
## What changed
- remove `rules_confidence`, `setup_confidence`, `gameplay_confidence`, and `end_game_confidence` from `GameDetail`
- remove the same unsupported fields from `GameUpdate`
- add a regression test proving the API schema no longer fabricates those values
- remove the now-unused Pydantic `Field` import

## Verified evidence
- production `games` table has no columns for these four confidence values
- current production `/api/games/game` nevertheless returns all four as `0.5` because the Pydantic model supplies defaults
- existing canonical trust fields are `identity_status`, `source_trust`, and `content_review_status`; claim/evidence tables remain unchanged

Closes the concrete API-fabrication portion of #266 without adding a replacement score or database migration.