### PR TITLE
Stop retired mixed game from SSR

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from fastapi.responses import HTMLResponse
 from app.core.logger import setup_logging
 from app.middleware.validation import ValidationMiddleware
 from app.routers import auth, games, lists, mechanical_dna, presentation, vrchat
+from app.services.search_visibility import should_return_gone
 from app.services.seo_renderer import generate_seo_html
 from app.services.sitemap import get_sitemap_xml
 
@@ -90,6 +91,8 @@ def game_not_found_html() -> str:
 @app.get("/games/{slug}", response_class=HTMLResponse)
 async def game_seo_page(slug: str):
     """Serve a crawlable game page with game-specific metadata and a real 404 boundary."""
+    if should_return_gone(slug):
+        return HTMLResponse(content=game_not_found_html(), status_code=410)
     content = await generate_seo_html(slug)
     if content is None:
         return HTMLResponse(content=game_not_found_html(), status_code=404)

--- a/backend/tests/test_game_identity_conflict_guard.py
+++ b/backend/tests/test_game_identity_conflict_guard.py
@@ -1,6 +1,7 @@
 import pytest
 from fastapi import HTTPException
 
+from app.main import game_seo_page
 from app.routers.games import get_game_details, update_game
 
 
@@ -41,3 +42,16 @@ async def test_repaired_mixed_game_slug_is_gone() -> None:
 
     assert exc_info.value.status_code == 410
     assert exc_info.value.detail == "Game record retired after identity repair"
+
+
+@pytest.mark.asyncio
+async def test_repaired_mixed_game_slug_is_not_rendered_in_ssr(monkeypatch) -> None:
+    async def _render_must_not_run(_slug: str):
+        pytest.fail("retired mixed identity must be rejected before SSR data read")
+
+    monkeypatch.setattr("app.main.generate_seo_html", _render_must_not_run)
+
+    response = await game_seo_page("game")
+
+    assert response.status_code == 410
+    assert "ゲームが見つかりません" in response.body.decode("utf-8")


### PR DESCRIPTION
Fixes the remaining public-read leak in #256.

Production evidence on the current #349 deployment shows `/api/games/game` correctly returns 410, but `/games/game` still returns HTTP 200 and server-renders the contaminated historical record. This reuses the existing `should_return_gone()` authority before SEO rendering so the retired slug cannot reach the database-backed SSR path.

Changes:
- apply the existing retired-slug guard to `/games/{slug}`;
- return the existing noindex/nofollow not-found HTML with HTTP 410;
- add a regression test proving SEO rendering is not called for the retired `game` slug.

No schema, dependency, workflow, or production-data changes.