### PR TITLE
Persist privacy-safe Web Analytics history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "17 * * * *"
@@ -14,28 +13,11 @@ permissions:
 
 concurrency:
   group: vercel-${{ github.workflow }}-${{ github.ref }}
-  # PR validation should converge on the latest head. Production/catch-up runs
-  # must never cancel one another because they verify/deploy exact main state.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # Never let an hourly catch-up cancel a main-push production verification.
+  # A queued catch-up re-checks the exact SHA and becomes a no-op when production is current.
+  cancel-in-progress: false
 
 jobs:
-  Build-Preview:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-      - name: Build PR without deployment secrets
-        working-directory: frontend
-        run: npm run build
-
   Production-Build-And-Verify:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ permissions:
 
 concurrency:
   group: vercel-${{ github.workflow }}-${{ github.ref }}
-  # Never let an hourly catch-up cancel a main-push production verification.
-  # A queued catch-up re-checks the exact SHA and becomes a no-op when production is current.
-  cancel-in-progress: false
+  # PR validation should converge on the latest head. Production/catch-up runs
+  # must never cancel one another because they verify/deploy exact main state.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   Build-Preview:

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -22,8 +22,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: web-analytics-history
-  cancel-in-progress: false
+  group: web-analytics-history-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'production' }}
+  # PR validation should converge on the latest head; production snapshots must not race.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   Validate-Exporter:

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -1,0 +1,99 @@
+name: Web Analytics Snapshot
+
+on:
+  pull_request:
+    paths:
+      - frontend/index.html
+      - scripts/export_vercel_web_analytics.py
+      - .github/workflows/web-analytics.yml
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/index.html
+      - scripts/export_vercel_web_analytics.py
+      - .github/workflows/web-analytics.yml
+  schedule:
+    # 00:24 JST. Re-query the latest 31 days and merge them into durable history.
+    - cron: "24 15 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: web-analytics-history
+  cancel-in-progress: false
+
+jobs:
+  Validate-Exporter:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Compile exporter
+        run: python -m py_compile scripts/export_vercel_web_analytics.py
+      - name: Test history merge
+        run: python scripts/export_vercel_web_analytics.py --self-test
+
+  Snapshot-Production-Traffic:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install Vercel CLI
+        run: npm install --global vercel@59.0.0
+      - name: Link production project
+        run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
+      - name: Enable Vercel Web Analytics
+        run: vercel project web-analytics --token="${VERCEL_TOKEN}" --format json
+      - name: Read existing durable history
+        shell: bash
+        run: |
+          if git ls-remote --exit-code --heads origin analytics-history >/dev/null 2>&1; then
+            git fetch origin analytics-history
+            git show FETCH_HEAD:data/analytics/web-traffic.json > /tmp/web-traffic.previous.json || true
+            echo "ANALYTICS_HISTORY_REF=FETCH_HEAD" >> "$GITHUB_ENV"
+          else
+            echo "ANALYTICS_HISTORY_REF=" >> "$GITHUB_ENV"
+          fi
+      - name: Export rolling production traffic
+        shell: bash
+        run: |
+          args=(--output /tmp/web-traffic.json --since-days 31)
+          if [ -s /tmp/web-traffic.previous.json ]; then
+            args+=(--existing /tmp/web-traffic.previous.json)
+          fi
+          python scripts/export_vercel_web_analytics.py "${args[@]}"
+      - name: Persist history outside deployment branch
+        shell: bash
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [ -n "${ANALYTICS_HISTORY_REF}" ]; then
+            git switch -C analytics-history "${ANALYTICS_HISTORY_REF}"
+          else
+            git switch --orphan analytics-history
+            git rm -rf .
+          fi
+          mkdir -p data/analytics
+          cp /tmp/web-traffic.json data/analytics/web-traffic.json
+          git add data/analytics/web-traffic.json
+          if git diff --cached --quiet; then
+            echo "Analytics history is unchanged."
+            exit 0
+          fi
+          git commit -m "data: update web analytics history"
+          git push origin HEAD:analytics-history

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: web-analytics-history
@@ -42,6 +42,8 @@ jobs:
   Snapshot-Production-Traffic:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -90,7 +92,10 @@ jobs:
           fi
           mkdir -p data/analytics
           cp /tmp/web-traffic.json data/analytics/web-traffic.json
