### PR TITLE
Bind Slide identity evidence

### DIFF
--- a/data/curated-games/slide.json
+++ b/data/curated-games/slide.json
@@ -35,6 +35,7 @@
     "generated_from_source_revision": "gigamic-slide-rulebook-01-2024-attachment-548-accessed-2026-08-17",
     "source_trust": "official_publisher",
     "identity_status": "verified",
+    "identity_source": "https://en.gigamic.com/family-games/1211-slide.html",
     "content_review_status": "human_reviewed"
   },
   "guide": {


### PR DESCRIPTION
Refs #264. Add Gigamic's official Slide product page as `identity_source`; keep the rulebook as the separate rules source.