### PR TITLE
Bind Ipso verified identity to Gigamic evidence

### DIFF
--- a/data/curated-games/ipso.json
+++ b/data/curated-games/ipso.json
@@ -32,7 +32,8 @@
     "source_revision": "gigamic-ipso-rulebook-10-2025-attachment-668-accessed-2026-08-20",
     "generated_from_source_revision": "gigamic-ipso-rulebook-10-2025-attachment-668-accessed-2026-08-20",
     "source_trust": "official_publisher",
-    "identity_status": "verified"
+    "identity_status": "verified",
+    "identity_source": "https://www.gigamic.com/jeux-de-voyage/1425-ipso-3421276345317.html"
   },
   "guide": {
     "reviewed": true,


### PR DESCRIPTION
Refs #264.

Before: curated Ipso is `identity_status=verified` but has no identity-specific evidence pointer.

After: bind the current Gigamic IPSO product page as `identity_source`, while keeping the Gigamic rulebook attachment as the separate rules source.

Primary source: https://www.gigamic.com/jeux-de-voyage/1425-ipso-3421276345317.html

No schema, workflow, dependency, documentation, or rule-content changes.