### PR TITLE
Fix Skull King advanced-rule FAQ clarifications

### DIFF
--- a/data/curated-games/skull-king.json
+++ b/data/curated-games/skull-king.json
@@ -17,7 +17,7 @@
     "title_en": "Skull King",
     "description": "Grandpa Beck's Gamesの現行版Skull King。通常ゲームは10ラウンドで、毎ラウンド配られた手札を見て獲得トリック数をビッドします。黒は切り札で、海賊・スカルキング・人魚などの特殊カードが通常の数字カードより強い相互作用を持ちます。ビッドを正確に当てることと、ボーナスカードを取ることが得点につながります。",
     "summary": "各ラウンドで取るトリック数を予想してビッドし、予想どおりに取ることを目指す海賊テーマのトリックテイキング。",
-    "rules_content": "# スカルキング\n\n## 目的\n10ラウンドを通して得点し、終了時に合計得点が最も高いプレイヤーが勝ちます。各ラウンドの最初に、そのラウンドで自分が取るトリック数をビッドします。\n\n## 通常ゲームの準備\n1. ブランクカード、Loot、Kraken、White Whaleを通常デッキから外します。これらは任意の上級ルール用です。\n2. 残りのカードをシャッフルします。\n3. 第1ラウンドは1枚、第2ラウンドは2枚というように、通常はラウンド数と同じ枚数を各プレイヤーへ配ります。第10ラウンドは10枚です。8人戦では第9・第10ラウンドも8枚ずつ配ります。\n\n## ビッド\n手札を見て、そのラウンドで自分が取ると思うトリック数を宣言します。0もビッドできます。\n\n## 1トリックの流れ\n1. ディーラー左隣のプレイヤーが最初のトリックをリードし、以後は直前のトリックの勝者が次をリードします。\n2. 数字カードがリードされ、数字カードを出す場合、リードされたスートを持っていれば同じスートを出します。特殊カードはいつでも出せます。\n3. 全員が1枚ずつ出したら、最も強いカードを出したプレイヤーがトリックを取ります。\n\n## カードの基本関係\n- 緑・黄・紫は通常スートです。同じスート同士なら数字が高い方が勝ちます。\n- 黒（Jolly Roger）は切り札で、通常スートより強いです。\n- Pirateはすべての数字カードより強く、複数のPirateが出た場合は先に出たPirateが勝ちます。\n- Tigressは出したときにPirateまたはEscapeとして扱うかを選びます。\n- Skull Kingは数字カードとPirateに勝ち、Mermaidに負けます。\n- MermaidはSkull Kingと数字カードに勝ち、通常はPirateに負けます。ただしPirate・Skull King・Mermaidが同じトリックに揃った場合はMermaidが勝ちます。\n- Escapeは通常は負けます。全員がEscapeまたはEscape扱いのカードだけを出した場合は、最初に出たEscapeが勝ちます。\n\n## 得点\n### 1以上をビッド\n- ビッドどおりなら、取ったトリック1つにつき20点です。\n- 多くても少なくても、ビッドとの差1トリックにつき10点を失います。この場合、取ったトリック自体の得点はありません。\n\n### 0をビッド\n- 0トリックを達成すると、そのラウンドの配札枚数 × 10点を獲得します。\n- 1トリック以上取ると、そのラウンドの配札枚数 × 10点を失います。\n\n### ボーナス\nボーナスはビッドを成功させたラウンドだけ得られます。\n- 緑・黄・紫の14を取る: 各10点\n- 黒の14を取る: 20点\n- PirateでMermaidを取る: Mermaid 1枚につき20点\n- Skull KingでPirateを取る: Pirate 1枚につき30点\n- MermaidでSkull Kingを取る: 40点\n\n## ゲーム終了\n10ラウンド終了後に合計得点を比べます。同点なら、決着するまで追加ラウンドを行います。\n\n## 2人プレイ\n1. 3人分の手札を配り、3つ目の手札は裏向きのままGraybeard's Ghost用にします。2人のプレイヤーは通常どおりビッドしてプレイします。\n2. 2人のプレイヤーはラウンドごとにリード役を交代します。誰がリードしてもGraybeardは各トリックで2番目にプレイします。\n3. Graybeardの手番では裏向き手札の一番上を表にしてそのままトリックへ加えます。Graybeardはリードされたスートをフォローする必要がありません。\n4. Graybeardがトリックを取った場合、次のトリックはGraybeardがリードし、そのラウンドのリード役だったプレイヤーが2番目にプレイします。\n5. GraybeardがTigressを出した場合はEscapeとして扱います。Lootカードは2人プレイでは使用しません。",
+    "rules_content": "# スカルキング\n\n## 目的\n10ラウンドを通して得点し、終了時に合計得点が最も高いプレイヤーが勝ちます。各ラウンドの最初に、そのラウンドで自分が取るトリック数をビッドします。\n\n## 通常ゲームの準備\n1. ブランクカード、Loot、Kraken、White Whaleを通常デッキから外します。これらは任意の上級ルール用です。\n2. 残りのカードをシャッフルします。\n3. 第1ラウンドは1枚、第2ラウンドは2枚というように、通常はラウンド数と同じ枚数を各プレイヤーへ配ります。第10ラウンドは10枚です。8人戦では第9・第10ラウンドも8枚ずつ配ります。\n\n## ビッド\n手札を見て、そのラウンドで自分が取ると思うトリック数を宣言します。0もビッドできます。\n\n## 1トリックの流れ\n1. ディーラー左隣のプレイヤーが最初のトリックをリードし、以後は直前のトリックの勝者が次をリードします。\n2. 数字カードがリードされ、数字カードを出す場合、リードされたスートを持っていれば同じスートを出します。特殊カードはいつでも出せます。\n3. 全員が1枚ずつ出したら、最も強いカードを出したプレイヤーがトリックを取ります。\n\n## カードの基本関係\n- 緑・黄・紫は通常スートです。同じスート同士なら数字が高い方が勝ちます。\n- 黒（Jolly Roger）は切り札で、通常スートより強いです。\n- Pirateはすべての数字カードより強く、複数のPirateが出た場合は先に出たPirateが勝ちます。\n- Tigressは出したときにPirateまたはEscapeとして扱うかを選びます。\n- Skull Kingは数字カードとPirateに勝ち、Mermaidに負けます。\n- MermaidはSkull Kingと数字カードに勝ち、通常はPirateに負けます。ただしPirate・Skull King・Mermaidが同じトリックに揃った場合はMermaidが勝ちます。\n- Escapeは通常は負けます。全員がEscapeまたはEscape扱いのカードだけを出した場合は、最初に出たEscapeが勝ちます。\n\n## 得点\n### 1以上をビッド\n- ビッドどおりなら、取ったトリック1つにつき20点です。\n- 多くても少なくても、ビッドとの差1トリックにつき10点を失います。この場合、取ったトリック自体の得点はありません。\n\n### 0をビッド\n- 0トリックを達成すると、そのラウンドの配札枚数 × 10点を獲得します。\n- 1トリック以上取ると、そのラウンドの配札枚数 × 10点を失います。\n\n### ボーナス\nボーナスはビッドを成功させたラウンドだけ得られます。\n- 緑・黄・紫の14を取る: 各10点\n- 黒の14を取る: 20点\n- PirateでMermaidを取る: Mermaid 1枚につき20点\n- Skull KingでPirateを取る: Pirate 1枚につき30点\n- MermaidでSkull Kingを取る: 40点\n\n## ゲーム終了\n10ラウンド終了後に合計得点を比べます。同点なら、決着するまで追加ラウンドを行います。\n\n## 2人プレイ\n1. 3人分の手札を配り、3つ目の手札は裏向きのままGraybeard's Ghost用にします。2人のプレイヤーは通常どおりビッドしてプレイします。\n2. 2人のプレイヤーはラウンドごとにリード役を交代します。誰がリードしてもGraybeardは各トリックで2番目にプレイします。\n3. Graybeardの手番では裏向き手札の一番上を表にしてそのままトリックへ加えます。Graybeardはリードされたスートをフォローする必要がありません。\n4. Graybeardがトリックを取った場合、次のトリックはGraybeardがリードし、そのラウンドのリード役だったプレイヤーが2番目にプレイします。\n5. GraybeardがTigressを出した場合はEscapeとして扱います。Lootカードは2人プレイでは使用しません。\n\n## 任意の上級ルール\n以下は通常ゲームではデッキから外すカード・能力です。採用する場合だけ適用します。\n\n### Kraken\nKrakenが出たトリックは誰も獲得せず、出されたカードを脇へ置きます。次のトリックは、Krakenがなければそのトリックを取っていたプレイヤーがリードします。\n\n### White Whale\nWhite Whaleが出ると特殊カードは無効になり、数字カードはスートを失います。最も大きい数字がトリックを取り、同じ最大値なら先に出されたカードが勝ちます。数字カードが1枚もない場合は誰もトリックを取らず、本来勝っていたプレイヤーが次をリードします。公式FAQでは、White Whaleがトリック途中で出ても、それ以前に成立していたリードスートへのフォロー義務は残り、後続プレイヤーはそのスートを持っていれば数字カードを出す際にフォローするか、特殊カードを出します。\n\n### KrakenとWhite Whaleが同じトリックに出た場合\n後から出た方の効果だけが残り、先に出た方はEscapeとして扱います。KrakenがWhite Whaleの後に出た場合、誰もそのトリックを取らず、両者が出なかった場合に勝っていたプレイヤーが次をリードします。\n\n### Loot\nLootはEscapeとしてプレイし、そのLootを出したプレイヤーとトリックの勝者が同盟になります。両者がそれぞれ自分のビッドを正確に当てた場合、各20点のボーナスを得ます。Lootがリードされた場合はEscapeのように扱い、次のプレイヤーがリードスートを決めます。\n\n### Pirateの上級能力\n上級能力を使う場合、そのPirateを出してトリックに勝った直後に能力を使います。単にPirateカードを獲得しただけでは発動しません。Harry the Giantだけはラウンド最後のトリック後にも能力を使えます。",
     "setup_summary": "通常ルールでは上級カードを外してシャッフルし、通常はラウンド数と同じ枚数を配る。8人戦の第9・第10ラウンドは8枚ずつ。",
     "gameplay_summary": "各ラウンドで獲得トリック数をビッドし、数字カードのフォロー義務と特殊カードの例外に従って全手札をプレイする。",
     "end_game_summary": "10ラウンド終了時に合計得点が最も高いプレイヤーが勝利。同点なら決着まで追加ラウンド。",
