### PR TITLE
Add canonical title/work coherence audit

### DIFF
--- a/backend/app/services/identity_coherence.py
+++ b/backend/app/services/identity_coherence.py
@@ -1,0 +1,73 @@
+import re
+import unicodedata
+from collections import defaultdict
+from typing import Any
+
+_TITLE_FIELDS = ("title", "title_ja", "title_en")
+
+
+def _normalize_title(value: str | None) -> str:
+    normalized = unicodedata.normalize("NFKC", value or "").casefold().strip()
+    return re.sub(r"[^\w]+", "", normalized, flags=re.UNICODE)
+
+
+def audit_title_work_coherence(
+    games: list[dict[str, Any]],
+    aliases: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Report title fields that resolve only to a different canonical work.
+
+    The audit is intentionally fail-closed: titles with no explicit alias binding are
+    reported as review_required instead of being guessed into a work.
+    """
+    game_work_by_id = {
+        str(game.get("id")): str(game.get("work_id"))
+        for game in games
+        if game.get("id") and game.get("work_id")
+    }
+
+    works_by_title: dict[str, set[str]] = defaultdict(set)
+    for alias in aliases:
+        game_id = str(alias.get("game_id") or "")
+        normalized = _normalize_title(str(alias.get("title") or ""))
+        work_id = game_work_by_id.get(game_id)
+        if normalized and work_id:
+            works_by_title[normalized].add(work_id)
+
+    findings: list[dict[str, Any]] = []
+    for game in games:
+        game_id = str(game.get("id") or "")
+        work_id = str(game.get("work_id") or "")
+        if not game_id or not work_id:
+            continue
+
+        for field in _TITLE_FIELDS:
+            raw_value = game.get(field)
+            if not raw_value:
+                continue
+            normalized = _normalize_title(str(raw_value))
+            bound_works = works_by_title.get(normalized, set())
+            if work_id in bound_works:
+                continue
+
+            if bound_works:
+                status = "identity_conflict"
+                reason = "title_bound_to_different_work"
+            else:
+                status = "review_required"
+                reason = "title_has_no_verified_alias_binding"
+
+            findings.append(
+                {
+                    "game_id": game_id,
+                    "slug": game.get("slug"),
+                    "work_id": work_id,
+                    "field": field,
+                    "value": raw_value,
+                    "status": status,
+                    "reason": reason,
+                    "bound_work_ids": sorted(bound_works),
+                }
+            )
+
+    return findings

--- a/backend/tests/test_identity_coherence.py
+++ b/backend/tests/test_identity_coherence.py
@@ -1,0 +1,90 @@
+from app.services.identity_coherence import audit_title_work_coherence
+
+
+def test_same_work_verified_aliases_are_coherent() -> None:
+    games = [
+        {
+            "id": "game-1",
+            "slug": "sample",
+            "work_id": "work-1",
+            "title": "Sample Game",
+            "title_ja": "サンプルゲーム",
+        }
+    ]
+    aliases = [
+        {"game_id": "game-1", "title": "Sample Game"},
+        {"game_id": "game-1", "title": "サンプルゲーム"},
+    ]
+
+    assert audit_title_work_coherence(games, aliases) == []
+
+
+def test_title_bound_to_another_work_is_identity_conflict() -> None:
+    games = [
+        {
+            "id": "game-1",
+            "slug": "first",
+            "work_id": "work-1",
+            "title": "First Game",
+            "title_ja": "別のゲーム",
+        },
+        {
+            "id": "game-2",
+            "slug": "second",
+            "work_id": "work-2",
+            "title": "別のゲーム",
+        },
+    ]
+    aliases = [
+        {"game_id": "game-1", "title": "First Game"},
+        {"game_id": "game-2", "title": "別のゲーム"},
+    ]
+
+    findings = audit_title_work_coherence(games, aliases)
+
+    assert findings == [
+        {
+            "game_id": "game-1",
+            "slug": "first",
+            "work_id": "work-1",
+            "field": "title_ja",
+            "value": "別のゲーム",
+            "status": "identity_conflict",
+            "reason": "title_bound_to_different_work",
+            "bound_work_ids": ["work-2"],
+        }
+    ]
+
+
+def test_unknown_title_requires_review_instead_of_guessing() -> None:
+    games = [
+        {
+            "id": "game-1",
+            "slug": "sample",
+            "work_id": "work-1",
+            "title": "Sample Game",
+            "title_en": "Unreviewed Alias",
+        }
+    ]
+    aliases = [{"game_id": "game-1", "title": "Sample Game"}]
+
+    findings = audit_title_work_coherence(games, aliases)
+
+    assert findings[0]["field"] == "title_en"
+    assert findings[0]["status"] == "review_required"
+    assert findings[0]["reason"] == "title_has_no_verified_alias_binding"
+    assert findings[0]["bound_work_ids"] == []
+
+
+def test_nfkc_and_casefold_match_verified_alias() -> None:
+    games = [
+        {
+            "id": "game-1",
+            "slug": "sample",
+            "work_id": "work-1",
+            "title": "ＳＡＭＰＬＥ　ＧＡＭＥ",
+        }
+    ]
+    aliases = [{"game_id": "game-1", "title": "sample game"}]
+
+    assert audit_title_work_coherence(games, aliases) == []


### PR DESCRIPTION
## Summary
- add a reusable catalog audit that checks `title`, `title_ja`, and `title_en` against explicit title-alias bindings
- report a title bound only to another work as `identity_conflict`
- report an unbound title as `review_required` instead of guessing
- keep the audit side-effect free; no production writes or destructive merge/split behavior

## Tests
- same-work Japanese/English aliases are accepted
- cross-work title contamination is reported
- unknown alias is fail-closed as review-required
- NFKC/casefold normalization is covered

## Issue
Advances #256 catalog-wide identity coherence work without adding a new schema, dependency, or game-specific exception.