### PR TITLE
Block manual title updates that cross canonical works

### DIFF
--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -4,11 +4,14 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+import anyio
+
 from app.core import supabase
 from app.core.gemini import GeminiClient
 from app.core.llm_manager import LLMKeyRotator
 from app.models import GeneratedGameMetadata
 from app.prompts.prompts import PROMPTS
+from app.services.identity_coherence import audit_title_work_coherence
 from app.services.rule_quality import RULE_PROMPT_VERSION, RULE_QUALITY_GOLDEN_VERSION
 from app.utils.affiliate import amazon_search_url
 from app.utils.slugify import slugify
@@ -48,10 +51,15 @@ _ALLOWED_FIELDS = {
     "updated_at",
 }
 _RULE_DERIVED_FIELDS = ("rules_content", "min_players", "max_players", "play_time", "min_age", "bga_url")
+_TITLE_FIELDS = ("title", "title_ja", "title_en")
 
 
 class UnverifiedGameIdentityError(ValueError):
     """Raised when generation would use an unverified game identity as input."""
+
+
+class GameIdentityConflictError(UnverifiedGameIdentityError):
+    """Raised when a mutation cannot be tied to one verified canonical work."""
 
 
 def _load_prompt(key: str) -> str:
@@ -59,6 +67,47 @@ def _load_prompt(key: str) -> str:
     for part in key.split("."):
         data = data[part]
     return str(data).strip()
+
+
+async def _load_identity_coherence_context() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if supabase.is_local():
+        raise GameIdentityConflictError("Title identity changes require verified alias bindings")
+
+    def _q() -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        client = supabase._get_client()
+        games = client.table("games").select("id,slug,work_id,title,title_ja,title_en").execute().data
+        aliases = client.table("game_title_aliases").select("game_id,title").execute().data
+        return games, aliases
+
+    return await anyio.to_thread.run_sync(_q)
+
+
+async def _validate_manual_title_update(
+    game: dict[str, Any],
+    merged: dict[str, Any],
+    safe_updates: dict[str, Any],
+) -> None:
+    changed_fields = {
+        field for field in _TITLE_FIELDS if field in safe_updates and safe_updates[field] != game.get(field)
+    }
+    if not changed_fields:
+        return
+
+    games, aliases = await _load_identity_coherence_context()
+    game_id = str(game.get("id") or "")
+    candidate = {key: merged.get(key) for key in ("id", "slug", "work_id", *_TITLE_FIELDS)}
+    catalog = [candidate if str(row.get("id") or "") == game_id else row for row in games]
+    if not any(str(row.get("id") or "") == game_id for row in games):
+        catalog.append(candidate)
+
+    findings = [
+        finding
+        for finding in audit_title_work_coherence(catalog, aliases)
+        if str(finding.get("game_id") or "") == game_id and finding.get("field") in changed_fields
+    ]
+    if findings:
+        reasons = ", ".join(sorted({str(finding["reason"]) for finding in findings}))
+        raise GameIdentityConflictError(f"Manual title update requires reviewed identity evidence: {reasons}")
 
 
 async def generate_metadata(query: str, context: str | None = None, source_bound: bool = False) -> dict[str, Any]:
@@ -254,6 +303,7 @@ class GameService:
         protected = {"id", "slug", "work_id", "identity_status"}
         safe_updates = {key: value for key, value in updates.items() if key not in protected}
         merged = {**game, **safe_updates}
+        await _validate_manual_title_update(game, merged, safe_updates)
         merged["updated_at"] = datetime.now(UTC).isoformat()
         out = await supabase.upsert(merged)
         if not out:

