### PR TITLE
Restore curated write validation and republish Raise Your Goblets

### DIFF
--- a/backend/app/scripts/curated_game_workflow.py
+++ b/backend/app/scripts/curated_game_workflow.py
@@ -308,7 +308,10 @@ def write_catalog(spec: CuratedGameSpec) -> dict[str, Any]:
 
     if not rows:
         raise WorkflowError("catalog write returned no game row")
-    return rows[0]
+    row = rows[0]
+    if row.get("slug") != spec.slug:
+        raise WorkflowError("catalog write returned unexpected slug")
+    return row
 
 
 def verify_production(spec: CuratedGameSpec, base_url: str) -> None:

--- a/data/curated-games/raise-your-goblets.json
+++ b/data/curated-games/raise-your-goblets.json
@@ -25,7 +25,7 @@
     "play_time": 30,
     "min_age": 8,
     "published_year": 2016,
-    "publisher": "ホビージャパン",
+    "publisher": "Horrible Games",
     "official_url": "https://hobbyjapan.games/wine_poison_and_goblets/",
     "source_url": "https://hobbyjapan.games/wine_poison_and_goblets/",
     "source_revision": "hobbyjapan-wine-poison-and-goblets-accessed-2026-08-20",


### PR DESCRIPTION
## Summary

Follow-up to #347 / #256 after post-merge read-back.

- restores the catalog write fixed-point check so an unexpected returned slug fails closed
- corrects `publisher` for `Raise Your Goblets` to `Horrible Games`, matching the official Hobby Japan page (`版元 Horrible Games`, `販売 ホビージャパン`)
- the curated spec change also gives the main publish workflow a direct changed spec to republish the existing `raise-your-goblets` production row

No duplicate work is created and the quarantined generic `game` record remains untouched.

Refs #256