### PR TITLE
ci: separate PR merge checks from product release

### DIFF
--- a/.github/workflows/curated-game-fast-path.yml
+++ b/.github/workflows/curated-game-fast-path.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 jobs:
-  validate-release-source:
+  curated-game:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -46,7 +46,8 @@ jobs:
         run: uv run python backend/app/scripts/curated_game_fast_path_v2.py check-all
 
   publish-catalog:
-    needs: validate-release-source
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: curated-game
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/curated-game-fast-path.yml
+++ b/.github/workflows/curated-game-fast-path.yml
@@ -1,21 +1,6 @@
-name: Curated game fast path
+name: Curated game release
 
 on:
-  pull_request:
-    paths:
-      - "data/curated-games/**"
-      - "backend/app/scripts/curated_game_workflow.py"
-      - "backend/app/scripts/curated_game_fast_path_v2.py"
-      - "backend/tests/test_curated_game_workflow.py"
-      - "backend/tests/test_curated_game_fast_path_v2.py"
-      - "frontend/scripts/generate-curated-game-artifacts.mjs"
-      - "frontend/package.json"
-      - "frontend/src/lib/curatedRuleGuides.js"
-      - ".gitignore"
-      - "Taskfile.yml"
-      - "docs/CURATED_GAME_FAST_PATH.md"
-      - ".github/workflows/curated-game-fast-path.yml"
-      - ".github/workflows/curated-game-release-verification.yml"
   push:
     branches:
       - main
@@ -31,6 +16,7 @@ on:
       - ".gitignore"
       - "Taskfile.yml"
       - "docs/CURATED_GAME_FAST_PATH.md"
+      - ".github/workflows/curated-game-pr-checks.yml"
       - ".github/workflows/curated-game-fast-path.yml"
       - ".github/workflows/curated-game-release-verification.yml"
 
@@ -38,7 +24,7 @@ permissions:
   contents: read
 
 jobs:
-  curated-game:
+  validate-release-source:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -60,8 +46,7 @@ jobs:
         run: uv run python backend/app/scripts/curated_game_fast_path_v2.py check-all
 
   publish-catalog:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: curated-game
+    needs: validate-release-source
     runs-on: ubuntu-latest
     timeout-minutes: 10
     concurrency:

--- a/.github/workflows/curated-game-pr-checks.yml
+++ b/.github/workflows/curated-game-pr-checks.yml
@@ -1,0 +1,44 @@
+name: Curated game PR checks
+
+on:
+  pull_request:
+    paths:
+      - "data/curated-games/**"
+      - "backend/app/scripts/curated_game_workflow.py"
+      - "backend/app/scripts/curated_game_fast_path_v2.py"
+      - "backend/tests/test_curated_game_workflow.py"
+      - "backend/tests/test_curated_game_fast_path_v2.py"
+      - "frontend/scripts/generate-curated-game-artifacts.mjs"
+      - "frontend/package.json"
+      - "frontend/src/lib/curatedRuleGuides.js"
+      - ".gitignore"
+      - "Taskfile.yml"
+      - "docs/CURATED_GAME_FAST_PATH.md"
+      - ".github/workflows/curated-game-pr-checks.yml"
+      - ".github/workflows/curated-game-fast-path.yml"
+      - ".github/workflows/curated-game-release-verification.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  curated-game:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+      - name: Run focused workflow tests
+        env:
+          PYTHONPATH: backend
+        run: >-
+          uv run pytest -q
+          backend/tests/test_curated_game_workflow.py
+          backend/tests/test_curated_game_fast_path_v2.py
+      - name: Regenerate and validate all curated artifacts from source
+        env:
+          PYTHONPATH: backend
+        run: uv run python backend/app/scripts/curated_game_fast_path_v2.py check-all

--- a/.github/workflows/curated-game-release-verification.yml
+++ b/.github/workflows/curated-game-release-verification.yml
@@ -2,7 +2,7 @@ name: Curated game release verification
 
 on:
   workflow_run:
-    workflows: ["Vercel Deployment"]
+    workflows: ["Vercel Deployment", "Curated game release"]
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: "17 * * * *"
@@ -19,23 +18,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  Build-Preview:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install frontend dependencies
-        working-directory: frontend
-        run: npm ci
-      - name: Build PR without deployment secrets
-        working-directory: frontend
-        run: npm run build
-
   Production-Build-And-Verify:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-pr-build.yml
