### PR TITLE
Fix curated catalog publish blocked by missing identity_source

### DIFF
--- a/backend/app/db/migrations/021_add_identity_source.sql
+++ b/backend/app/db/migrations/021_add_identity_source.sql
@@ -1,0 +1,9 @@
+-- Keep catalog storage aligned with the GameDetail / curated-game identity provenance contract.
+-- Existing rows remain NULL until their identity evidence is reviewed; do not infer provenance.
+
+BEGIN;
+
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS identity_source text;
+
+COMMIT;


### PR DESCRIPTION
## User/data outcome

Production is deployed at current main `0b7a2267`, but `/api/games/skull-king` still contains the older #363 catalog row: `identity_source` is null and the #365 advanced-rule FAQ clarifications are absent.

Direct production DB inspection found the cause: `public.games.identity_source` does not exist, while `GameDetail` and the curated Skull King spec already use that field. The main-push curated publisher therefore cannot write #364/#365's current spec.

## Change

Add the missing nullable `public.games.identity_source` column. Existing rows remain null; no provenance is inferred or bulk-backfilled.

This is the smallest schema change required to let the existing curated publish path write the current Skull King spec. No new identity taxonomy or duplicate provenance field is introduced.

Refs #264, #209, #254

## Verification before merge

- exact-head PR CI/build
- migration remains additive/idempotent

## After merge

Apply the repository migration to the production Supabase project, publish the current `skull-king` curated spec through the existing catalog path (or equivalent canonical-spec write), then verify production API/page values rather than treating deployment alone as completion.