### PR TITLE
Add Vercel Web Analytics pageview collection

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,6 +72,10 @@
 
   <body>
     <div id="root"></div>
+    <script>
+      window.va = window.va || function () { (window.vaq = window.vaq || []).push(arguments) }
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Why

Issue #208 needs a trustworthy pageview/visitor time series. Production currently rewrites `/_vercel/insights/script.js` to the SPA HTML, and `frontend/index.html` does not load the Vercel Web Analytics collector.

## Change

- add Vercel's documented HTML Web Analytics bootstrap and `/_vercel/insights/script.js` collector to the existing Vite HTML entry
- no analytics SDK dependency
- no custom analytics database
- no user identifier or free-text payload

Primary reference: https://vercel.com/docs/analytics/quickstart
Web Analytics API reference: https://vercel.com/docs/analytics/web-analytics-api

## Verification

- require exact-head Vercel preview/build success before merge
- after production deploy, verify the deployed HTML contains the collector and `/_vercel/insights/script.js` is served as JavaScript rather than the SPA fallback
- pageview/visitor history only starts once Vercel Web Analytics is enabled for the project; do not infer historical PV from runtime logs

Refs #208