### PR TITLE
Retire contaminated generic game record from public reads

### DIFF
--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -26,7 +26,7 @@ from app.services.evidence import EvidenceService
 from app.services.game_service import GameService, UnverifiedGameIdentityError
 from app.services.rule_graph import RuleGraphService
 from app.services.rulesets import RuleSetService
-from app.services.search_visibility import has_known_identity_conflict
+from app.services.search_visibility import has_known_identity_conflict, should_return_gone
 
 router = APIRouter()
 
@@ -254,6 +254,8 @@ async def get_game_rule_graph(
 
 @router.get("/games/{slug}", response_model=GameDetail)
 async def get_game_details(slug: str, service: GameService = Depends(get_game_service)):
+    if should_return_gone(slug):
+        raise HTTPException(status_code=status.HTTP_410_GONE, detail="Game record retired after identity repair")
     game = await service.get_game_by_slug(slug)
     if not game:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")

--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -3,9 +3,18 @@
 # underlying records are repaired through an explicit reviewed workflow.
 EXCLUDED_GAME_SLUGS = frozenset({"game", "hack-clad"})
 
+# `game` mixed two different games and has no single correct canonical target.
+# Its two source-backed works now exist separately, so public reads must not
+# continue serving the contaminated historical row.
+GONE_GAME_SLUGS = frozenset({"game"})
+
 
 def has_known_identity_conflict(slug: str) -> bool:
     return slug in EXCLUDED_GAME_SLUGS
+
+
+def should_return_gone(slug: str) -> bool:
+    return slug in GONE_GAME_SLUGS
 
 
 def should_hide_game_from_search(slug: str) -> bool:

--- a/backend/tests/test_game_identity_conflict_guard.py
+++ b/backend/tests/test_game_identity_conflict_guard.py
@@ -1,7 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
-from app.routers.games import update_game
+from app.routers.games import get_game_details, update_game
 
 
 class _MutationMustNotRun:
@@ -10,6 +10,11 @@ class _MutationMustNotRun:
 
     async def update_game_manual(self, *_args, **_kwargs):
         pytest.fail("known identity conflicts must be rejected before manual update")
+
+
+class _ReadMustNotRun:
+    async def get_game_by_slug(self, *_args, **_kwargs):
+        pytest.fail("retired mixed identity must be rejected before database read")
 
 
 @pytest.mark.asyncio
@@ -27,3 +32,12 @@ async def test_known_identity_conflict_blocks_regeneration(slug: str) -> None:
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == "Game identity conflict requires reviewed repair before mutation"
+
+
+@pytest.mark.asyncio
+async def test_repaired_mixed_game_slug_is_gone() -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        await get_game_details(slug="game", service=_ReadMustNotRun())
+
+    assert exc_info.value.status_code == 410
+    assert exc_info.value.detail == "Game record retired after identity repair"


### PR DESCRIPTION
Closes part of #256.

The historical `game` row mixes two distinct games. Both source-backed games now exist as separate canonical records, and there is no single correct redirect target for the generic slug. This change therefore returns HTTP 410 for `GET /api/games/game` before the database row is read, while preserving the existing search exclusion and mutation guard.

Changes:
- mark only `game` as a retired public-read slug
- return 410 Gone for the detail API instead of serving mixed fields
- keep `hack-clad` quarantined but not retired
- add a regression test proving the mixed row is rejected before DB read

No schema, dependency, or workflow changes.