### PR TITLE
Bind Skull King verified identity to publisher evidence

### DIFF
--- a/data/curated-games/skull-king.json
+++ b/data/curated-games/skull-king.json
@@ -35,6 +35,7 @@
     "generated_from_source_revision": "grandpa-becks-current-en-rulebook-faq-accessed-2026-08-22",
     "source_trust": "official_publisher",
     "identity_status": "verified",
+    "identity_source": "https://www.grandpabecksgames.com/products/copy-of-skull-king%C2%AE",
     "structured_data": {
       "keywords": [
         {"term": "ビッド", "description": "そのラウンドで自分が取ると予想するトリック数。"},


### PR DESCRIPTION
## User/data outcome
Production currently returns `identity_status=verified` for Skull King while `identity_source=null`.

This change binds the verified canonical identity to Grandpa Beck's Games' current Skull King product page, which explicitly identifies the same game/work, while keeping rules provenance (`source_url`) separate.

## Change
- add `game.identity_source` to `data/curated-games/skull-king.json`
- reuse the existing curated source→artifact semantic-diff validation; no new assertion/test mechanism
- no schema, dependency, workflow, generated output, or production write from this PR

Official identity evidence:
- https://www.grandpabecksgames.com/products/copy-of-skull-king%C2%AE

Continues #264.