### PR TITLE
Record source-backed evidence for mixed game identity

### DIFF
--- a/backend/tests/test_identity_conflict_evidence.py
+++ b/backend/tests/test_identity_conflict_evidence.py
@@ -1,0 +1,43 @@
+import json
+from pathlib import Path
+
+from app.services.search_visibility import EXCLUDED_GAME_SLUGS
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT = ROOT / "data" / "identity-conflicts" / "game.json"
+
+
+def test_game_identity_conflict_report_is_source_backed_and_quarantined() -> None:
+    data = json.loads(REPORT.read_text(encoding="utf-8"))
+
+    assert data["slug"] == "game"
+    assert data["slug"] in EXCLUDED_GAME_SLUGS
+    assert data["decision"]["status"] == "identity_conflict"
+    assert data["decision"]["normal_mutation_allowed"] is False
+    assert data["decision"]["indexable"] is False
+    assert data["decision"]["destructive_auto_merge_allowed"] is False
+
+    works = data["canonical_works"]
+    assert [work["title_ja"] for work in works] == [
+        "ワインと毒とゴブレット",
+        "みんなでぽんこつペイント",
+    ]
+    assert len({work["source_url"] for work in works}) == 2
+    assert all(work["source_url"].startswith("https://hobbyjapan.games/") for work in works)
+
+    assigned_fields = {
+        field
+        for work in works
+        for field in work["field_assignment"]
+    }
+    assert {"title", "description", "rules_content"} <= assigned_fields
+    assert {"title_ja", "title_en", "summary", "structured_data.keywords"} <= assigned_fields
+
+    assert set(data["unresolved_fields"]) == {
+        "min_players",
+        "max_players",
+        "play_time",
+        "published_year",
+        "source_url",
+    }

--- a/data/identity-conflicts/game.json
+++ b/data/identity-conflicts/game.json
@@ -1,0 +1,67 @@
+{
+  "slug": "game",
+  "issue": "https://github.com/KAFKA2306/rule-scribe-games/issues/256",
+  "production_snapshot": {
+    "observed_at": "2026-08-15",
+    "fields": {
+      "title": "ワインと毒とゴブレット",
+      "title_ja": "みんなでぽんこつペイント",
+      "title_en": "Minna de Ponkotsu Paint",
+      "source_url": "https://hobbyjapan.games/raise_your_goblets/",
+      "min_players": 2,
+      "max_players": 6,
+      "play_time": 15,
+      "published_year": 2020
+    }
+  },
+  "canonical_works": [
+    {
+      "title_ja": "ワインと毒とゴブレット",
+      "title_original": "Raise Your Goblets",
+      "source_url": "https://hobbyjapan.games/wine_poison_and_goblets/",
+      "verified_facts": {
+        "min_players": 2,
+        "max_players": 12,
+        "play_time_minutes": 30,
+        "min_age": 8,
+        "release": "2016-10"
+      },
+      "field_assignment": [
+        "title",
+        "description",
+        "rules_content"
+      ]
+    },
+    {
+      "title_ja": "みんなでぽんこつペイント",
+      "source_url": "https://hobbyjapan.games/ponkotsu_paint/",
+      "verified_facts": {
+        "min_players": 2,
+        "max_players": 12,
+        "play_time_minutes": 10,
+        "min_age": 6,
+        "release": "2018-09"
+      },
+      "field_assignment": [
+        "title_ja",
+        "title_en",
+        "summary",
+        "structured_data.keywords"
+      ]
+    }
+  ],
+  "unresolved_fields": [
+    "min_players",
+    "max_players",
+    "play_time",
+    "published_year",
+    "source_url"
+  ],
+  "decision": {
+    "status": "identity_conflict",
+    "normal_mutation_allowed": false,
+    "indexable": false,
+    "destructive_auto_merge_allowed": false,
+    "repair": "reviewed split or merge into separately verified canonical works"
+  }
+}


### PR DESCRIPTION
## Summary

Advances #256 without mutating production data.

- saves a field-level contamination report for the quarantined `game` record
- separates fields attributable to `ワインと毒とゴブレット` from fields attributable to `みんなでぽんこつペイント`
- leaves player/time/year/source metadata unresolved instead of guessing
- records the reviewed-repair requirement and existing fail-closed state
- adds a regression test tying the report to the existing search/mutation quarantine

## Primary sources

- https://hobbyjapan.games/wine_poison_and_goblets/
- https://hobbyjapan.games/ponkotsu_paint/

## Before -> After

Before: #256 described the contamination in the Issue, but there was no versioned field-level report in the repository.

After: `data/identity-conflicts/game.json` persists the observed mixed record, two distinct official source-backed works, field assignments, unresolved fields, and repair constraints. No production row is changed.

## Safety

This PR does not split, merge, overwrite, or delete production records. Unresolved metadata remains unresolved. The existing `game` quarantine remains the runtime authority.

Closes no issue; #256 still requires reviewed canonical split/merge and catalog-wide detection.