### PR TITLE
Lock restored game metadata to official-source assertions

### DIFF
--- a/data/curated-games/minna-de-ponkotsu-paint.json
+++ b/data/curated-games/minna-de-ponkotsu-paint.json
@@ -71,8 +71,11 @@
     ]
   },
   "assertions": [
+    {"path": "facts.playersMin", "equals": 2},
     {"path": "facts.playersMax", "equals": 12},
     {"path": "facts.playTimeMinutes", "equals": 10},
+    {"path": "facts.minimumAge", "equals": 6},
+    {"path": "facts.releaseYear", "equals": 2018},
     {"path": "quick.actions", "contains": "直線と正円"}
   ]
 }

--- a/data/curated-games/raise-your-goblets.json
+++ b/data/curated-games/raise-your-goblets.json
@@ -73,7 +73,11 @@
   },
   "assertions": [
     {"path": "facts.rounds", "equals": 3},
+    {"path": "facts.playersMin", "equals": 2},
     {"path": "facts.playersMax", "equals": 12},
+    {"path": "facts.playTimeMinutes", "equals": 30},
+    {"path": "facts.minimumAge", "equals": 8},
+    {"path": "facts.releaseYear", "equals": 2016},
     {"path": "quick.end", "contains": "3ラウンド"}
   ]
 }


### PR DESCRIPTION
Continues #256 using the existing curated-game assertion mechanism; no new schema, dependency, workflow, or production write.

## Change
- lock all five source-backed basic metadata facts for `ワインと毒とゴブレット / Raise Your Goblets`: players 2–12, 30 minutes, age 8+, release year 2016
- lock all five source-backed basic metadata facts for `みんなでぽんこつペイント`: players 2–12, 10 minutes, age 6+, release year 2018
- preserve existing rule assertions and canonical source revisions

## Primary sources (rechecked 2026-08-21)
- https://hobbyjapan.games/wine_poison_and_goblets/
- https://hobbyjapan.games/ponkotsu_paint/

## Why
The two works were restored separately under #256, but their generic curated regression assertions covered only a subset of the basic metadata. These assertions make future curated regeneration/check-all fail if the reviewed guide facts drift from the currently verified publisher values.

## Boundary
This strengthens the two repaired source-backed records only. Catalog-wide field-level provenance remains unfinished under #256.