--- a/backend/tests/test_manual_title_work_coherence.py
+++ b/backend/tests/test_manual_title_work_coherence.py
@@ -1,0 +1,109 @@
+import pytest
+
+from app.services import game_service
+from app.services.game_service import GameIdentityConflictError, GameService
+
+
+@pytest.fixture
+def existing_game() -> dict[str, object]:
+    return {
+        "id": "game-1",
+        "slug": "first-game",
+        "work_id": "work-1",
+        "identity_status": "verified",
+        "title": "First Game",
+        "title_ja": "ファーストゲーム",
+        "title_en": "First Game",
+        "summary": "old summary",
+    }
+
+
+@pytest.mark.asyncio
+async def test_manual_title_update_rejects_title_bound_to_another_work(monkeypatch, existing_game) -> None:
+    writes: list[dict[str, object]] = []
+
+    async def _get_by_slug(_slug: str):
+        return dict(existing_game)
+
+    async def _upsert(payload):
+        writes.append(payload)
+        return [payload]
+
+    async def _context():
+        games = [
+            dict(existing_game),
+            {
+                "id": "game-2",
+                "slug": "second-game",
+                "work_id": "work-2",
+                "title": "Second Game",
+            },
+        ]
+        aliases = [
+            {"game_id": "game-1", "title": "First Game"},
+            {"game_id": "game-1", "title": "ファーストゲーム"},
+            {"game_id": "game-2", "title": "Second Game"},
+        ]
+        return games, aliases
+
+    monkeypatch.setattr(game_service.supabase, "get_by_slug", _get_by_slug)
+    monkeypatch.setattr(game_service.supabase, "upsert", _upsert)
+    monkeypatch.setattr(game_service, "_load_identity_coherence_context", _context)
+
+    service = GameService.__new__(GameService)
+    with pytest.raises(GameIdentityConflictError, match="title_bound_to_different_work"):
+        await service.update_game_manual("first-game", {"title_en": "Second Game"})
+
+    assert writes == []
+
+
+@pytest.mark.asyncio
+async def test_manual_title_update_accepts_verified_alias_for_same_work(monkeypatch, existing_game) -> None:
+    writes: list[dict[str, object]] = []
+
+    async def _get_by_slug(_slug: str):
+        return dict(existing_game)
+
+    async def _upsert(payload):
+        writes.append(payload)
+        return [payload]
+
+    async def _context():
+        games = [dict(existing_game)]
+        aliases = [
+            {"game_id": "game-1", "title": "First Game"},
+            {"game_id": "game-1", "title": "ファーストゲーム"},
+            {"game_id": "game-1", "title": "First Game Revised"},
+        ]
+        return games, aliases
+
+    monkeypatch.setattr(game_service.supabase, "get_by_slug", _get_by_slug)
+    monkeypatch.setattr(game_service.supabase, "upsert", _upsert)
+    monkeypatch.setattr(game_service, "_load_identity_coherence_context", _context)
+
+    service = GameService.__new__(GameService)
+    result = await service.update_game_manual("first-game", {"title_en": "First Game Revised"})
+
+    assert result["title_en"] == "First Game Revised"
+    assert len(writes) == 1
+
+
+@pytest.mark.asyncio
+async def test_non_title_manual_update_does_not_require_identity_context(monkeypatch, existing_game) -> None:
+    async def _get_by_slug(_slug: str):
+        return dict(existing_game)
+
+    async def _upsert(payload):
+        return [payload]
+
+    async def _context_must_not_run():
+        pytest.fail("non-title updates must not load title identity context")
+
+    monkeypatch.setattr(game_service.supabase, "get_by_slug", _get_by_slug)
+    monkeypatch.setattr(game_service.supabase, "upsert", _upsert)
+    monkeypatch.setattr(game_service, "_load_identity_coherence_context", _context_must_not_run)
+
+    service = GameService.__new__(GameService)
+    result = await service.update_game_manual("first-game", {"summary": "new summary"})
+
+    assert result["summary"] == "new summary"


### PR DESCRIPTION
Closes part of #256.

## Change
- reuse `audit_title_work_coherence()` before manual writes that change `title`, `title_ja`, or `title_en`
- require the candidate title to resolve to exactly the existing `work_id` through verified `game_title_aliases`
- reject cross-work, ambiguous, and unbound title changes before `upsert`
- leave non-title manual updates on the existing path

## Tests
- cross-work title update is rejected and performs no write
- same-work verified alias is accepted
- non-title update does not load identity context

No schema, dependency, workflow, or production-data changes.