+++ b/.github/workflows/frontend-pr-build.yml
@@ -1,0 +1,24 @@
+name: Frontend PR build
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Build without production secrets
+        working-directory: frontend
+        run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Prefer the smallest coherent change. Do not redesign unrelated schemas or UI, cr
 
 Run the narrowest meaningful tests first, then the broader checks required by the affected code or repository CI. Do not weaken or skip checks to make a change pass.
 
-When safe, complete work through implementation, tests, pull request, exact-head CI, merge, issue close, cleanup, and production verification. Do not claim CI, deployment, production state, or cleanup unless directly verified.
+Treat **PR merge** and **product release** as separate decisions. Merge checks run on the pull request and must not require production credentials, production writes, or production deployment. Release checks run only after the change reaches `main` and cover production publication, deployment, exact-main-SHA verification, and production read-back. A release failure means the merged change is not yet released; do not retroactively redefine a passed PR merge check as failed.
 
-After merge, remove temporary files and superseded work when the available GitHub operations allow it. Report the repository, Issue or PR, commit, measurable change, tests, CI, files and lines changed, dependency or configuration changes, production verification, and remaining unverified items.
+When safe, complete work through implementation, tests, pull request, exact-head merge checks, merge, post-merge release, cleanup, and production verification. Do not claim CI, deployment, production state, or cleanup unless directly verified. If release is blocked after merge, report the product as **UNRELEASED/UNVERIFIED** and preserve the successful merge evidence separately.
+
+After merge, remove temporary files and superseded work when the available GitHub operations allow it. Report the repository, Issue or PR, commit, measurable change, merge-check evidence, release evidence, files and lines changed, dependency or configuration changes, production verification, and remaining unverified items.

--- a/docs/CURATED_GAME_FAST_PATH.md
+++ b/docs/CURATED_GAME_FAST_PATH.md
@@ -1,126 +1,100 @@
 # Adding a Curated Game
 
-This document describes the supported procedure for adding a source-backed game to ボドゲのミカタ.
+This is the supported procedure for adding or updating a source-backed game in ボドゲのミカタ.
 
-## Source file
+## Canonical source
 
-Create or update one Git-tracked source file:
+Create or update:
 
 `data/curated-games/<slug>.json`
 
-Then run:
+The filename, `spec.slug`, and routine `GAME` argument must match. The structured file owns repository-specific game identity, source provenance, catalog fields, reviewed guide data, and regression assertions. Do not copy official rulebooks or FAQ text into separate repository documents.
+
+Run:
 
 ```bash
 task game:add GAME=<slug>
 ```
 
-`GAME` is the routine input. `game:add` validates the structured source, checks the official source, performs a read-only production identity check, regenerates local generated files, and validates the runtime guide. It does not write the production catalog.
+This validates the source, checks the official source and live identity read-only, regenerates local generated artifacts, validates the runtime guide, and stops without a production write.
 
-The filename, `GAME`, and `spec.slug` must match.
+## PR merge conditions
 
-## Pull request and publication
+PR merge and product release are separate decisions.
 
-1. Create or update `data/curated-games/<slug>.json`.
-2. Run `task game:add GAME=<slug>`.
-3. Open one pull request containing the source JSON.
-4. GitHub Actions validates the pull request without production-write credentials.
-5. Merge to `main`.
-6. The same validation runs on the `main` push.
-7. `publish-catalog` identifies added or modified curated JSON files from the push.
-8. When a curated source changed, it obtains the production environment from Vercel and runs the internal publish command for those slugs.
-9. The publish command rechecks the primary source and live identity, performs an idempotent catalog write, and verifies the production API and page.
-10. After a successful Vercel deployment, release verification checks the deployed revision manifest.
+The pull request is evaluated only with checks that can run safely before merge:
 
-Production catalog data therefore cannot be published through this procedure before its source reaches `main`.
+- `Frontend PR build` builds the frontend without production secrets;
+- `Curated game PR checks` runs when curated-game paths change;
+- curated checks validate schema, assertions, source reachability, production identity read-only, generated artifacts, and runtime guide integration;
+- no PR job publishes catalog data, writes production data, or deploys production.
 
-## Validation order
+A curated source change is merge-ready when its applicable PR checks pass on the exact head and review requirements are satisfied. Production deployment state is not a PR merge condition.
 
-`task game:add GAME=<slug>`:
+## Product release conditions
 
