### PR TITLE
Restore mixed game identities as separate canonical games

### DIFF
--- a/data/curated-games/minna-de-ponkotsu-paint.json
+++ b/data/curated-games/minna-de-ponkotsu-paint.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "1",
+  "slug": "minna-de-ponkotsu-paint",
+  "work": {
+    "canonical_title": "みんなでぽんこつペイント",
+    "identity_status": "verified"
+  },
+  "source": {
+    "url": "https://hobbyjapan.games/ponkotsu_paint/",
+    "rule_version": "hobbyjapan-product-page-2018",
+    "revision": "hobbyjapan-ponkotsu-paint-accessed-2026-08-20"
+  },
+  "game": {
+    "slug": "minna-de-ponkotsu-paint",
+    "title": "みんなでぽんこつペイント",
+    "title_en": "Minna de Ponkotsu Paint",
+    "description": "お題を直線と正円だけで描き、少ない画数の人から回答者へ見せて当ててもらうお絵描きゲーム。",
+    "summary": "サイコロで決めたお題を直線と正円だけで表現します。全員が描き終わったら画数が少ない人から順に回答者へ見せ、少ない画数で早く見せるか、多く描いて分かりやすくするかを競います。",
+    "rules_content": "# みんなでぽんこつペイント\n\n## 目的\nサイコロで決めたお題を直線と正円だけで描き、回答者に当ててもらいます。\n\n## 描画\n各プレイヤーはお題を表す絵を、直線と正円だけを使って描きます。\n\n## 回答\n全員が描き終えたら、画数が少ない人から順に回答者へ絵を見せます。画数を増やせば伝わりやすくなる可能性がありますが、見せる順番は遅くなります。少ない画数なら早く見せられますが、伝わりにくくなる可能性があります。\n\n## 追加ルール\nホビージャパンの現行商品ページでは、7人まで遊べるチーム戦「ぽんこつ紅白チーム戦」と、2人用協力戦「ぽんこつデュエット」が追加ルールとして案内されています。",
+    "setup_summary": "サイコロでお題を決め、各プレイヤーが描画できるようにお絵かきボードとマーカーを用意します。",
+    "gameplay_summary": "直線と正円だけでお題を描き、全員が描き終わったら画数が少ない人から順に回答者へ見せます。",
+    "end_game_summary": "回答者にお題を当ててもらうことを目指し、画数の少なさと伝わりやすさのバランスを競います。",
+    "min_players": 2,
+    "max_players": 12,
+    "play_time": 10,
+    "min_age": 6,
+    "published_year": 2018,
+    "publisher": "ホビージャパン",
+    "official_url": "https://hobbyjapan.games/ponkotsu_paint/",
+    "source_url": "https://hobbyjapan.games/ponkotsu_paint/",
+    "source_revision": "hobbyjapan-ponkotsu-paint-accessed-2026-08-20",
+    "generated_from_source_revision": "hobbyjapan-ponkotsu-paint-accessed-2026-08-20",
+    "source_trust": "official_publisher",
+    "identity_status": "verified"
+  },
+  "guide": {
+    "reviewed": true,
+    "ruleVersion": "hobbyjapan-product-page-2018",
+    "source": {
+      "label": "ホビージャパン公式商品ページ",
+      "url": "https://hobbyjapan.games/ponkotsu_paint/",
+      "ruleVersion": "hobbyjapan-product-page-2018"
+    },
+    "facts": {
+      "playersMin": 2,
+      "playersMax": 12,
+      "playTimeMinutes": 10,
+      "minimumAge": 6,
+      "releaseYear": 2018,
+      "teamVariantMaxPlayers": 7,
+      "duetPlayers": 2
+    },
+    "quick": {
+      "win": "直線と正円だけでお題を表現し、回答者に当ててもらう。",
+      "actions": ["サイコロで決めたお題を確認する。", "直線と正円だけで絵を描く。", "画数が少ない人から順に回答者へ見せる。"],
+      "turnSteps": ["お題を直線と正円だけで描く。", "全員の描画完了後、画数を比較する。", "少ない画数の人から順に回答者へ見せる。"],
+      "turnEndChecks": ["直線と正円以外を使っていないか確認する。"],
+      "end": "回答者がお題を推測し、少ない画数と伝わりやすさの駆け引きを楽しむ。"
+    },
+    "scoring": {
+      "summary": "現行商品ページは、少ない画数ほど先に回答者へ見せられるという順序ルールを説明している。",
+      "rules": [
+        {"label": "表示順", "detail": "描いた絵の画数が少ない人から順に回答者へ見せる。"}
+      ]
+    },
+    "flow": [
+      {"id": "prompt", "kind": "step", "label": "サイコロでお題を決める"},
+      {"id": "draw", "kind": "step", "label": "直線と正円だけでお題を描く"},
+      {"id": "order", "kind": "step", "label": "画数が少ない人から順に回答者へ見せる"},
+      {"id": "guess", "kind": "end", "label": "回答者がお題を推測する"}
+    ]
+  },
+  "assertions": [
+    {"path": "facts.playersMax", "equals": 12},
+    {"path": "facts.playTimeMinutes", "equals": 10},
+    {"path": "quick.actions", "contains": "直線と正円"}
+  ]
+}

