### PR TITLE
Bind Terraforming Mars Dice identity to official product evidence

### DIFF
--- a/data/curated-games/terraforming-mars-the-dice-game.json
+++ b/data/curated-games/terraforming-mars-the-dice-game.json
@@ -34,6 +34,7 @@
     "generated_from_source_revision": "arclight-revised-2nd-printing-updated-2024-05-30-accessed-2026-08-16",
     "source_trust": "official_publisher",
     "identity_status": "verified",
+    "identity_source": "https://arclightgames.jp/product/826ter/",
     "content_review_status": "ai_draft"
   },
   "guide": {


### PR DESCRIPTION
Refs #264 and #206.

Before: `terraforming-mars-the-dice-game` is `identity_status=verified` but both curated source and production expose no `identity_source`.

After: bind identity provenance to the current Arclight official product page, which explicitly identifies the Japanese product and original title `Terraforming Mars: The Dice Game`, while keeping rule/content provenance on the separate revised-rulebook PDF.

This is a one-field curated-data change. No rule text, schema, workflow, dependency, or documentation change.