### PR TITLE
Mark Slide 01-2024 rules human-reviewed

### DIFF
--- a/data/curated-games/slide.json
+++ b/data/curated-games/slide.json
@@ -35,7 +35,7 @@
     "generated_from_source_revision": "gigamic-slide-rulebook-01-2024-attachment-548-accessed-2026-08-17",
     "source_trust": "official_publisher",
     "identity_status": "verified",
-    "content_review_status": "review_required"
+    "content_review_status": "human_reviewed"
   },
   "guide": {
     "reviewed": true,


### PR DESCRIPTION
Closes #207.

Slide's curated record already pins Gigamic's official `01-2024` rulebook (attachment 548), and its displayed rules/summaries match that revision for first-player setup/rotation, 16-round base-game end, orthogonal equal-card removal, tie-break, tournament `>= 100`, and tournament first-player changes. This PR changes only `content_review_status` from `review_required` to the existing model value `human_reviewed`.

The Gigamic product page's different starting-player wording remains excluded from the physical-game rules; the rulebook remains the pinned rule source.

No schema, dependency, runtime logic, or generated output changes.