### PR TITLE
Show play-time filter labels in active chips

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -383,7 +383,7 @@ function App() {
             </button>
             <span className="results-count">{filteredGames.length}件</span>
             {activePlayers && <div className="filter-chip">人数: {activePlayers} <button type="button" aria-label="人数フィルターを解除" onClick={() => setActivePlayers(null)}>×</button></div>}
-            {activeTime && <div className="filter-chip">時間: {activeTime} <button type="button" aria-label="時間フィルターを解除" onClick={() => setActiveTime(null)}>×</button></div>}
+            {activeTime && <div className="filter-chip">時間: {TIME_FILTERS.find((time) => time.id === activeTime)?.label || activeTime} <button type="button" aria-label="時間フィルターを解除" onClick={() => setActiveTime(null)}>×</button></div>}
             {activeTier && <div className="filter-chip">戦略ティア: {activeTier} <button type="button" aria-label="戦略ティアフィルターを解除" onClick={() => setActiveTier(null)}>×</button></div>}
           </div>
 

--- a/frontend/tests/navigation.spec.js
+++ b/frontend/tests/navigation.spec.js
@@ -217,6 +217,26 @@ test('player filters exclude games with unknown player bounds', async ({ page })
   await expect(page.getByText('人数未確認ゲーム', { exact: true })).toHaveCount(0)
 })
 
+test('play-time filter chip uses the visible label instead of the internal filter id', async ({ page }) => {
+  const games = [
+    { id: '1', slug: 'short', title_ja: '30分ゲーム', min_players: 2, max_players: 4, play_time: 30 },
+    { id: '2', slug: 'medium', title_ja: '45分ゲーム', min_players: 2, max_players: 4, play_time: 45 },
+  ]
+  await page.route('**/api/games?limit=20000&offset=0', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games, total: games.length }),
+    })
+  })
+
+  await page.goto('/')
+  await page.getByRole('button', { name: '30分以内', exact: true }).click()
+
+  await expect(page.locator('.filter-chip').filter({ hasText: '時間:' })).toContainText('時間: 30分以内')
+  await expect(page.getByText('時間: 30-', { exact: true })).toHaveCount(0)
+})
+
 test('comparison renders missing player count and duration as unknown', async ({ page }) => {
   const games = [
     { id: '1', slug: 'known', title_ja: '既知ゲーム', min_players: 2, max_players: 4, play_time: 30 },


### PR DESCRIPTION
Fixes the Directory presentation slice tracked in #197.

Current `TIME_FILTERS` already defines the user-facing labels (`30分以内`, `30-60分`, `60-120分`, `120分以上`), but the active filter chip rendered the internal IDs such as `30-` directly. This change reuses the existing label definition for the active chip and adds a Playwright regression in the existing navigation suite.

Scope:
- no filter semantics change
- no API/schema/data change
- no new helper, dependency, or test file
- keeps the existing internal filter IDs unchanged

Verification requested from existing CI: frontend build/lint/accessibility and `tests/navigation.spec.js`.