### PR TITLE
Bind Ponkotsu Paint identity to official evidence

### DIFF
--- a/data/curated-games/minna-de-ponkotsu-paint.json
+++ b/data/curated-games/minna-de-ponkotsu-paint.json
@@ -31,7 +31,8 @@
     "source_revision": "hobbyjapan-ponkotsu-paint-accessed-2026-08-20",
     "generated_from_source_revision": "hobbyjapan-ponkotsu-paint-accessed-2026-08-20",
     "source_trust": "official_publisher",
-    "identity_status": "verified"
+    "identity_status": "verified",
+    "identity_source": "https://hobbyjapan.games/ponkotsu_paint/"
   },
   "guide": {
     "reviewed": true,


### PR DESCRIPTION
Refs #264

## Before
`minna-de-ponkotsu-paint` was `identity_status=verified` but production exposed `identity_source=null`.

## After
Bind canonical identity provenance to the current Hobby Japan official product page. Rules/content provenance remains a separate field even though this official page supports both identity and the curated summary.

Primary evidence: https://hobbyjapan.games/ponkotsu_paint/

Expected change: one curated source file, one `identity_source` field. No schema, dependency, workflow, or documentation change.