-1. loads the structured source;
-2. validates schema, cross-field requirements, and assertions;
-3. verifies primary-source reachability;
-4. checks production `slug -> work -> edition/language` identity without writing;
-5. regenerates generated files;
-6. checks the generated deployment manifest against the source revision;
-7. validates the runtime guide returned by `getCuratedRuleGuide(slug)`;
-8. reports the expected pull-request files and stops without a database write.
+Release begins only after the change reaches `main`.
+
+Two release paths may run independently:
+
+1. `Curated game release` revalidates the merged source and publishes only changed curated games to the production catalog.
+2. `Vercel Deployment` builds/verifies the production application and ensures production reaches the intended `main` SHA when deployment capacity permits.
+
+`Curated game release verification` runs after successful completion of either release workflow and checks the actual production curated registry/catalog state. For a curated change, an early verification may fail while the other release path is still pending; the later release workflow triggers verification again.
+
+A merged change is **released** only when the production state required by that change is directly verified. If publication, deployment, quota, credentials, or production read-back fails after merge, the code remains merged but the product is **UNRELEASED/UNVERIFIED**. Do not reinterpret that as a failed PR merge check.
+
+## Validation performed before merge
+
+`task game:add GAME=<slug>` and `Curated game PR checks` cover the reusable pre-merge contract:
+
+1. load and validate the structured source;
+2. validate cross-field requirements and assertions;
+3. verify primary-source reachability;
+4. check live `slug -> work -> edition/language` identity without writing;
+5. regenerate generated files;
+6. validate generated revision consistency;
+7. validate `getCuratedRuleGuide(slug)` integration.
+
+Pull-request validation has no production database write step and does not require production deployment credentials.
 
 ## Publishing from `main`
 
-The internal command is:
+The internal publish command is:
 
 `curated_game_fast_path_v2.py publish --game <slug>`
 
-The GitHub Actions workflow is the supported caller. It is intentionally not exposed as the normal Taskfile command.
+`Curated game release` is the supported caller. It:
 
-Before writing, it repeats source reachability, production identity, generated-file validation, and runtime validation. If production identity changed between pull-request preparation and merge, publication stops rather than writing to a different work or edition.
+- runs only after a push to `main` on relevant paths;
+- re-runs focused source/runtime validation on the merged commit;
+- identifies added or modified `data/curated-games/<slug>.json` files from the main push;
+- rejects source deletion because removal requires an explicit deprecation change;
+- skips production environment setup when no game source changed;
+- loads trusted production Supabase credentials from the established Vercel production environment;
+- publishes only changed games;
+- rechecks source reachability and live identity before writing;
+- verifies catalog fixed points after publication;
+- does not itself request a Vercel deployment.
 
-`publish-catalog`:
+The production publication job uses `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`. Browser-safe anonymous/publishable keys are not substitutes.
 
-- runs only on pushes to `main`;
-- waits for curated-game validation;
-- publishes only changed curated source files;
-- ignores schema-only changes;
-- refuses source deletion because removal requires an explicit deprecation change;
-- skips environment setup when no game source changed;
-- uses `vercel pull --environment=production` for the established production environment;
-- does not request a Vercel deployment.
-
-## Credentials
-
-Pull-request validation has no production database write step.
-
-The main-only publication job uses:
-
-- `SUPABASE_URL`
-- `SUPABASE_SERVICE_ROLE_KEY`
-
-They are loaded from Vercel's production environment. Browser-safe anonymous or publishable keys are not substitutes for server credentials.
-
-## Pull request contents
-
-A normal game addition changes exactly one source file:
-
-`data/curated-games/<slug>.json`
-
-Do not commit game-specific generated JavaScript, deployment manifests, importer scripts, or separate test files. Put game-specific regression facts in the structured `assertions` array so generic tests can evaluate them.
-
-## Structured input
-
-`data/curated-games/schema-v1.json` defines the file format. Each game source contains:
-
-- `work`: work title and identity status;
-- `source`: HTTPS primary source, rule version, and source revision;
-- `game`: catalog fields including provenance;
-- `guide`: reviewed quick rules, scoring, and flow;
-- `assertions`: facts that generic validation must preserve.
-
-Validation also checks slug, source URL, source revision, and guide rule-version consistency.
-
-## Generated files
+## Generated artifacts
 
 `frontend/scripts/generate-curated-game-artifacts.mjs` generates:
 
 - `frontend/src/lib/generatedCuratedRuleGuides.js`
 - `frontend/public/curated-guides-manifest.json`
 
