### PR TITLE
Block source URLs bound to another game work

### DIFF
--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -82,6 +82,72 @@ async def _load_identity_coherence_context() -> tuple[list[dict[str, Any]], list
     return await anyio.to_thread.run_sync(_q)
 
 
+async def _load_source_work_bindings(source_url: str) -> set[str]:
+    if supabase.is_local():
+        raise GameIdentityConflictError("Source URL changes require canonical evidence bindings")
+
+    def _q() -> set[str]:
+        client = supabase._get_client()
+        source_rows = client.table("evidence_sources").select("source_id").eq("url", source_url).execute().data
+        source_ids = sorted({str(row.get("source_id") or "") for row in source_rows if row.get("source_id")})
+        if not source_ids:
+            return set()
+
+        binding_rows = (
+            client.table("evidence_bindings")
+            .select("claim_id")
+            .in_("source_id", source_ids)
+            .eq("relation", "supports")
+            .execute()
+            .data
+        )
+        claim_ids = sorted({str(row.get("claim_id") or "") for row in binding_rows if row.get("claim_id")})
+        if not claim_ids:
+            return set()
+
+        claim_rows = (
+            client.table("claims")
+            .select("claim_id,rule_set_id")
+            .in_("claim_id", claim_ids)
+            .eq("lifecycle_status", "accepted")
+            .execute()
+            .data
+        )
+        rule_set_ids = sorted({str(row.get("rule_set_id") or "") for row in claim_rows if row.get("rule_set_id")})
+        if not rule_set_ids:
+            return set()
+
+        rule_set_rows = client.table("rule_sets").select("id,game_id").in_("id", rule_set_ids).execute().data
+        game_ids = sorted({str(row.get("game_id") or "") for row in rule_set_rows if row.get("game_id")})
+        if not game_ids:
+            return set()
+
+        game_rows = client.table("games").select("id,work_id").in_("id", game_ids).execute().data
+        return {str(row.get("work_id") or "") for row in game_rows if row.get("work_id")}
+
+    return await anyio.to_thread.run_sync(_q)
+
+
+async def _validate_manual_source_update(game: dict[str, Any], safe_updates: dict[str, Any]) -> None:
+    if "source_url" not in safe_updates or safe_updates["source_url"] == game.get("source_url"):
+        return
+
+    source_url = str(safe_updates.get("source_url") or "").strip()
+    if not source_url:
+        return
+
+    work_id = str(game.get("work_id") or "")
+    source_work_ids = await _load_source_work_bindings(source_url)
+    if source_work_ids != {work_id}:
+        if not source_work_ids:
+            reason = "source_unbound"
+        elif work_id not in source_work_ids:
+            reason = "source_bound_to_another_work"
+        else:
+            reason = "source_bound_to_multiple_works"
+        raise GameIdentityConflictError(f"Manual source URL update requires reviewed evidence binding: {reason}")
+
+
 async def _validate_current_title_identity(game: dict[str, Any]) -> None:
     games, aliases = await _load_identity_coherence_context()
     game_id = str(game.get("id") or "")
@@ -323,6 +389,7 @@ class GameService:
         safe_updates = {key: value for key, value in updates.items() if key not in protected}
         merged = {**game, **safe_updates}
         await _validate_manual_title_update(game, merged, safe_updates)
+        await _validate_manual_source_update(game, safe_updates)
         merged["updated_at"] = datetime.now(UTC).isoformat()
         out = await supabase.upsert(merged)
         if not out:

--- a/backend/tests/test_game_source_identity.py
+++ b/backend/tests/test_game_source_identity.py
@@ -1,0 +1,54 @@
+import pytest
+
+from app.services.game_service import (
+    GameIdentityConflictError,
+    _validate_manual_source_update,
+)
+
+
+@pytest.mark.asyncio
+async def test_source_url_bound_only_to_current_work_is_accepted(monkeypatch) -> None:
+    async def _bindings(_url: str) -> set[str]:
+        return {"work-a"}
+
+    monkeypatch.setattr("app.services.game_service._load_source_work_bindings", _bindings)
+
+    await _validate_manual_source_update(
+        {"work_id": "work-a", "source_url": "https://example.com/old"},
+        {"source_url": "https://example.com/new"},
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("bindings", "reason"),
+    [
+        (set(), "source_unbound"),
+        ({"work-b"}, "source_bound_to_another_work"),
+        ({"work-a", "work-b"}, "source_bound_to_multiple_works"),
+    ],
+)
+async def test_source_url_without_unique_current_work_binding_is_rejected(monkeypatch, bindings, reason) -> None:
+    async def _bindings(_url: str) -> set[str]:
+        return bindings
+
+    monkeypatch.setattr("app.services.game_service._load_source_work_bindings", _bindings)
+
+    with pytest.raises(GameIdentityConflictError, match=reason):
+        await _validate_manual_source_update(
+            {"work_id": "work-a", "source_url": "https://example.com/old"},
+            {"source_url": "https://example.com/new"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_unchanged_source_url_does_not_load_evidence(monkeypatch) -> None:
+    async def _must_not_run(_url: str) -> set[str]:
+        pytest.fail("unchanged source_url must not query evidence bindings")
+
+    monkeypatch.setattr("app.services.game_service._load_source_work_bindings", _must_not_run)
+
+    await _validate_manual_source_update(
+        {"work_id": "work-a", "source_url": "https://example.com/current"},
+        {"summary": "updated"},
+    )


### PR DESCRIPTION
Closes part of #256.

- Reuse canonical Claim/Evidence bindings for manual `source_url` changes.
- Resolve exact evidence source URL -> supporting EvidenceBinding -> accepted Claim -> RuleSet -> game -> `work_id`.
- Allow the write only when the source is bound uniquely to the current work.
- Fail closed for unbound, other-work, and multi-work sources.
- Skip evidence queries when `source_url` is unchanged.
- No schema, dependency, workflow, or production-data changes.

This intentionally does not infer redirects or URL equivalence; redirected/replacement URLs must be re-bound as reviewed evidence.