### PR TITLE
Fail curated release verification when production catalog is stale

### DIFF
--- a/backend/app/scripts/curated_game_fast_path_v2.py
+++ b/backend/app/scripts/curated_game_fast_path_v2.py
@@ -148,6 +148,24 @@ def write_catalog_with_plan(client: Any, spec: CuratedGameSpec, plan: IdentityPl
     return row
 
 
+def validate_exposed_catalog_fields(expected: Any, actual: Any, path: str = "game") -> None:
+    """Compare structured source fields that the public API actually exposes.
+
+    API response models intentionally omit some storage-only curated fields. Those
+    keys are skipped, while every exposed key from the canonical spec must match.
+    """
+    if isinstance(expected, dict):
+        if not isinstance(actual, dict):
+            raise WorkflowError(f"production catalog mismatch at {path}")
+        for key, expected_value in expected.items():
+            if key not in actual:
+                continue
+            validate_exposed_catalog_fields(expected_value, actual[key], f"{path}.{key}")
+        return
+    if expected != actual:
+        raise WorkflowError(f"production catalog mismatch at {path}")
+
+
 def verify_catalog_live(spec: CuratedGameSpec, base_url: str) -> None:
     base = base_url.rstrip("/")
     with httpx.Client(follow_redirects=True, timeout=20) as client:
@@ -161,6 +179,7 @@ def verify_catalog_live(spec: CuratedGameSpec, base_url: str) -> None:
             raise WorkflowError("production API source provenance does not match structured input")
         if not payload.get("work_id"):
             raise WorkflowError("production API record has no canonical work_id")
+        validate_exposed_catalog_fields(spec.game, payload)
 
         page_response = client.get(f"{base}/games/{spec.slug}")
         if page_response.status_code != 200:
@@ -200,6 +219,13 @@ def verify_frontend_release(
     if response.status_code != 200:
         raise WorkflowError(f"production curated manifest failed: HTTP {response.status_code}")
     validate_release_manifest(expected, response.json(), game=game)
+
+
+def verify_release(specs: list[CuratedGameSpec], base_url: str) -> None:
+    generate_artifacts(specs)
+    verify_frontend_release(specs, base_url)
+    for spec in specs:
+        verify_catalog_live(spec, base_url)
 
 
 def routine_files(spec: CuratedGameSpec) -> list[str]:
@@ -295,8 +321,7 @@ def main() -> None:
     if args.mode == "check-all":
         check_all(specs)
     else:
-        generate_artifacts(specs)
-        verify_frontend_release(specs, args.base_url)
+        verify_release(specs, args.base_url)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_curated_game_fast_path_v2.py
+++ b/backend/tests/test_curated_game_fast_path_v2.py
@@ -169,6 +169,63 @@ def test_release_manifest_digest_mismatch_fails():
         v2.validate_release_manifest(expected, deployed, game="skull-king")
 
 
+def test_exposed_catalog_field_mismatch_fails():
+    expected = {
+        "rules_content": "current rules",
+        "identity_source": "https://publisher.example/game",
+        "structured_data": {
+            "rule_mistakes": ["current clarification"],
+            "source_documents": [{"url": "https://publisher.example/rules"}],
+        },
+    }
+    deployed = {
+        "rules_content": "old rules",
+        "identity_source": None,
+        "structured_data": {
+            "rule_mistakes": ["old clarification"],
+        },
+    }
+
+    with pytest.raises(WorkflowError, match="game.rules_content"):
+        v2.validate_exposed_catalog_fields(expected, deployed)
+
+
+def test_unexposed_storage_fields_do_not_fail_catalog_comparison():
+    expected = {
+        "rules_content": "current rules",
+        "structured_data": {
+            "rule_mistakes": ["current clarification"],
+            "source_documents": [{"url": "https://publisher.example/rules"}],
+        },
+        "publisher": "Publisher",
+    }
+    deployed = {
+        "rules_content": "current rules",
+        "structured_data": {
+            "rule_mistakes": ["current clarification"],
+        },
+    }
+
+    v2.validate_exposed_catalog_fields(expected, deployed)
+
+
+def test_release_check_verifies_catalog_for_every_curated_game(monkeypatch):
+    specs = load_all_specs()[:2]
+    events = []
+
+    monkeypatch.setattr(v2, "generate_artifacts", lambda values: events.append("generate"))
+    monkeypatch.setattr(v2, "verify_frontend_release", lambda values, base_url: events.append("frontend"))
+    monkeypatch.setattr(
+        v2,
+        "verify_catalog_live",
+        lambda spec, base_url: events.append(f"catalog:{spec.slug}"),
+    )
+
+    v2.verify_release(specs, "https://example.invalid")
+
+    assert events == ["generate", "frontend", *[f"catalog:{spec.slug}" for spec in specs]]
+
+
 def test_routine_pr_contains_only_structured_source():
     spec = load_spec(SKULL_KING)
 


### PR DESCRIPTION
## Why

The #365 Vercel production deployment was current, but the Skull King production catalog row remained on #363. `Curated game release verification` still passed because `release-check` only compared the generated frontend revision manifest.

## Change

Reuse the existing `curated_game_fast_path_v2.py` release check and extend it to verify every curated game's live API/page after the frontend manifest check. For fields exposed by the public API, the deployed value must match the canonical `spec.game` subset. Storage-only fields omitted by the API remain ignored.

This directly catches the stale `rules_content`, `identity_source`, and exposed structured-data regression observed in production without adding a new workflow/service.

Refs #209, #254, #264

## Tests

- mismatch in an exposed field fails with its field path
- storage-only fields omitted by the API do not cause false failures
- release check invokes catalog verification for every curated game
- existing focused fast-path tests and Vercel build