-Both outputs are gitignored. Do not commit or hand-edit them.
+Both are gitignored. Do not commit or hand-edit them. The Python workflow calls the Node generator rather than maintaining a second generator.
 
-Generation runs through:
-
-- `npm run dev` via `predev`;
-- `npm run build` via `prebuild`;
-- Vercel production and preview builds;
-- curated-game prepare, publish, check, and release verification.
-
-The Python command calls the Node generator rather than maintaining a second generator.
+A normal game addition should therefore contain the canonical source JSON, not game-specific generated JavaScript, deployment manifests, importers, or duplicate test files. Put game-specific regression facts in the structured `assertions` array when the generic schema can express them.
 
 ## Production verification
 
 After catalog publication, verify the production API and `/games/<slug>`.
 
-After Vercel deployment, verify `curated-guides-manifest.json` against the deployed commit and expected source revision.
+After application deployment, verify the deployed revision and `curated-guides-manifest.json`. Release verification also compares live API-visible curated fields with the canonical specs so a current frontend deployment cannot hide stale production game data.
 
 Manual diagnostics:
 
@@ -129,48 +103,18 @@ task game:verify GAME=<slug>
 task game:release-check
 ```
 
-A generic deployment failure does not undo a verified catalog publication and should not be repaired inside an unrelated game-content pull request.
-
-## CI
-
-The curated-game GitHub Actions workflow is path-scoped and does not require a browser for source-only changes. From a clean checkout it:
-
-- runs generic curated-game tests;
-- validates structured assertions;
-- regenerates generated files from source;
-- checks revision consistency;
-- validates runtime guide integration.
-
-On pull requests it stops after validation. On `main`, `publish-catalog` may obtain production credentials and publish changed game sources after validation succeeds.
-
-Do not make the full UI suite or an unrelated deployment request a prerequisite for a source-only catalog publication.
+A generic deployment failure does not undo a verified catalog publication. Conversely, a successful deployment does not prove catalog publication succeeded. Keep those release facts separate.
 
 ## Completion
 
-A curated game is released when:
+A curated game change is complete when:
 
-- its structured source is merged to `main`;
-- focused source, identity, and runtime checks pass;
-- publication rechecks the live source and identity;
+- applicable exact-head PR merge checks passed before merge;
+- the canonical source is merged to `main`;
+- main-only publication revalidated the live source and identity;
 - production contains the intended work and edition;
-- the production API and page are verified;
-- generated files are reproducible from source;
-- after deployment, the revision manifest matches the expected source revision.
+- production API/page behavior is verified;
+- generated artifacts are reproducible from source;
+- deployed revision verification passes when deployment is part of the change.
 
-## Scope
-
-During a game-addition task, do not:
-
-- write production data before merge;
-- repeat source research after a primary source and revision are established unless contradictory evidence appears;
-- repeat repository-wide searches after the relevant paths are known;
-- provide `SLUG`, `SOURCE_URL`, or `DATA` separately when they are already in the source file;
-- commit or hand-edit generated files;
-- create a game-specific regression test when structured assertions can express the requirement;
-- publish unchanged games on every `main` push;
-- silently delete a production game because its source JSON disappeared;
-- repair unrelated Vercel or CI infrastructure in the game-content branch;
-- create replacement branches or pull requests for the same task;
-- retry a failed job more than once without new evidence.
-
-After completion, remove repeatable deterministic work when doing so does not weaken source, identity, semantic, CI, merge, production, or cleanup checks.
+During this workflow, do not write production before merge, commit generated artifacts, create duplicate game-specific authorities, publish unchanged games on every push, silently delete production games, or repair unrelated release infrastructure inside a game-content change.


### PR DESCRIPTION
Closes #368

## Before
- `Vercel Deployment` mixed PR frontend build with production deployment/catch-up.
- `Curated game fast path` mixed PR validation with main-only production catalog publication.
- release verification could only follow the Vercel workflow.

## After
- `Frontend PR build`: pull-request-only frontend build, no production secrets/deploy.
- `Curated game PR checks`: pull-request-only curated validation, no production write.
- `Curated game release`: main-push-only revalidation + changed-game publication.
- `Vercel Deployment`: main/scheduled/manual release only; no pull_request trigger.
- `Curated game release verification`: follows either production release path and verifies actual production state.
- AGENTS.md and curated-game maintenance docs define merge-ready separately from released.

A post-merge release failure now means UNRELEASED/UNVERIFIED rather than retroactively failing the PR merge decision.