### PR TITLE
Detect title aliases bound to multiple works

### DIFF
--- a/backend/app/services/identity_coherence.py
+++ b/backend/app/services/identity_coherence.py
@@ -15,10 +15,11 @@ def audit_title_work_coherence(
     games: list[dict[str, Any]],
     aliases: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
-    """Report title fields that resolve only to a different canonical work.
+    """Report title fields whose explicit alias bindings do not identify one work.
 
-    The audit is intentionally fail-closed: titles with no explicit alias binding are
-    reported as review_required instead of being guessed into a work.
+    The audit is intentionally fail-closed: titles with no explicit alias binding or
+    bindings to multiple works are reported as review_required instead of being
+    guessed into a work.
     """
     game_work_by_id = {
         str(game.get("id")): str(game.get("work_id"))
@@ -47,10 +48,14 @@ def audit_title_work_coherence(
                 continue
             normalized = _normalize_title(str(raw_value))
             bound_works = works_by_title.get(normalized, set())
-            if work_id in bound_works:
+
+            if bound_works == {work_id}:
                 continue
 
-            if bound_works:
+            if work_id in bound_works and len(bound_works) > 1:
+                status = "review_required"
+                reason = "title_alias_bound_to_multiple_works"
+            elif bound_works:
                 status = "identity_conflict"
                 reason = "title_bound_to_different_work"
             else:

--- a/backend/tests/test_identity_coherence_ambiguous_alias.py
+++ b/backend/tests/test_identity_coherence_ambiguous_alias.py
@@ -1,0 +1,47 @@
+from app.services.identity_coherence import audit_title_work_coherence
+
+
+def test_title_alias_bound_to_multiple_works_requires_review() -> None:
+    games = [
+        {
+            "id": "game-1",
+            "slug": "first",
+            "work_id": "work-1",
+            "title": "Shared Title",
+        },
+        {
+            "id": "game-2",
+            "slug": "second",
+            "work_id": "work-2",
+            "title": "Shared Title",
+        },
+    ]
+    aliases = [
+        {"game_id": "game-1", "title": "Shared Title"},
+        {"game_id": "game-2", "title": "Shared Title"},
+    ]
+
+    findings = audit_title_work_coherence(games, aliases)
+
+    assert findings == [
+        {
+            "game_id": "game-1",
+            "slug": "first",
+            "work_id": "work-1",
+            "field": "title",
+            "value": "Shared Title",
+            "status": "review_required",
+            "reason": "title_alias_bound_to_multiple_works",
+            "bound_work_ids": ["work-1", "work-2"],
+        },
+        {
+            "game_id": "game-2",
+            "slug": "second",
+            "work_id": "work-2",
+            "field": "title",
+            "value": "Shared Title",
+            "status": "review_required",
+            "reason": "title_alias_bound_to_multiple_works",
+            "bound_work_ids": ["work-1", "work-2"],
+        },
+    ]


### PR DESCRIPTION
## Why

Issue #256 requires a catalog-wide identity coherence audit before the same logic can safely guard writes. The audit added in #351 treated a title as coherent whenever its alias set included the current work, even if the same normalized title was also explicitly bound to another work. Production data contains this case, including the retired mixed `game` record and `raise-your-goblets`.

## Change

- accept a title only when its explicit alias binding resolves to exactly the current work
- classify an alias bound to the current work and one or more other works as `review_required`
- keep the existing `identity_conflict` behavior when the title resolves only to another work
- keep unknown aliases fail-closed as `review_required`
- add a regression test for an alias shared across two works

No schema, dependency, workflow, database write, merge, or automatic identity repair is introduced.

## Observed catalog evidence

Read-only audit of the active games database found 8 normalized titles bound to more than one work across 6 slug pairs. This PR fixes the false-negative before the audit is used at the mutation boundary.

Related: #256