### PR TITLE
Keep the mixed game record out of search indexing

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -52,6 +52,7 @@ async def generate_seo_html(slug: str) -> str | None:
     game_url = f"{BASE_URL}/games/{slug}"
     page_title = _page_title(game, title)
     seo_description = description or f"「{title}」の登録済みルール要約と出典情報を確認できます。"
+    hide_from_search = slug == "game" and game.get("identity_status") != "verified"
 
     structured_data: dict[str, object] = {
         "@context": "https://schema.org",
@@ -120,6 +121,8 @@ async def generate_seo_html(slug: str) -> str | None:
         f"<title>{escaped_title}</title>",
     )
     html_content = _meta_tag(html_content, attr="name", key="description", content=seo_description)
+    if hide_from_search:
+        html_content = _meta_tag(html_content, attr="name", key="robots", content="noindex, follow")
     html_content = _meta_tag(html_content, attr="property", key="og:title", content=page_title)
     html_content = _meta_tag(html_content, attr="property", key="og:description", content=seo_description)
     html_content = _meta_tag(html_content, attr="property", key="og:url", content=game_url)

--- a/backend/app/services/sitemap.py
+++ b/backend/app/services/sitemap.py
@@ -32,7 +32,7 @@ async def get_sitemap_xml() -> str:
 
     for game in games:
         slug = str(game.get("slug") or "").strip()
-        if not slug:
+        if not slug or slug == "game":
             continue
 
         url_elem = ET.SubElement(root, f"{{{NS_SITEMAP}}}url")

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -89,3 +89,35 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert '<img src=x onerror=alert("summary")>' not in rendered
     assert '&lt;script&gt;alert(&quot;rules&quot;)&lt;/script&gt;' in rendered
     assert "\\u003cscript" in rendered
+
+
+@pytest.mark.asyncio
+async def test_known_mixed_game_record_is_noindex(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    async def game(_slug: str):
+        return {
+            "slug": "game",
+            "title": "ワインと毒とゴブレット",
+            "title_ja": "みんなでぽんこつペイント",
+            "identity_status": "unverified",
+            "summary": "mixed identity fixture",
+        }
+
+    template_dir = tmp_path / "frontend" / "dist"
+    template_dir.mkdir(parents=True)
+    (template_dir / "index.html").write_text(
+        '<html lang="ja"><head><meta name="robots" content="index, follow" /></head>'
+        '<body><div id="root"></div></body></html>',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(seo_renderer, "get_by_slug", game)
+    monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
+
+    rendered = await seo_renderer.generate_seo_html("game")
+
+    assert rendered is not None
+    assert '<meta name="robots" content="noindex, follow" />' in rendered
+    assert 'content="index, follow"' not in rendered

--- a/backend/tests/test_sitemap.py
+++ b/backend/tests/test_sitemap.py
@@ -62,3 +62,20 @@ async def test_invalid_game_slugs_are_not_emitted(monkeypatch: pytest.MonkeyPatc
     assert "https://example.test/games/valid-game" in xml_text
     assert "/games/None" not in xml_text
     assert "/games/  " not in xml_text
+
+
+@pytest.mark.asyncio
+async def test_known_mixed_game_record_is_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_list_for_sitemap() -> list[dict[str, str | None]]:
+        return [
+            {"slug": "game", "title": "Mixed", "updated_at": None, "image_url": None},
+            {"slug": "raise-your-goblets", "title": "Raise Your Goblets", "updated_at": None, "image_url": None},
+        ]
+
+    monkeypatch.setattr(sitemap, "list_for_sitemap", fake_list_for_sitemap)
+    monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
+
+    xml_text = await sitemap.get_sitemap_xml()
+
+    assert "https://example.test/games/game" not in xml_text
+    assert "https://example.test/games/raise-your-goblets" in xml_text


### PR DESCRIPTION
## Why

Production `/games/game` currently combines fields from two distinct games: `title=ワインと毒とゴブレット` while `title_ja=みんなでぽんこつペイント`, and the SSR page is currently `index, follow` and present in `sitemap.xml`.

The catalog already has a separate `/games/raise-your-goblets` record, so this PR does not guess how to repair or split the mixed record. It only prevents the known broken URL from being promoted to search engines while #256 remains open.

## Change

- emit `<meta name="robots" content="noindex, follow">` for the unverified `/games/game` SSR page
- exclude `/games/game` from the generated sitemap
- add focused regression tests for both behaviors
- leave every other game URL unchanged

## Evidence

- Existing Issue: #256
- Production `/games/game`: HTTP 200, currently `index, follow`
- Production sitemap currently includes `/games/game`
- Hobby Japan lists `ワインと毒とゴブレット` and `みんなでぽんこつペイント` as distinct products with different release dates, play times, and rules
- Google Search Central documents `noindex` for preventing page indexing and recommends putting in sitemaps the URLs intended to appear in Search

## Verification

CI must pass at the exact PR head before merge. After merge, verify the exact Vercel production SHA, raw `/games/game` robots meta, sitemap exclusion, and runtime errors.

## Cleanup

This is a narrow quarantine for the known broken URL. Remove the special-case exclusion when #256 repairs or removes the `game` record and production evidence confirms the page is internally consistent.