### PR TITLE
Render open-ended player counts without inventing a maximum

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -39,6 +39,27 @@ def _page_title(game: dict, title: str) -> str:
     return f"「{title}」のルール{strategy_label}・インスト要約 | ボドゲのミカタ"
 
 
+def _player_count_projection(game: dict) -> tuple[dict[str, object] | None, str]:
+    min_players = game.get("min_players")
+    max_players = game.get("max_players")
+    if not min_players and not max_players:
+        return None, ""
+
+    quantitative_value: dict[str, object] = {"@type": "QuantitativeValue"}
+    if min_players:
+        quantitative_value["minValue"] = min_players
+    if max_players:
+        quantitative_value["maxValue"] = max_players
+
+    if min_players and max_players:
+        label = f"{min_players}人" if min_players == max_players else f"{min_players}-{max_players}人"
+    elif min_players:
+        label = f"{min_players}人以上"
+    else:
+        label = f"最大{max_players}人"
+    return quantitative_value, label
+
+
 async def generate_seo_html(slug: str) -> str | None:
     game = await get_by_slug(slug)
     if not game:
@@ -63,12 +84,9 @@ async def generate_seo_html(slug: str) -> str | None:
         "image": image_url,
         "url": game_url,
     }
-    if game.get("min_players") or game.get("max_players"):
-        structured_data["numberOfPlayers"] = {
-            "@type": "QuantitativeValue",
-            "minValue": game.get("min_players"),
-            "maxValue": game.get("max_players") or game.get("min_players"),
-        }
+    player_count, player_count_label = _player_count_projection(game)
+    if player_count:
+        structured_data["numberOfPlayers"] = player_count
     if game.get("min_age"):
         structured_data["audience"] = {
             "@type": "PeopleAudience",
@@ -155,12 +173,8 @@ async def generate_seo_html(slug: str) -> str | None:
     safe_summary = html.escape(str(game.get("summary") or ""))
     safe_rules = html.escape(str(game.get("rules_content") or "")[:2000])
     players_info = ""
-    if game.get("min_players"):
-        max_players = game.get("max_players") or game.get("min_players")
-        players_info = (
-            f"<p><strong>プレイ人数:</strong> {html.escape(str(game.get('min_players')))}-"
-            f"{html.escape(str(max_players))}人</p>"
-        )
+    if player_count_label:
+        players_info = f"<p><strong>プレイ人数:</strong> {html.escape(player_count_label)}</p>"
     time_info = ""
     if game.get("play_time"):
         time_info = f"<p><strong>プレイ時間:</strong> {html.escape(str(game.get('play_time')))}分</p>"

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -17,6 +17,13 @@ def test_page_title_includes_strategy_when_available() -> None:
     assert seo_renderer._page_title(game, "Example") == "「Example」のルール・戦略・インスト要約 | ボドゲのミカタ"
 
 
+def test_open_ended_player_count_does_not_invent_maximum() -> None:
+    structured, label = seo_renderer._player_count_projection({"min_players": 3, "max_players": None})
+
+    assert structured == {"@type": "QuantitativeValue", "minValue": 3}
+    assert label == "3人以上"
+
+
 @pytest.mark.asyncio
 async def test_missing_game_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     async def missing(_slug: str):


### PR DESCRIPTION
Refs #204.

Production validation after #378 exposed one remaining user-facing correctness bug: the official The Op metadata is `3+ Players`, so the curated record correctly has `min_players=3` and no invented maximum, but SSR/JSON-LD currently converts a missing maximum into `3-3人` / `maxValue: 3`.

This PR fixes only that projection:
- min + max -> existing range/exact rendering;
- min only -> `3人以上` and JSON-LD `minValue` only;
- max only -> `最大N人` and JSON-LD `maxValue` only.

No game data, schema, dependency, or release workflow changes. Adds one focused regression test for the open-ended case.