### PR TITLE
Block regeneration from incoherent game identity

### DIFF
--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -82,6 +82,24 @@ async def _load_identity_coherence_context() -> tuple[list[dict[str, Any]], list
     return await anyio.to_thread.run_sync(_q)
 
 
+async def _validate_current_title_identity(game: dict[str, Any]) -> None:
+    games, aliases = await _load_identity_coherence_context()
+    game_id = str(game.get("id") or "")
+    candidate = {key: game.get(key) for key in ("id", "slug", "work_id", *_TITLE_FIELDS)}
+    catalog = [candidate if str(row.get("id") or "") == game_id else row for row in games]
+    if not any(str(row.get("id") or "") == game_id for row in games):
+        catalog.append(candidate)
+
+    findings = [
+        finding
+        for finding in audit_title_work_coherence(catalog, aliases)
+        if str(finding.get("game_id") or "") == game_id
+    ]
+    if findings:
+        reasons = ", ".join(sorted({str(finding["reason"]) for finding in findings}))
+        raise GameIdentityConflictError(f"Content regeneration requires reviewed identity evidence: {reasons}")
+
+
 async def _validate_manual_title_update(
     game: dict[str, Any],
     merged: dict[str, Any],
@@ -272,6 +290,7 @@ class GameService:
             raise ValueError(f"Game not found for slug: {slug}")
         if game.get("identity_status") != "verified":
             raise UnverifiedGameIdentityError("Game identity must be verified before content regeneration")
+        await _validate_current_title_identity(game)
 
         title = game.get("title")
         summary = game.get("summary")

--- a/backend/tests/test_regeneration_title_work_coherence.py
+++ b/backend/tests/test_regeneration_title_work_coherence.py
@@ -1,0 +1,95 @@
+import pytest
+
+from app.services import game_service
+from app.services.game_service import GameIdentityConflictError, GameService
+
+
+@pytest.fixture
+def verified_game() -> dict[str, object]:
+    return {
+        "id": "game-1",
+        "slug": "first-game",
+        "work_id": "work-1",
+        "identity_status": "verified",
+        "title": "First Game",
+        "title_ja": "ファーストゲーム",
+        "title_en": "First Game",
+        "summary": "old summary",
+        "data_version": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_regeneration_rejects_existing_cross_work_title_before_generation(monkeypatch, verified_game) -> None:
+    writes: list[dict[str, object]] = []
+
+    async def _get_by_slug(_slug: str):
+        return dict(verified_game)
+
+    async def _upsert(payload):
+        writes.append(payload)
+        return [payload]
+
+    async def _context():
+        games = [
+            dict(verified_game),
+            {
+                "id": "game-2",
+                "slug": "second-game",
+                "work_id": "work-2",
+                "title": "First Game",
+            },
+        ]
+        aliases = [
+            {"game_id": "game-1", "title": "First Game"},
+            {"game_id": "game-1", "title": "ファーストゲーム"},
+            {"game_id": "game-2", "title": "First Game"},
+        ]
+        return games, aliases
+
+    async def _generate_must_not_run(*_args, **_kwargs):
+        pytest.fail("incoherent title identity must be rejected before generation")
+
+    monkeypatch.setattr(game_service.supabase, "get_by_slug", _get_by_slug)
+    monkeypatch.setattr(game_service.supabase, "upsert", _upsert)
+    monkeypatch.setattr(game_service, "_load_identity_coherence_context", _context)
+    monkeypatch.setattr(game_service, "generate_metadata", _generate_must_not_run)
+
+    service = GameService.__new__(GameService)
+    with pytest.raises(GameIdentityConflictError, match="title_alias_bound_to_multiple_works"):
+        await service.update_game_content("first-game")
+
+    assert writes == []
+
+
+@pytest.mark.asyncio
+async def test_regeneration_accepts_titles_bound_only_to_current_work(monkeypatch, verified_game) -> None:
+    writes: list[dict[str, object]] = []
+
+    async def _get_by_slug(_slug: str):
+        return dict(verified_game)
+
+    async def _upsert(payload):
+        writes.append(payload)
+        return [payload]
+
+    async def _context():
+        return [dict(verified_game)], [
+            {"game_id": "game-1", "title": "First Game"},
+            {"game_id": "game-1", "title": "ファーストゲーム"},
+        ]
+
+    async def _generate(_query: str, _context: str):
+        return {"summary": "new summary"}
+
+    monkeypatch.setattr(game_service.supabase, "get_by_slug", _get_by_slug)
+    monkeypatch.setattr(game_service.supabase, "upsert", _upsert)
+    monkeypatch.setattr(game_service, "_load_identity_coherence_context", _context)
+    monkeypatch.setattr(game_service, "generate_metadata", _generate)
+
+    service = GameService.__new__(GameService)
+    result = await service.update_game_content("first-game")
+
+    assert result["summary"] == "new summary"
+    assert result["data_version"] == 2
+    assert len(writes) == 1


### PR DESCRIPTION
## Summary

- reuse the existing catalog title/work coherence audit before `update_game_content()` builds generation context
- fail closed before model generation or DB write when current title fields are unbound, cross-work, or multi-work ambiguous
- add regression coverage for an already-verified record whose title alias is shared across canonical works, plus the coherent success path

## Why

Issue #256 still requires `update_game_content()` not to reuse a contaminated identity as generation truth. `identity_status=verified` alone does not establish that the current title fields still resolve to one work.

## Scope

No schema, dependency, workflow, source-trust, or production-data change. This reuses `audit_title_work_coherence()` and the existing alias context loader.

Closes part of #256.