### PR TITLE
Block normal mutation of known mixed game identities

### DIFF
--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -26,6 +26,7 @@ from app.services.evidence import EvidenceService
 from app.services.game_service import GameService, UnverifiedGameIdentityError
 from app.services.rule_graph import RuleGraphService
 from app.services.rulesets import RuleSetService
+from app.services.search_visibility import has_known_identity_conflict
 
 router = APIRouter()
 
@@ -234,7 +235,7 @@ async def get_game_claim_detail(
 ):
     result = await service.get_claim(slug, rule_set_id, claim_id)
     if result is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Claim not found")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     return result
 
 
@@ -268,6 +269,12 @@ async def update_game(
     editor: dict = Depends(require_catalog_editor),
     service: GameService = Depends(get_game_service),
 ) -> dict[str, object]:
+    if has_known_identity_conflict(slug):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Game identity conflict requires reviewed repair before mutation",
+        )
+
     try:
         if regenerate:
             if not gen_limiter.acquire():

--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,7 +1,12 @@
 # These records are known to mix fields from different game identities.
-# Keep them out of search indexing until the underlying records are repaired.
+# Keep them out of search indexing and block normal mutation until the
+# underlying records are repaired through an explicit reviewed workflow.
 EXCLUDED_GAME_SLUGS = frozenset({"game", "hack-clad"})
 
 
-def should_hide_game_from_search(slug: str) -> bool:
+def has_known_identity_conflict(slug: str) -> bool:
     return slug in EXCLUDED_GAME_SLUGS
+
+
+def should_hide_game_from_search(slug: str) -> bool:
+    return has_known_identity_conflict(slug)

--- a/backend/tests/test_game_identity_conflict_guard.py
+++ b/backend/tests/test_game_identity_conflict_guard.py
@@ -1,0 +1,29 @@
+import pytest
+from fastapi import HTTPException
+
+from app.routers.games import update_game
+
+
+class _MutationMustNotRun:
+    async def update_game_content(self, *_args, **_kwargs):
+        pytest.fail("known identity conflicts must be rejected before regeneration")
+
+    async def update_game_manual(self, *_args, **_kwargs):
+        pytest.fail("known identity conflicts must be rejected before manual update")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slug", ["game", "hack-clad"])
+async def test_known_identity_conflict_blocks_regeneration(slug: str) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await update_game(
+            slug=slug,
+            game_update=None,
+            regenerate=True,
+            fill_missing_only=False,
+            editor={"id": "editor"},
+            service=_MutationMustNotRun(),
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == "Game identity conflict requires reviewed repair before mutation"

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -103,7 +103,7 @@ def test_authorized_regeneration_reports_unverified_identity_conflict():
     }
     client = TestClient(app)
 
-    response = client.patch("/api/games/game?regenerate=true")
+    response = client.patch("/api/games/unverified-game?regenerate=true")
 
     assert response.status_code == 409
     assert response.json() == {"detail": "Game identity must be verified before content regeneration"}


### PR DESCRIPTION
Closes part of #256 by making the existing known mixed-identity quarantine fail closed at the catalog PATCH boundary.

What changes:
- reuse the existing `game` / `hack-clad` conflict set instead of creating another registry;
- reject normal PATCH/regeneration for those records with HTTP 409 before any mutation runs;
- preserve the same conflict set for SEO/sitemap exclusion;
- add a regression test proving regeneration is never reached for either known mixed record.

This intentionally does not auto-split, merge, or overwrite production data. The field-level repair and catalog-wide coherence validator in #256 remain separate reviewed work because the current mixed records contain evidence from multiple works.

Primary identity evidence for the `game` fixture remains the two distinct Hobby Japan products documented in #256:
- https://hobbyjapan.games/wine_poison_and_goblets/
- https://hobbyjapan.games/ponkotsu_paint/

Production data repair remains UNVERIFIED/not performed by this PR.