-          git add data/analytics/web-traffic.json
+          # Prevent Vercel Git integration from creating daily preview deployments
+          # for the data-only history branch.
+          printf '%s\n' '{"ignoreCommand":"exit 0"}' > vercel.json
+          git add data/analytics/web-traffic.json vercel.json
           if git diff --cached --quiet; then
             echo "Analytics history is unchanged."
             exit 0

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -6,6 +6,7 @@ on:
       - frontend/index.html
       - scripts/export_vercel_web_analytics.py
       - .github/workflows/web-analytics.yml
+      - vercel.json
   push:
     branches:
       - main
@@ -13,6 +14,7 @@ on:
       - frontend/index.html
       - scripts/export_vercel_web_analytics.py
       - .github/workflows/web-analytics.yml
+      - vercel.json
   schedule:
     # 09:24 JST / 00:24 UTC. Persist only completed UTC days.
     - cron: "24 0 * * *"
@@ -53,6 +55,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: main
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -67,43 +70,30 @@ jobs:
       - name: Enable Vercel Web Analytics
         if: github.event_name != 'schedule'
         run: vercel project web-analytics --token="${VERCEL_TOKEN}" --format json --non-interactive
-      - name: Read existing durable history
-        shell: bash
-        run: |
-          if git ls-remote --exit-code --heads origin analytics-history >/dev/null 2>&1; then
-            git fetch origin analytics-history
-            git show FETCH_HEAD:data/analytics/web-traffic.json > /tmp/web-traffic.previous.json || true
-            echo "ANALYTICS_HISTORY_REF=FETCH_HEAD" >> "$GITHUB_ENV"
-          else
-            echo "ANALYTICS_HISTORY_REF=" >> "$GITHUB_ENV"
-          fi
       - name: Export rolling production traffic
         shell: bash
         run: |
           args=(--output /tmp/web-traffic.json --since-days 31)
-          if [ -s /tmp/web-traffic.previous.json ]; then
-            args+=(--existing /tmp/web-traffic.previous.json)
+          if [ -s data/analytics/web-traffic.json ]; then
+            args+=(--existing data/analytics/web-traffic.json)
           fi
           python scripts/export_vercel_web_analytics.py "${args[@]}"
-      - name: Persist history outside deployment branch
+      - name: Persist history on main
         shell: bash
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if [ -n "${ANALYTICS_HISTORY_REF}" ]; then
-            git switch -C analytics-history "${ANALYTICS_HISTORY_REF}"
-          else
-            git switch --orphan analytics-history
-            git rm -rf .
-          fi
+          git fetch origin main
+          git reset --hard origin/main
           mkdir -p data/analytics
           cp /tmp/web-traffic.json data/analytics/web-traffic.json
-          # The history branch is data-only and must never trigger a Vercel Git deployment.
-          printf '%s\n' '{"git":{"deploymentEnabled":false}}' > vercel.json
-          git add data/analytics/web-traffic.json vercel.json
+          git add data/analytics/web-traffic.json
           if git diff --cached --quiet; then
             echo "Analytics history is unchanged."
             exit 0
           fi
-          git commit -m "data: update web analytics history"
-          git push origin HEAD:analytics-history
+          # GitHub Actions recognizes [skip ci] on push commits. Vercel separately
+          # ignores commits whose only changed path is data/analytics/**.
+          git commit -m "data: update web analytics history [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -56,11 +56,16 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      # Web Analytics only needs to be enabled when this workflow is introduced
+      # or manually re-run. Scheduled snapshots query the API directly.
       - name: Install Vercel CLI
+        if: github.event_name != 'schedule'
         run: npm install --global vercel@59.0.0
       - name: Link production project
+        if: github.event_name != 'schedule'
         run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
       - name: Enable Vercel Web Analytics
+        if: github.event_name != 'schedule'
         run: vercel project web-analytics --token="${VERCEL_TOKEN}" --format json --non-interactive
       - name: Read existing durable history
         shell: bash

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -14,8 +14,8 @@ on:
       - scripts/export_vercel_web_analytics.py
       - .github/workflows/web-analytics.yml
   schedule:
-    # 00:24 JST. Re-query the latest 31 days and merge them into durable history.
-    - cron: "24 15 * * *"
+    # 09:24 JST / 00:24 UTC. Persist only completed UTC days.
+    - cron: "24 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -61,7 +61,7 @@ jobs:
       - name: Link production project
         run: vercel pull --yes --environment=production --token="${VERCEL_TOKEN}"
       - name: Enable Vercel Web Analytics
-        run: vercel project web-analytics --token="${VERCEL_TOKEN}" --format json
+        run: vercel project web-analytics --token="${VERCEL_TOKEN}" --format json --non-interactive
       - name: Read existing durable history
         shell: bash
         run: |
@@ -93,9 +93,8 @@ jobs:
           fi
           mkdir -p data/analytics
           cp /tmp/web-traffic.json data/analytics/web-traffic.json
-          # Prevent Vercel Git integration from creating daily preview deployments
-          # for the data-only history branch.
-          printf '%s\n' '{"ignoreCommand":"exit 0"}' > vercel.json
+          # The history branch is data-only and must never trigger a Vercel Git deployment.
+          printf '%s\n' '{"git":{"deploymentEnabled":false}}' > vercel.json
           git add data/analytics/web-traffic.json vercel.json
           if git diff --cached --quiet; then
             echo "Analytics history is unchanged."

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -55,8 +55,14 @@
         url.hash = ''
         return { ...event, url: url.toString() }
       })
+
+      if (!['localhost', '127.0.0.1', '::1'].includes(window.location.hostname)) {
+        const analyticsScript = document.createElement('script')
+        analyticsScript.defer = true
+        analyticsScript.src = '/_vercel/insights/script.js'
+        document.head.appendChild(analyticsScript)
+      }
     </script>
-    <script defer src="/_vercel/insights/script.js"></script>
 
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,6 +42,22 @@
     />
     <meta name="twitter:image" content="https://bodoge-no-mikata.vercel.app/og-image.webp" />
 
