### PR TITLE
Hide empty preparation navigation

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -121,6 +121,9 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   )
   const hasRuleFlow = Boolean(ruleGuide?.flow?.length)
   const hasInfographics = hasRuleFlow || legacyInfographicsVerified
+  const hasCoachSummary = Boolean(
+    game.setup_summary || game.gameplay_summary || game.end_game_summary,
+  )
 
   const pageTitle = `「${title}」のルール${sd.strategy_analysis ? '・戦略' : ''}・インスト要約 | ボドゲのミカタ`
   const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
@@ -196,9 +199,11 @@ export default function GamePage({ slug: propSlug, initialGame }) {
             <button type="button" aria-pressed={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => setActiveTab('rules')}>
               詳しいルール
             </button>
-            <button type="button" aria-pressed={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>
-              準備・流れ・終了
-            </button>
+            {hasCoachSummary && (
+              <button type="button" aria-pressed={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>
+                準備・流れ・終了
+              </button>
+            )}
             <button type="button" aria-pressed={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>
               戦略
             </button>

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -180,7 +180,7 @@ test('game detail uses one native button group after quick rules', async ({ page
   await expect(page.getByRole('link', { name: /公式出典:/ })).toHaveCount(1)
 })
 
-test('preparation flow and end view shows only game-specific summaries and fails closed when missing', async ({ page }) => {
+test('preparation flow only appears when at least one game-specific summary exists', async ({ page }) => {
   await mockGameApi(page)
   await page.goto('/games/big-shot')
   await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
@@ -203,11 +203,25 @@ test('preparation flow and end view shows only game-specific summaries and fails
   await page.unrouteAll({ behavior: 'wait' })
   await mockGameApi(page, missing)
   await page.reload()
+
+  await expect(page.getByRole('button', { name: '準備・流れ・終了', exact: true })).toHaveCount(0)
+  await expect(page.getByText('このゲーム固有のセットアップ要約は未確認です。')).toHaveCount(0)
+  await expect(page.getByText('このゲーム固有のゲーム進行要約は未確認です。')).toHaveCount(0)
+  await expect(page.getByText('このゲーム固有の終了条件要約は未確認です。')).toHaveCount(0)
+
+  const partial = {
+    ...bigShot,
+    setup_summary: null,
+    gameplay_summary: null,
+  }
+  await page.unrouteAll({ behavior: 'wait' })
+  await mockGameApi(page, partial)
+  await page.reload()
   await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
 
   await expect(page.getByText('このゲーム固有のセットアップ要約は未確認です。')).toBeVisible()
   await expect(page.getByText('このゲーム固有のゲーム進行要約は未確認です。')).toBeVisible()
-  await expect(page.getByText('このゲーム固有の終了条件要約は未確認です。')).toBeVisible()
+  await expect(page.getByText(bigShot.end_game_summary)).toBeVisible()
 })
 
 test('empty strategy and review states do not suggest unavailable regeneration actions', async ({ page }) => {


### PR DESCRIPTION
## Finding
Production data for `azul` currently has `setup_summary`, `gameplay_summary`, and `end_game_summary` all null, while the GamePage always renders the `準備・流れ・終了` control. The resulting view contains only three unverified placeholders.

## Change
- show `準備・流れ・終了` only when at least one of the three game-specific summaries exists
- keep the existing per-field `未確認` fallback when only some summaries exist
- update the existing Playwright coverage for complete, empty, and partial summary states

This uses the existing fields and existing test file. No new schema, helper, data generation, dependency, or database write.

Related: #193, #158

## Production verification after merge
- confirm the deployed Git SHA matches the merge commit
- confirm `/games/azul` no longer presents the empty preparation-flow control
- confirm a game with summaries, e.g. `/games/skull-king`, still presents the control

## Rollback
Revert this PR; no data or schema migration is involved.