@@ -49,7 +49,9 @@
         "数字カードをフォローできる状況でも、特殊カードは出せる。",
         "Pirate・Skull King・Mermaidが同じトリックに出た場合はMermaidが勝つ。",
         "ボーナス点はそのラウンドのビッド成功時だけ得られる。",
-        "2人プレイでGraybeardがTigressを出した場合はPirateではなくEscapeとして扱う。"
+        "2人プレイでGraybeardがTigressを出した場合はPirateではなくEscapeとして扱う。",
+        "上級ルールでWhite Whaleがトリック途中に出ても、すでに成立したリードスートへのフォロー義務は公式FAQ上維持される。",
+        "Pirateの上級能力はそのPirateでトリックに勝った直後に使う。Harry the Giantだけはラウンド最後のトリック後にも使える。"
       ],
       "source_documents": [
         {
@@ -63,14 +65,14 @@
           "url": "https://cdn.shopify.com/s/files/1/0565/3230/4053/files/Skull_King_Simplified_Rulebook_US_WEB_NO_CROP_a0eb3b84-f1cd-4087-8bda-0aab43d231af.pdf?v=1764178570",
           "type": "publisher_official_rulebook",
           "label": "Grandpa Beck's Games — Skull King English current rulebook",
-          "locator": "Setup; Game Play; The Cards; Scoring; Bonus Points; Two-Player Rules",
+          "locator": "Setup; Game Play; The Cards; Scoring; Bonus Points; Two-Player Rules; Advanced Play Options; Advanced Pirate Abilities; Leading with Advanced Cards",
           "accessed_at": "2026-08-22"
         },
         {
           "url": "https://www.grandpabecksgames.com/pages/faq-skull-king",
           "type": "official_faq",
           "label": "Grandpa Beck's Games — Skull King FAQ",
-          "locator": "Pirate power timing; Graybeard/Tigress; Mermaid + Skull King + Pirate; Kraken + White Whale clarifications",
+          "locator": "Pirate power timing; Graybeard/Tigress; Mermaid + Skull King + Pirate; Kraken + White Whale ordering; Kraken next lead; Loot lead; White Whale mid-trick follow-suit",
           "accessed_at": "2026-08-22"
         },
         {


### PR DESCRIPTION
Continues #209 and #254 without adding a new rule authority.

User-visible change:
- keep Loot / Kraken / White Whale / advanced Pirate abilities explicitly outside the normal game;
- add their current-rule behavior to Skull King's detailed rules only under an optional advanced-rules section;
- apply the current official FAQ clarifications for White Whale mid-trick follow-suit, Kraken/White Whale ordering, Kraken next-lead resolution, Loot lead, and Pirate ability timing;
- expand the existing source-document locators instead of adding another source record or schema.

Primary sources checked 2026-08-22:
- current publisher rule page: https://www.grandpabecksgames.com/pages/skull-king
- current English rulebook PDF linked there: https://cdn.shopify.com/s/files/1/0565/3230/4053/files/Skull_King_Simplified_Rulebook_US_WEB_NO_CROP_a0eb3b84-f1cd-4087-8bda-0aab43d231af.pdf?v=1764178570
- official FAQ: https://www.grandpabecksgames.com/pages/faq-skull-king

The rulebook marks Loot/Kraken/White Whale as optional advanced cards and documents advanced play on pages 16-19. The FAQ specifically clarifies that White Whale played mid-trick does not erase an already-established follow-suit obligation, and resolves the Kraken/White Whale and Pirate-power timing edge cases.

No dependency, schema, workflow, or generated artifact is added. Production data is not written from this PR.