+    <!-- Vercel Web Analytics. Strip query/hash values so search text is not retained. -->
+    <script>
+      window.va =
+        window.va ||
+        function () {
+          ;(window.vaq = window.vaq || []).push(arguments)
+        }
+      window.va('beforeSend', function (event) {
+        const url = new URL(event.url)
+        url.search = ''
+        url.hash = ''
+        return { ...event, url: url.toString() }
+      })
+    </script>
+    <script defer src="/_vercel/insights/script.js"></script>
+
     <!-- Structured Data (JSON-LD) -->
     <script type="application/ld+json">
       {

--- a/scripts/export_vercel_web_analytics.py
+++ b/scripts/export_vercel_web_analytics.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Export Vercel Web Analytics daily pageviews into a durable history file."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from urllib import error, parse, request
+
+API_URL = "https://api.vercel.com/v1/query/web-analytics/visits/aggregate"
+SCHEMA_VERSION = 1
+
+
+def normalize_rows(rows: Any) -> list[dict[str, Any]]:
+    if not isinstance(rows, list):
+        raise ValueError("Vercel analytics response data must be a list")
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("Vercel analytics rows must be objects")
+        timestamp = row.get("timestamp")
+        if not isinstance(timestamp, str) or len(timestamp) < 10:
+            raise ValueError("Vercel analytics row is missing timestamp")
+        normalized.append(
+            {
+                "date": timestamp[:10],
+                "pageviews": int(row.get("pageviews", 0)),
+                "visitors": int(row.get("visitors", 0)),
+            }
+        )
+    return normalized
+
+
+def read_existing(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {"schema_version": SCHEMA_VERSION, "days": []}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError("Unsupported analytics history schema_version")
+    if not isinstance(data.get("days"), list):
+        raise ValueError("Analytics history days must be a list")
+    return data
+
+
+def merge_history(
+    existing: dict[str, Any], fresh_days: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    by_date: dict[str, dict[str, Any]] = {}
+    for row in existing.get("days", []):
+        if isinstance(row, dict) and isinstance(row.get("date"), str):
+            by_date[row["date"]] = {
+                "date": row["date"],
+                "pageviews": int(row.get("pageviews", 0)),
+                "visitors": int(row.get("visitors", 0)),
+            }
+    for row in fresh_days:
+        by_date[row["date"]] = row
+    return [by_date[key] for key in sorted(by_date)]
+
+
+def fetch_daily(
+    *, token: str, project_id: str, team_id: str, since: str, until: str
+) -> list[dict[str, Any]]:
+    params = parse.urlencode(
+        {
+            "projectId": project_id,
+            "teamId": team_id,
+            "since": since,
+            "until": until,
+            "by": "day",
+            "filter": "environment eq 'production'",
+            "limit": "100",
+        }
+    )
+    req = request.Request(
+        f"{API_URL}?{params}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+            "User-Agent": "rule-scribe-games-web-analytics/1",
+        },
+    )
+    try:
+        with request.urlopen(req, timeout=30) as response:
+            payload = json.load(response)
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:1000]
+        raise RuntimeError(
+            f"Vercel Web Analytics API returned HTTP {exc.code}: {body}"
+        ) from exc
+    except error.URLError as exc:
+        raise RuntimeError(
+            f"Vercel Web Analytics API request failed: {exc.reason}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Vercel analytics response must be an object")
+    return normalize_rows(payload.get("data"))
+
+
+def write_history(
+    output: Path,
+    existing: dict[str, Any],
+    fresh_days: list[dict[str, Any]],
+    collected_at: str,
+) -> None:
+    result = {
+        "schema_version": SCHEMA_VERSION,
+        "source": API_URL,
+        "scope": "production pageviews grouped by UTC day",
+        "collected_at": collected_at,
+        "days": merge_history(existing, fresh_days),
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def self_test() -> None:
+    existing = {
+        "schema_version": 1,
+        "days": [
+            {"date": "2026-08-18", "pageviews": 2, "visitors": 2},
+            {"date": "2026-08-19", "pageviews": 3, "visitors": 2},
+        ],
+    }
+    fresh = normalize_rows(
+        [
+            {
+                "timestamp": "2026-08-19T00:00:00.000Z",
+                "pageviews": 5,
+                "visitors": 4,
+            },
+            {
+                "timestamp": "2026-08-20T00:00:00.000Z",
+                "pageviews": 7,
+                "visitors": 6,
+            },
+        ]
+    )
+    assert merge_history(existing, fresh) == [
+        {"date": "2026-08-18", "pageviews": 2, "visitors": 2},
+        {"date": "2026-08-19", "pageviews": 5, "visitors": 4},
+        {"date": "2026-08-20", "pageviews": 7, "visitors": 6},
+    ]
+    print("web analytics exporter self-test: OK")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output", type=Path, default=Path("data/analytics/web-traffic.json")
+    )
+    parser.add_argument("--existing", type=Path)
+    parser.add_argument("--since-days", type=int, default=31)
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        self_test()
+        return 0
+    if args.since_days < 1 or args.since_days > 100:
+        parser.error("--since-days must be between 1 and 100")
+
+    token = os.environ.get("VERCEL_TOKEN", "").strip()
+    project_id = os.environ.get("VERCEL_PROJECT_ID", "").strip()
+    team_id = os.environ.get("VERCEL_ORG_ID", "").strip()
+    missing = [
+        name
+        for name, value in (
+            ("VERCEL_TOKEN", token),
+            ("VERCEL_PROJECT_ID", project_id),
+            ("VERCEL_ORG_ID", team_id),
+        )
+        if not value
+    ]
+    if missing:
+        raise SystemExit("Missing required environment variables: " + ", ".join(missing))
+
+    now = datetime.now(timezone.utc)
+    since = (now - timedelta(days=args.since_days - 1)).date().isoformat()
+    until = (now + timedelta(days=1)).date().isoformat()
+    fresh_days = fetch_daily(
+        token=token,
+        project_id=project_id,
+        team_id=team_id,
+        since=since,
+        until=until,
+    )
+    write_history(
+        args.output,
+        read_existing(args.existing),
+        fresh_days,
+        now.isoformat(),
+    )
+    print(f"wrote {len(fresh_days)} refreshed day(s) to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/export_vercel_web_analytics.py
+++ b/scripts/export_vercel_web_analytics.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Export Vercel Web Analytics daily pageviews into a durable history file."""
+"""Export completed UTC days from Vercel Web Analytics into durable history."""
 
 from __future__ import annotations
 
@@ -34,6 +34,11 @@ def normalize_rows(rows: Any) -> list[dict[str, Any]]:
             }
         )
     return normalized
+
+
+def completed_days(rows: list[dict[str, Any]], today_utc: str) -> list[dict[str, Any]]:
+    """Exclude the in-progress UTC day so persisted daily values are final."""
+    return [row for row in rows if row["date"] < today_utc]
 
 
 def read_existing(path: Path | None) -> dict[str, Any]:
@@ -111,7 +116,7 @@ def write_history(
     result = {
         "schema_version": SCHEMA_VERSION,
         "source": API_URL,
-        "scope": "production pageviews grouped by UTC day",
+        "scope": "production pageviews grouped by completed UTC day",
         "collected_at": collected_at,
         "days": merge_history(existing, fresh_days),
     }
@@ -141,8 +146,14 @@ def self_test() -> None:
                 "pageviews": 7,
                 "visitors": 6,
             },
+            {
+                "timestamp": "2026-08-21T00:00:00.000Z",
+                "pageviews": 1,
+                "visitors": 1,
+            },
         ]
     )
+    fresh = completed_days(fresh, "2026-08-21")
     assert merge_history(existing, fresh) == [
         {"date": "2026-08-18", "pageviews": 2, "visitors": 2},
         {"date": "2026-08-19", "pageviews": 5, "visitors": 4},
@@ -183,14 +194,18 @@ def main() -> int:
         raise SystemExit("Missing required environment variables: " + ", ".join(missing))
 
     now = datetime.now(timezone.utc)
-    since = (now - timedelta(days=args.since_days - 1)).date().isoformat()
-    until = (now + timedelta(days=1)).date().isoformat()
-    fresh_days = fetch_daily(
-        token=token,
-        project_id=project_id,
-        team_id=team_id,
-        since=since,
-        until=until,
+    today_utc = now.date().isoformat()
+    since = (now - timedelta(days=args.since_days)).date().isoformat()
+    until = today_utc
+    fresh_days = completed_days(
+        fetch_daily(
+            token=token,
+            project_id=project_id,
+            team_id=team_id,
+            since=since,
+            until=until,
+        ),
+        today_utc,
     )
     write_history(
         args.output,
@@ -198,7 +213,7 @@ def main() -> int:
         fresh_days,
         now.isoformat(),
     )
-    print(f"wrote {len(fresh_days)} refreshed day(s) to {args.output}")
+    print(f"wrote {len(fresh_days)} completed day(s) to {args.output}")
     return 0
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "buildCommand": "cd frontend && npm ci && npm run build",
   "outputDirectory": "frontend/dist",
+  "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ':(exclude)data/analytics/**'",
   "rewrites": [
     {
       "source": "/api/:path*",


### PR DESCRIPTION
Closes the pageview-trend foundation in #208 without creating a second analytics authority.

What changes:
- enable Vercel Web Analytics from the existing Vercel project credentials;
- load the Vercel analytics script in the public frontend and strip query/hash values before collection so free-text searches are not retained;
- query the official Vercel Web Analytics aggregate API by UTC day for production pageviews + visitors;
- merge the rolling 31-day response into durable `main:data/analytics/web-traffic.json`;
- persist history with a data-only `[skip ci]` commit and skip Vercel builds when `data/analytics/**` is the only changed path;
- run the exporter compile/self-test on pull requests.

No Supabase analytics tables, cookies, user IDs, custom event taxonomy, or dedicated/orphan analytics branch is added. The stored history is aggregate `{date, pageviews, visitors}` only.

Primary references:
- https://vercel.com/docs/analytics/quickstart
- https://vercel.com/docs/analytics/web-analytics-api
- https://vercel.com/docs/analytics/privacy-policy
- https://vercel.com/docs/analytics/limits-and-pricing

Verification required before merge:
- exact-head `Web Analytics Snapshot / Validate-Exporter` success;
- existing Vercel preview/build checks remain green;
- after merge, scheduled/push snapshot successfully enables analytics and writes `data/analytics/web-traffic.json` on `main`;
- a subsequent analytics-only history commit is skipped by CI and Vercel build logic;
- production `/_vercel/insights/script.js` is reachable.

Related: #208