### PR TITLE
Return 503 for unavailable list reads

### DIFF
--- a/backend/app/routers/lists.py
+++ b/backend/app/routers/lists.py
@@ -109,7 +109,10 @@ async def get_owned_games(
     user: dict = Depends(get_current_user),
     service: ListService = Depends(get_list_service),
 ):
-    return await service.get_owned_collection(_owner_id(user))
+    try:
+        return await service.get_owned_collection(_owner_id(user))
+    except httpx.TransportError as exc:
+        raise _list_storage_unavailable() from exc
 
 
 @router.get("/owned-games/{game_id}")
@@ -118,7 +121,10 @@ async def get_owned_game_status(
     user: dict = Depends(get_current_user),
     service: ListService = Depends(get_list_service),
 ):
-    return await service.owned_status(_owner_id(user), str(game_id))
+    try:
+        return await service.owned_status(_owner_id(user), str(game_id))
+    except httpx.TransportError as exc:
+        raise _list_storage_unavailable() from exc
 
 
 @router.put("/owned-games/{game_id}")
@@ -152,6 +158,8 @@ async def get_user_list(
         return await service.get_list(_owner_id(user), str(list_id))
     except ListNotFoundError as exc:
         raise _not_found() from exc
+    except httpx.TransportError as exc:
+        raise _list_storage_unavailable() from exc
 
 
 @router.patch("/lists/{list_id}")

--- a/backend/tests/test_lists.py
+++ b/backend/tests/test_lists.py
@@ -81,17 +81,43 @@ def test_item_payloads_forbid_user_supplied_owner_id():
 
 
 @pytest.mark.asyncio
-async def test_list_index_returns_503_for_transport_failure():
-    class FailingListService:
-        async def list_lists(self, owner_id):
-            assert owner_id == USER_A["id"]
+async def test_list_reads_return_503_for_transport_failure():
+    class FailingReadListService:
+        @staticmethod
+        def _fail():
             raise httpx.RemoteProtocolError("Server disconnected")
 
-    with pytest.raises(lists.HTTPException) as exc:
-        await lists.list_user_lists(user=USER_A, service=FailingListService())
+        async def list_lists(self, owner_id):
+            assert owner_id == USER_A["id"]
+            self._fail()
 
-    assert exc.value.status_code == 503
-    assert exc.value.detail == "リストを一時的に取得できません。時間をおいて再試行してください。"
+        async def get_list(self, owner_id, list_id):
+            assert owner_id == USER_A["id"]
+            assert list_id == LIST_ID
+            self._fail()
+
+        async def get_owned_collection(self, owner_id):
+            assert owner_id == USER_A["id"]
+            self._fail()
+
+        async def owned_status(self, owner_id, game_id):
+            assert owner_id == USER_A["id"]
+            assert game_id == GAME_ID
+            self._fail()
+
+    service = FailingReadListService()
+    reads = (
+        lambda: lists.list_user_lists(user=USER_A, service=service),
+        lambda: lists.get_user_list(LIST_ID, user=USER_A, service=service),
+        lambda: lists.get_owned_games(user=USER_A, service=service),
+        lambda: lists.get_owned_game_status(GAME_ID, user=USER_A, service=service),
+    )
+
+    for read in reads:
+        with pytest.raises(lists.HTTPException) as exc:
+            await read()
+        assert exc.value.status_code == 503
+        assert exc.value.detail == "リストを一時的に取得できません。時間をおいて再試行してください。"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Addresses the production-observability slice in #91.

A previous fix classified transport failures only for `GET /api/lists`. The other authenticated list reads (`GET /api/lists/{id}`, `GET /api/owned-games`, `GET /api/owned-games/{game_id}`) used the same Supabase/PostgREST dependency but could still surface an exhausted network failure as an unclassified server error.

This change reuses the existing 503 response for all read-only list endpoints and expands the existing focused test. It does not add another retry loop; Supabase clients already own transient GET/HEAD retry behavior when supported by the installed version.

Scope:
- no write endpoint semantics change
- no schema/data/config/dependency change
- no new helper or test file
- no transport details exposed to clients