### PR TITLE
Add source-backed Ipso curated game

### DIFF
--- a/data/curated-games/ipso.json
+++ b/data/curated-games/ipso.json
@@ -1,0 +1,170 @@
+{
+  "schema_version": "1",
+  "slug": "ipso",
+  "work": {
+    "canonical_title": "Ipso",
+    "identity_status": "verified"
+  },
+  "source": {
+    "url": "https://en.gigamic.com/index.php?controller=attachment&id_attachment=668",
+    "rule_version": "gigamic-ipso-10-2025",
+    "revision": "gigamic-ipso-rulebook-10-2025-attachment-668-accessed-2026-08-20"
+  },
+  "game": {
+    "slug": "ipso",
+    "title": "Ipso",
+    "title_en": "Ipso",
+    "description": "数字カードを4段のピラミッドに並べ、中央の2枚と交換しながら昇順の列を作って得点するカードゲーム。",
+    "summary": "各プレイヤーは14枚の数字カードで5・4・3・2枚の4段ピラミッドを作り、頂点にスターカードを置きます。手番では中央の表向き2枚から1枚を選び、自分の裏向きカード1枚と交換。全員のカードが表向きになったらスターカードを3点として残すか、捨てて最後の1回だけ改善します。昇順の列だけが得点になり、合計点が最も高い人が勝ちます。",
+    "rules_content": "# Ipso\n\n## 目的\n昇順の数字が並ぶ列を作り、ゲーム終了時に最も高い得点を取ります。\n\n## 準備\n数字カードをシャッフルし、各プレイヤーに14枚ずつ裏向きで配ります。14枚を使って、下から5枚・4枚・3枚・2枚の4段ピラミッドを作ります。頂点にはスターカード1枚を置きます。残りの数字カードを山札にし、上から2枚を表向きにして中央へ置きます。最年少のプレイヤーから時計回りに開始します。\n\n## 手番\n中央の表向き2枚から1枚を選び、自分のピラミッドにある裏向きカード1枚と交換します。交換で取り除いたカードを表向きにして中央へ置きます。追加済みの表向きカードは交換できず、交換対象は裏向きカードだけです。その後、左隣のプレイヤーへ手番が移ります。\n\n## 最終ラウンド\n全員のピラミッドがすべて表向きになったら、中央の2枚を山札の下へ戻します。各プレイヤーは次のどちらかを選びます。スターカードを残してゲーム終了時に3点を得るか、スターカードを捨てて最後の1手番を行います。最後の1手番を選んだ場合は山札の一番上を引き、ピラミッド内の表向きカード1枚と交換してよいです。引いたカードを使わない場合は捨てます。どちらの場合でも、最後の1手番を選んだ時点でスターカードは失います。全員がこの最終手番を終えるとゲーム終了です。\n\n## 得点\n昇順になっていない列は得点になりません。昇順の列が複数色ならカード1枚につき1点、同じ色だけならカード1枚につき2点です。有効な列に含まれるスター印1つにつき1点を加えます。頂点のスターカードを残した場合はさらに3点です。合計点が最も高いプレイヤーが勝ちます。同点なら数字カード上のスター印が多いプレイヤーが勝ち、それも同じならもう一度プレイします。\n\n## バリアント\n奇数・偶数列バリアントでは、通常得点に加えて、列の数字がすべて奇数またはすべて偶数なら、その列のカード1枚につき1点を追加します。トーナメントでは4ゲーム行い、ゲームごとに進行方向を変更し、4ゲームの合計点で勝者を決めます。",
+    "setup_summary": "各プレイヤーに数字カード14枚を配り、5・4・3・2枚の4段ピラミッドを裏向きで作ります。頂点にスターカードを置き、残りを山札にして上から2枚を中央へ表向きに置きます。",
+    "gameplay_summary": "手番では中央の表向き2枚から1枚を選び、自分の裏向きカード1枚と交換します。交換したカードを中央へ表向きで置き、全員のピラミッドが表向きになるまで時計回りに続けます。",
+    "end_game_summary": "全カード公開後、スターカードを3点として残すか、捨てて最後の1回だけ表向きカードを改善します。昇順の列だけを得点し、複数色は1点/枚、単色は2点/枚、有効列のスター印は1点ずつ、頂点のスターカードを残せばさらに3点。最高得点が勝利です。",
+    "min_players": 2,
+    "max_players": 6,
+    "play_time": 15,
+    "min_age": 7,
+    "edition_label": "Gigamic English rulebook 10-2025",
+    "language_code": "ja",
+    "publisher": "Gigamic",
+    "official_url": "https://en.gigamic.com/family-games/1417-ipso.html",
+    "source_url": "https://en.gigamic.com/index.php?controller=attachment&id_attachment=668",
+    "source_revision": "gigamic-ipso-rulebook-10-2025-attachment-668-accessed-2026-08-20",
+    "generated_from_source_revision": "gigamic-ipso-rulebook-10-2025-attachment-668-accessed-2026-08-20",
+    "source_trust": "official_publisher",
+    "identity_status": "verified"
+  },
+  "guide": {
+    "reviewed": true,
+    "ruleVersion": "gigamic-ipso-10-2025",
+    "source": {
+      "label": "Gigamic official Ipso rulebook",
+      "url": "https://en.gigamic.com/index.php?controller=attachment&id_attachment=668",
+      "ruleVersion": "gigamic-ipso-10-2025"
+    },
+    "facts": {
+      "numberCards": 90,
+      "starCards": 6,
+      "cardsPerPlayer": 14,
+      "pyramidRows": 4,
+      "centerCards": 2,
+      "keptStarBonus": 3,
+      "mixedColorPointsPerCard": 1,
+      "singleColorPointsPerCard": 2,
+      "starSymbolPoints": 1,
+      "tournamentGames": 4
+    },
+    "quick": {
+      "win": "昇順の列から得点し、合計点を最も高くする。",
+      "actions": [
+        "中央の表向き2枚から1枚を選ぶ。",
+        "自分の裏向きカード1枚と交換する。",
+        "交換で取り除いたカードを中央へ表向きで置く。"
+      ],
+      "turnSteps": [
+        "中央の表向き2枚から1枚を選ぶ。",
+        "自分のピラミッドの裏向きカード1枚と交換する。",
+        "交換したカードを中央へ表向きで置き、次のプレイヤーへ渡す。"
+      ],
+      "turnEndChecks": [
+        "交換対象が裏向きカードであることを確認する。",
+        "追加済みの表向きカードを再交換していないことを確認する。"
+      ],
+      "end": "全員のピラミッドが表向きになったらスターカードを残すか最後の1回の改善に使い、全員の最終手番後に得点する。"
+    },
+    "scoring": {
+      "summary": "昇順の列だけが得点になり、複数色は1点/枚、単色は2点/枚。有効な列のスター印は1点ずつ、頂点のスターカードを残すと3点加算する。",
+      "rules": [
+        {
+          "label": "昇順列",
+          "detail": "昇順になっていない列は得点しない。"
+        },
+        {
+          "label": "複数色",
+          "detail": "昇順の列が複数色ならカード1枚につき1点。"
+        },
+        {
+          "label": "単色",
+          "detail": "昇順の列が同じ色だけならカード1枚につき2点。"
+        },
+        {
+          "label": "スター",
+          "detail": "有効な列のスター印1つにつき1点。頂点のスターカードを残した場合はさらに3点。"
+        },
+        {
+          "label": "同点",
+          "detail": "同点なら数字カード上のスター印が多いプレイヤーが勝つ。それも同じなら再戦する。"
+        }
+      ]
+    },
+    "flow": [
+      {
+        "id": "choose-center",
+        "kind": "step",
+        "label": "中央の表向き2枚から1枚を選ぶ"
+      },
+      {
+        "id": "replace-facedown",
+        "kind": "step",
+        "label": "裏向きカード1枚と交換し、取り除いたカードを中央へ置く"
+      },
+      {
+        "id": "repeat",
+        "kind": "check",
+        "label": "全員のピラミッドが表向きになるまで時計回りに続ける"
+      },
+      {
+        "id": "star-choice",
+        "kind": "step",
+        "label": "スターカードを3点として残すか、捨てて最後の1回の改善を行う"
+      },
+      {
+        "id": "score",
+        "kind": "end",
+        "label": "昇順の列とスターから得点し、最高得点を決める"
+      }
+    ]
+  },
+  "assertions": [
+    {
+      "path": "facts.cardsPerPlayer",
+      "equals": 14
+    },
+    {
+      "path": "facts.pyramidRows",
+      "equals": 4
+    },
+    {
+      "path": "facts.centerCards",
+      "equals": 2
+    },
+    {
+      "path": "facts.keptStarBonus",
+      "equals": 3
+    },
+    {
+      "path": "facts.tournamentGames",
+      "equals": 4
+    },
+    {
+      "path": "quick.turnSteps",
+      "contains": "裏向きカード1枚"
+    },
+    {
+      "path": "quick.end",
+      "contains": "スターカード"
+    },
+    {
+      "path": "scoring.rules",
+      "contains": "複数色"
+    },
+    {
+      "path": "scoring.rules",
+      "contains": "単色"
+    },
+    {
+      "path": "scoring.rules",
+      "contains": "スター印"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Advances #213 by adding `data/curated-games/ipso.json` from Gigamic's current official Ipso product page and English rulebook.

Primary sources:
- https://en.gigamic.com/family-games/1417-ipso.html
- https://en.gigamic.com/index.php?controller=attachment&id_attachment=668

The rulebook is marked `10-2025`. The curated data keeps the current 2–6 players / 15 min / age 7+ product metadata, 14-card 5/4/3/2 pyramid setup, two-card center exchange, Star-card final choice, ascending-row scoring, tie break, odd/even-row variant, and 4-game tournament mode source-bound to that rulebook.

No production data is written from this PR. No dependency, schema, workflow, or game-specific importer is added.

Closes #213 only after exact-head CI and the existing main-only publication path are verified.