--- a/data/curated-games/wine-poison-and-goblets.json
+++ b/data/curated-games/wine-poison-and-goblets.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "1",
+  "slug": "wine-poison-and-goblets",
+  "work": {
+    "canonical_title": "ワインと毒とゴブレット",
+    "identity_status": "verified"
+  },
+  "source": {
+    "url": "https://hobbyjapan.games/wine_poison_and_goblets/",
+    "rule_version": "hobbyjapan-product-page-2016",
+    "revision": "hobbyjapan-wine-poison-and-goblets-accessed-2026-08-20"
+  },
+  "game": {
+    "slug": "wine-poison-and-goblets",
+    "title": "ワインと毒とゴブレット",
+    "title_en": "Raise Your Goblets",
+    "description": "ゴブレットにワイン、毒、解毒薬を入れ、覗き、交換しながら標的を倒して自分は生き延びるブラフゲーム。",
+    "summary": "各プレイヤーは名家の一員となり、キャラクター能力を使いながらゴブレットへワイン・毒・解毒薬を入れたり、内容を確認したり、他人のゴブレットと交換したりします。乾杯後に生存、標的の殺害、ワイン量などで勝利点を得て、3ラウンドの合計点を競います。",
+    "rules_content": "# ワインと毒とゴブレット\n\n## 目的\n標的となる相手へ毒入りワインを飲ませつつ自分は生き延び、3ラウンドを通じて最も多くの勝利点を得ます。\n\n## ゲームの進行\nキャラクター能力を利用しながら、自分の前のゴブレットへワイン・毒・必要に応じて解毒薬を入れます。ゴブレットの中を確認したり、他プレイヤーの前のゴブレットと交換したりできます。乾杯後、自分の前のゴブレットを飲み、ラウンドを解決します。\n\n## 得点と終了\n公式商品説明では、自分が生き延びた場合、標的の殺害に成功した場合、飲んだゴブレット内のワイン量が最も多い場合に勝利点を得ます。これを3ラウンド行い、合計勝利点が最も多いプレイヤーが勝者です。",
+    "setup_summary": "各プレイヤーは名家のキャラクターを担当し、ゴブレットやワイン・毒・解毒薬を使ってラウンドを進めます。",
+    "gameplay_summary": "ゴブレットへワイン・毒・解毒薬を入れる、内容を確認する、他人のゴブレットと交換するといった行動を行い、乾杯後に結果を解決します。",
+    "end_game_summary": "各ラウンドで生存、標的の殺害、ワイン量などにより勝利点を得ます。3ラウンド終了時の合計勝利点が最多のプレイヤーが勝ちます。",
+    "min_players": 2,
+    "max_players": 12,
+    "play_time": 30,
+    "min_age": 8,
+    "published_year": 2016,
+    "publisher": "ホビージャパン",
+    "official_url": "https://hobbyjapan.games/wine_poison_and_goblets/",
+    "source_url": "https://hobbyjapan.games/wine_poison_and_goblets/",
+    "source_revision": "hobbyjapan-wine-poison-and-goblets-accessed-2026-08-20",
+    "generated_from_source_revision": "hobbyjapan-wine-poison-and-goblets-accessed-2026-08-20",
+    "source_trust": "official_publisher",
+    "identity_status": "verified"
+  },
+  "guide": {
+    "reviewed": true,
+    "ruleVersion": "hobbyjapan-product-page-2016",
+    "source": {
+      "label": "ホビージャパン公式商品ページ",
+      "url": "https://hobbyjapan.games/wine_poison_and_goblets/",
+      "ruleVersion": "hobbyjapan-product-page-2016"
+    },
+    "facts": {
+      "rounds": 3,
+      "playersMin": 2,
+      "playersMax": 12,
+      "playTimeMinutes": 30,
+      "minimumAge": 8,
+      "releaseYear": 2016
+    },
+    "quick": {
+      "win": "3ラウンドの合計勝利点を最も多くする。",
+      "actions": ["ゴブレットへワイン・毒・解毒薬を入れる。", "ゴブレットの内容を確認する。", "他プレイヤーのゴブレットと交換する。"],
+      "turnSteps": ["キャラクター能力を使いながらゴブレットを操作する。", "乾杯後に自分の前のゴブレットを飲む。", "生存・標的殺害・ワイン量に応じて得点を処理する。"],
+      "turnEndChecks": ["ラウンドの得点処理を完了したか確認する。"],
+      "end": "3ラウンド終了後、合計勝利点が最も多いプレイヤーが勝つ。"
+    },
+    "scoring": {
+      "summary": "公式商品説明では、生存、標的の殺害、飲んだゴブレット内のワイン量が最多の場合に勝利点を得る。",
+      "rules": [
+        {"label": "生存", "detail": "自分が生き延びた場合に勝利点を得る。"},
+        {"label": "標的", "detail": "標的の殺害に成功した場合に勝利点を得る。"},
+        {"label": "ワイン量", "detail": "飲んだゴブレット内のワイン量が最も多い場合に勝利点を得る。"}
+      ]
+    },
+    "flow": [
+      {"id": "manipulate", "kind": "step", "label": "ゴブレットへワイン・毒・解毒薬を入れ、確認・交換する"},
+      {"id": "toast", "kind": "step", "label": "乾杯して自分の前のゴブレットを飲む"},
+      {"id": "score", "kind": "step", "label": "生存・標的殺害・ワイン量に応じて得点する"},
+      {"id": "finish", "kind": "end", "label": "3ラウンド後に合計勝利点で勝者を決める"}
+    ]
+  },
+  "assertions": [
+    {"path": "facts.rounds", "equals": 3},
+    {"path": "facts.playersMax", "equals": 12},
+    {"path": "quick.end", "contains": "3ラウンド"}
+  ]
+}


### PR DESCRIPTION
Advances #256 by restoring the two source-backed works that were previously mixed into `slug=game` as separate curated canonical games.

Primary sources:
- https://hobbyjapan.games/wine_poison_and_goblets/
- https://hobbyjapan.games/ponkotsu_paint/

Before: one quarantined mixed record contained fields from both works.
After: each work has an independent source-backed curated spec with distinct slug, title, rules summary, player/time/age/release metadata, and official source.

This does not mutate, merge, or delete the quarantined `game` row. Existing quarantine remains fail-closed until a reviewed tombstone/redirect decision is implemented.