### PR TITLE
Keep the mixed Hack Clad record out of search indexing

### DIFF
--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,0 +1,7 @@
+# These records are known to mix fields from different game identities.
+# Keep them out of search indexing until the underlying records are repaired.
+EXCLUDED_GAME_SLUGS = frozenset({"game", "hack-clad"})
+
+
+def should_hide_game_from_search(slug: str) -> bool:
+    return slug in EXCLUDED_GAME_SLUGS

--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 from app.core.supabase import get_by_slug
+from app.services.search_visibility import should_hide_game_from_search
 
 logger = logging.getLogger(__name__)
 BASE_URL = "https://bodoge-no-mikata.vercel.app"
@@ -52,7 +53,7 @@ async def generate_seo_html(slug: str) -> str | None:
     game_url = f"{BASE_URL}/games/{slug}"
     page_title = _page_title(game, title)
     seo_description = description or f"「{title}」の登録済みルール要約と出典情報を確認できます。"
-    hide_from_search = slug == "game" and game.get("identity_status") != "verified"
+    hide_from_search = should_hide_game_from_search(slug)
 
     structured_data: dict[str, object] = {
         "@context": "https://schema.org",

--- a/backend/app/services/sitemap.py
+++ b/backend/app/services/sitemap.py
@@ -3,6 +3,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime
 
 from app.core.supabase import list_for_sitemap
+from app.services.search_visibility import should_hide_game_from_search
 
 NS_SITEMAP = "http://www.sitemaps.org/schemas/sitemap/0.9"
 NS_IMAGE = "http://www.google.com/schemas/sitemap-image/1.1"
@@ -32,7 +33,7 @@ async def get_sitemap_xml() -> str:
 
     for game in games:
         slug = str(game.get("slug") or "").strip()
-        if not slug or slug == "game":
+        if not slug or should_hide_game_from_search(slug):
             continue
 
         url_elem = ET.SubElement(root, f"{{{NS_SITEMAP}}}url")

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -91,16 +91,17 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert "\\u003cscript" in rendered
 
 
+@pytest.mark.parametrize("slug", ["game", "hack-clad"])
 @pytest.mark.asyncio
-async def test_known_mixed_game_record_is_noindex(
+async def test_known_mixed_game_records_are_noindex(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    slug: str,
 ) -> None:
     async def game(_slug: str):
         return {
-            "slug": "game",
-            "title": "ワインと毒とゴブレット",
-            "title_ja": "みんなでぽんこつペイント",
+            "slug": slug,
+            "title": "Mixed record",
             "identity_status": "unverified",
             "summary": "mixed identity fixture",
         }
@@ -116,7 +117,7 @@ async def test_known_mixed_game_record_is_noindex(
     monkeypatch.setattr(seo_renderer, "get_by_slug", game)
     monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
 
-    rendered = await seo_renderer.generate_seo_html("game")
+    rendered = await seo_renderer.generate_seo_html(slug)
 
     assert rendered is not None
     assert '<meta name="robots" content="noindex, follow" />' in rendered

--- a/backend/tests/test_sitemap.py
+++ b/backend/tests/test_sitemap.py
@@ -65,10 +65,12 @@ async def test_invalid_game_slugs_are_not_emitted(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.asyncio
-async def test_known_mixed_game_record_is_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_known_mixed_game_records_are_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_list_for_sitemap() -> list[dict[str, str | None]]:
         return [
             {"slug": "game", "title": "Mixed", "updated_at": None, "image_url": None},
+            {"slug": "hack-clad", "title": "Mixed Hack Clad", "updated_at": None, "image_url": None},
+            {"slug": "hackclad", "title": "HacKClaD", "updated_at": None, "image_url": None},
             {"slug": "raise-your-goblets", "title": "Raise Your Goblets", "updated_at": None, "image_url": None},
         ]
 
@@ -78,4 +80,6 @@ async def test_known_mixed_game_record_is_not_emitted(monkeypatch: pytest.Monkey
     xml_text = await sitemap.get_sitemap_xml()
 
     assert "https://example.test/games/game" not in xml_text
+    assert "https://example.test/games/hack-clad" not in xml_text
+    assert "https://example.test/games/hackclad" in xml_text
     assert "https://example.test/games/raise-your-goblets" in xml_text


### PR DESCRIPTION
## Summary
- reuse one search-visibility check for known mixed game records
- add `hack-clad` alongside the already isolated `game` record
- keep `hackclad` and `raise-your-goblets` indexable
- add SSR and sitemap regression coverage

## Evidence
Production currently has two `Hack Clad`/`HacKClaD`-named records. `hackclad` matches the official HacKClaD product: 1–4 players, 90–120 minutes, witches fighting Clad with future-sight/deck-building. `hack-clad` is unverified and has conflicting 2–4 player / 60 minute / 2023 metadata and unrelated rules/summary. This change is reversible and does not merge or delete either record.

Official HacKClaD references:
- https://www.hackclad.jp/
- https://www.hackclad.jp/game
- https://www.hackclad.jp/製品情報/1stシリーズorigin-world

Related: #256

## Verification
Exact-head CI must pass before merge. After deployment, verify `/games/hack-clad` has `noindex, follow`, `/games/hackclad` remains indexable, and sitemap contains only `hackclad` of the two.