### PR TITLE
Reuse canonical ranking for directory search

### DIFF
--- a/backend/app/services/directory_query.py
+++ b/backend/app/services/directory_query.py
@@ -62,6 +62,40 @@ def _sort_key(game: dict[str, Any], sort: DirectorySort):
     return str(game.get("created_at") or "")
 
 
+def _filter_rows(
+    rows: list[dict[str, Any]],
+    *,
+    players: str | None,
+    time_filter: DirectoryTime | None,
+    tier: str | None,
+) -> list[dict[str, Any]]:
+    return [
+        game
+        for game in rows
+        if _matches_players(game, players)
+        and _matches_time(game, time_filter)
+        and (not tier or game.get("strategy_tier") == tier)
+    ]
+
+
+def _query_ranked_search_results(
+    rows: list[dict[str, Any]],
+    *,
+    players: str | None,
+    time_filter: DirectoryTime | None,
+    tier: str | None,
+    sort: DirectorySort,
+    limit: int,
+    offset: int,
+) -> dict[str, Any]:
+    """Filter canonical ranked search results without replacing relevance with recent order."""
+    filtered = _filter_rows(rows, players=players, time_filter=time_filter, tier=tier)
+    if sort != "recent":
+        reverse = sort == "year"
+        filtered.sort(key=lambda game: _sort_key(game, sort), reverse=reverse)
+    return {"data": filtered[offset : offset + limit], "total": len(filtered)}
+
+
 def _query_local(
     *,
     q: str | None,
@@ -97,10 +131,22 @@ async def list_directory_games(
     offset: int = 0,
 ) -> dict[str, Any]:
     """Return one filtered directory page without loading the full catalog into the browser."""
+    if q and q.strip():
+        ranked = await supabase.search(q.strip())
+        return _query_ranked_search_results(
+            ranked,
+            players=players,
+            time_filter=time_filter,
+            tier=tier,
+            sort=sort,
+            limit=limit,
+            offset=offset,
+        )
+
     if supabase.is_local():
         local_db.init_db()
         return _query_local(
-            q=q,
+            q=None,
             players=players,
             time_filter=time_filter,
             tier=tier,
@@ -111,21 +157,6 @@ async def list_directory_games(
 
     def _q() -> dict[str, Any]:
         query = supabase._get_client().table("games").select("*", count="exact")
-
-        if q and q.strip():
-            safe_query = q.strip().replace('"', '\\"')
-            term = f"*{safe_query}*"
-            query = query.or_(
-                ",".join(
-                    [
-                        f'title.ilike."{term}"',
-                        f'title_ja.ilike."{term}"',
-                        f'title_en.ilike."{term}"',
-                        f'summary.ilike."{term}"',
-                        f'description.ilike."{term}"',
-                    ]
-                )
-            )
 
         if players:
             if players == "5+":

--- a/backend/tests/test_directory_query.py
+++ b/backend/tests/test_directory_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.services import directory_query
 
 
@@ -91,3 +93,43 @@ def test_five_plus_filter_matches_games_that_support_at_least_five(monkeypatch):
 
     assert result["total"] == 1
     assert result["data"][0]["id"] == "five"
+
+
+def test_ranked_search_keeps_canonical_relevance_for_default_sort():
+    rows = [
+        _game("exact", title="Skull King", minimum=2, maximum=8, play_time=45, year=2013, created_at="2020-01-01"),
+        _game("summary", title="Pirate Tricks", minimum=2, maximum=4, play_time=30, year=2026, created_at="2026-01-01"),
+    ]
+
+    result = directory_query._query_ranked_search_results(
+        rows,
+        players=None,
+        time_filter=None,
+        tier=None,
+        sort="recent",
+        limit=48,
+        offset=0,
+    )
+
+    assert [game["id"] for game in result["data"]] == ["exact", "summary"]
+
+
+@pytest.mark.asyncio
+async def test_directory_query_reuses_canonical_search(monkeypatch):
+    ranked = [
+        _game("alias-hit", title="6 nimmt!", minimum=2, maximum=10, play_time=45, year=1994, created_at="2020-01-01"),
+        _game("other", title="11 nimmt!", minimum=2, maximum=7, play_time=30, year=2010, created_at="2026-01-01"),
+    ]
+    calls = []
+
+    async def fake_search(query):
+        calls.append(query)
+        return ranked
+
+    monkeypatch.setattr(directory_query.supabase, "search", fake_search)
+
+    result = await directory_query.list_directory_games(q="6 Nimmt", limit=1)
+
+    assert calls == ["6 Nimmt"]
+    assert result["total"] == 2
+    assert [game["id"] for game in result["data"]] == ["alias-hit"]


### PR DESCRIPTION
Refs #198

## Before
`/api/games?q=` implemented a second title/summary contains search and then used recent ordering, so the public directory did not inherit the existing canonical search's NFKC normalization, verified alias lookup, or exact-title-first ranking.

## After
- when `q` is present, the directory reuses existing `supabase.search()` as the single search authority;
- players/time/tier filters and pagination are applied to those ranked canonical results;
- the default `recent` sort no longer destroys relevance order during a search;
- explicit title/year/play-time sorts still work on the matched result set;
- no new search service, dependency, taxonomy, or index is added.

Tests cover preservation of canonical ranking and reuse of the canonical search path, including a `6 Nimmt` alias-style fixture.

Merge readiness is determined by exact-head PR checks. Production search behavior is a separate release verification.