### PR TITLE
Show Pili Pili RuleSet context on GamePage

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -107,6 +107,7 @@ jobs:
           tests/text_to_speech.spec.js
           tests/source_links.spec.js
           tests/rule_ask.spec.js
+          tests/pili_pili_ruleset_context.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/components/game/RuleAskPanel.jsx
+++ b/frontend/src/components/game/RuleAskPanel.jsx
@@ -18,7 +18,7 @@ function ruleSetLabel(ruleset) {
   return ruleset.edition_label || ruleset.variant_label || ruleset.platform || ruleset.ruleset_id
 }
 
-export function RuleAskPanel() {
+export function RuleAskPanel({ game }) {
   const { slug } = useParams()
   const [question, setQuestion] = useState('')
   const [result, setResult] = useState(null)
@@ -27,13 +27,9 @@ export function RuleAskPanel() {
   useEffect(() => {
     let cancelled = false
 
-    Promise.all([
-      api.get(`/api/games/${slug}`),
-      api.get(`/api/games/${slug}/rule-sets`),
-    ])
-      .then(([gameResponse, rulesetResponse]) => {
+    api.get(`/api/games/${slug}/rule-sets`)
+      .then((rulesetResponse) => {
         if (cancelled || rulesetResponse?.status !== 'available' || !rulesetResponse.rulesets?.length) return
-        const game = Array.isArray(gameResponse) ? gameResponse[0] : gameResponse?.game || gameResponse
         const displayed = findDisplayedRuleSet(game, rulesetResponse.rulesets)
         setRuleSetContext({ displayed, rulesets: rulesetResponse.rulesets })
       })
@@ -42,7 +38,7 @@ export function RuleAskPanel() {
       })
 
     return () => { cancelled = true }
-  }, [slug])
+  }, [game, slug])
 
   const submit = (event) => {
     event.preventDefault()

--- a/frontend/src/components/game/RuleAskPanel.jsx
+++ b/frontend/src/components/game/RuleAskPanel.jsx
@@ -18,7 +18,7 @@ function ruleSetLabel(ruleset) {
   return ruleset.edition_label || ruleset.variant_label || ruleset.platform || ruleset.ruleset_id
 }
 
-export function RuleAskPanel({ game }) {
+export function RuleAskPanel() {
   const { slug } = useParams()
   const [question, setQuestion] = useState('')
   const [result, setResult] = useState(null)
@@ -27,9 +27,13 @@ export function RuleAskPanel({ game }) {
   useEffect(() => {
     let cancelled = false
 
-    api.get(`/api/games/${slug}/rule-sets`)
-      .then((rulesetResponse) => {
+    Promise.all([
+      api.get(`/api/games/${slug}`),
+      api.get(`/api/games/${slug}/rule-sets`),
+    ])
+      .then(([gameResponse, rulesetResponse]) => {
         if (cancelled || rulesetResponse?.status !== 'available' || !rulesetResponse.rulesets?.length) return
+        const game = Array.isArray(gameResponse) ? gameResponse[0] : gameResponse?.game || gameResponse
         const displayed = findDisplayedRuleSet(game, rulesetResponse.rulesets)
         setRuleSetContext({ displayed, rulesets: rulesetResponse.rulesets })
       })
@@ -38,7 +42,7 @@ export function RuleAskPanel({ game }) {
       })
 
     return () => { cancelled = true }
-  }, [game, slug])
+  }, [slug])
 
   const submit = (event) => {
     event.preventDefault()

--- a/frontend/src/components/game/RuleAskPanel.jsx
+++ b/frontend/src/components/game/RuleAskPanel.jsx
@@ -3,15 +3,31 @@ import { useParams } from 'react-router-dom'
 import { api } from '../../lib/api'
 import { askRule } from '../../lib/ruleAsk.js'
 
+function visibleRuleText(game) {
+  return `${game?.rules_content || ''} ${game?.setup_summary || ''} ${game?.gameplay_summary || ''} ${game?.end_game_summary || ''}`.toLowerCase()
+}
+
+function hasEditionBoundary(game) {
+  const text = visibleRuleText(game)
+  return [
+    'board game arena',
+    'bga',
+    'implementation',
+    '物理版',
+    '別版',
+    '版差',
+  ].some((marker) => text.includes(marker))
+}
+
 function findDisplayedRuleSet(game, rulesets) {
-  const visibleRuleText = `${game?.rules_content || ''} ${game?.setup_summary || ''} ${game?.gameplay_summary || ''} ${game?.end_game_summary || ''}`.toLowerCase()
-  if (!visibleRuleText) return null
+  const text = visibleRuleText(game)
+  if (!text) return null
 
   return rulesets.find((ruleset) => [
     ruleset.edition_label,
     ruleset.platform,
     ruleset.revision_label,
-  ].filter(Boolean).some((value) => visibleRuleText.includes(String(value).toLowerCase()))) || null
+  ].filter(Boolean).some((value) => text.includes(String(value).toLowerCase()))) || null
 }
 
 function ruleSetLabel(ruleset) {
@@ -27,13 +43,14 @@ export function RuleAskPanel() {
   useEffect(() => {
     let cancelled = false
 
-    Promise.all([
-      api.get(`/api/games/${slug}`),
-      api.get(`/api/games/${slug}/rule-sets`),
-    ])
-      .then(([gameResponse, rulesetResponse]) => {
-        if (cancelled || rulesetResponse?.status !== 'available' || !rulesetResponse.rulesets?.length) return
+    api.get(`/api/games/${slug}`)
+      .then(async (gameResponse) => {
         const game = Array.isArray(gameResponse) ? gameResponse[0] : gameResponse?.game || gameResponse
+        if (cancelled || !hasEditionBoundary(game)) return
+
+        const rulesetResponse = await api.get(`/api/games/${slug}/rule-sets`)
+        if (cancelled || rulesetResponse?.status !== 'available' || !rulesetResponse.rulesets?.length) return
+
         const displayed = findDisplayedRuleSet(game, rulesetResponse.rulesets)
         setRuleSetContext({ displayed, rulesets: rulesetResponse.rulesets })
       })

--- a/frontend/src/components/game/RuleAskPanel.jsx
+++ b/frontend/src/components/game/RuleAskPanel.jsx
@@ -1,11 +1,48 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
+import { api } from '../../lib/api'
 import { askRule } from '../../lib/ruleAsk.js'
+
+function findDisplayedRuleSet(game, rulesets) {
+  const visibleRuleText = `${game?.rules_content || ''} ${game?.setup_summary || ''} ${game?.gameplay_summary || ''} ${game?.end_game_summary || ''}`.toLowerCase()
+  if (!visibleRuleText) return null
+
+  return rulesets.find((ruleset) => [
+    ruleset.edition_label,
+    ruleset.platform,
+    ruleset.revision_label,
+  ].filter(Boolean).some((value) => visibleRuleText.includes(String(value).toLowerCase()))) || null
+}
+
+function ruleSetLabel(ruleset) {
+  return ruleset.edition_label || ruleset.variant_label || ruleset.platform || ruleset.ruleset_id
+}
 
 export function RuleAskPanel() {
   const { slug } = useParams()
   const [question, setQuestion] = useState('')
   const [result, setResult] = useState(null)
+  const [ruleSetContext, setRuleSetContext] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    Promise.all([
+      api.get(`/api/games/${slug}`),
+      api.get(`/api/games/${slug}/rule-sets`),
+    ])
+      .then(([gameResponse, rulesetResponse]) => {
+        if (cancelled || rulesetResponse?.status !== 'available' || !rulesetResponse.rulesets?.length) return
+        const game = Array.isArray(gameResponse) ? gameResponse[0] : gameResponse?.game || gameResponse
+        const displayed = findDisplayedRuleSet(game, rulesetResponse.rulesets)
+        setRuleSetContext({ displayed, rulesets: rulesetResponse.rulesets })
+      })
+      .catch(() => {
+        if (!cancelled) setRuleSetContext(null)
+      })
+
+    return () => { cancelled = true }
+  }, [slug])
 
   const submit = (event) => {
     event.preventDefault()
@@ -14,6 +51,32 @@ export function RuleAskPanel() {
 
   return (
     <section className="pro-card" aria-labelledby="rule-ask-title">
+      {ruleSetContext?.rulesets?.length > 1 && (
+        <div className="game-empty-note" aria-label="RuleSet context" style={{ marginBottom: '1rem' }}>
+          <strong>表示中のルール版:</strong>{' '}
+          {ruleSetContext.displayed ? (
+            <>
+              {ruleSetLabel(ruleSetContext.displayed)}
+              {ruleSetContext.displayed.platform ? ` · ${ruleSetContext.displayed.platform}` : ''}
+              {ruleSetContext.displayed.language_code ? ` · ${ruleSetContext.displayed.language_code}` : ''}
+              {ruleSetContext.displayed.revision_label ? ` · ${ruleSetContext.displayed.revision_label}` : ''}
+              {` · ${ruleSetContext.displayed.verification_status}`}
+            </>
+          ) : (
+            '既存本文とRuleSetの対応を確認できません'
+          )}
+          <div style={{ marginTop: '0.5rem' }}>
+            別版: {ruleSetContext.rulesets
+              .filter((ruleset) => ruleset.ruleset_id !== ruleSetContext.displayed?.ruleset_id)
+              .map((ruleset) => `${ruleSetLabel(ruleset)}${ruleset.platform ? ` · ${ruleset.platform}` : ''}${ruleset.language_code ? ` · ${ruleset.language_code}` : ''} · ${ruleset.verification_status}`)
+              .join(' / ')}
+          </div>
+          <div style={{ marginTop: '0.5rem' }}>
+            版ごとのRuleSetは分離されています。別版の情報を現在表示中の本文へ自動的に混ぜません。
+          </div>
+        </div>
+      )}
+
       <div className="pro-card-title" id="rule-ask-title">ルールを質問</div>
       <p className="summary-text">
         確認済みの公式ルール根拠だけから回答します。回答は登録済み要約で、公式本文そのものではありません。

--- a/frontend/tests/pili_pili_ruleset_context.spec.js
+++ b/frontend/tests/pili_pili_ruleset_context.spec.js
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+
+const piliPili = {
+  id: 'game-pili-pili',
+  slug: 'pili-pili',
+  title: 'Pili Pili',
+  title_ja: 'ピリピリ',
+  summary: '予想型トリックテイキング。',
+  description: 'Pili Pili',
+  rules_content: 'このページは Board Game Arena（BGA）実装 を基準にしています。',
+  setup_summary: 'BGA版の準備',
+  gameplay_summary: 'BGA版の流れ',
+  end_game_summary: 'BGA版では誰かが6ピリで終了',
+  structured_data: {},
+  source_url: 'https://atmgaming.com/product/pili-pili',
+  source_trust: 'official_publisher',
+  content_review_status: 'review_required',
+  identity_status: 'verified',
+}
+
+const ruleSets = {
+  schema_version: '1.0',
+  status: 'available',
+  game_id: piliPili.id,
+  slug: piliPili.slug,
+  rulesets: [
+    {
+      ruleset_id: 'bga-ruleset',
+      game_id: piliPili.id,
+      version: 1,
+      schema_version: '1.0',
+      language_code: 'ja',
+      edition_label: 'BGA implementation',
+      revision_label: '260623-1715',
+      source_revision: 'Board Game Arena Release 260623-1715',
+      platform: 'Board Game Arena',
+      publisher_name: 'ATM Gaming',
+      status: 'active',
+      verification_status: 'source_bound',
+      is_active: true,
+      source_ids: ['bga:pili-pili:260623-1715'],
+    },
+    {
+      ruleset_id: 'physical-ruleset',
+      game_id: piliPili.id,
+      version: 1,
+      schema_version: '1.0',
+      language_code: 'fr',
+      edition_label: 'ATM Gaming physical product',
+      platform: 'physical',
+      publisher_name: 'ATM Gaming',
+      status: 'active',
+      verification_status: 'source_bound',
+      is_active: true,
+      source_ids: ['publisher:atm:pili-pili:current'],
+    },
+  ],
+}
+
+test('Pili Pili identifies the displayed BGA RuleSet without merging the physical edition', async ({ page }) => {
+  await page.route('**/api/games/pili-pili/rule-sets', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(ruleSets),
+  }))
+  await page.route('**/api/games/pili-pili', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(piliPili),
+  }))
+  await page.route('**/api/games/pili-pili/glossary**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ status: 'not_available', concepts: [] }),
+  }))
+
+  await page.goto('/games/pili-pili')
+
+  const context = page.getByLabel('RuleSet context')
+  await expect(context).toContainText('表示中のルール版: BGA implementation · Board Game Arena · ja · 260623-1715 · source_bound')
+  await expect(context).toContainText('別版: ATM Gaming physical product · physical · fr · source_bound')
+  await expect(context).toContainText('別版の情報を現在表示中の本文へ自動的に混ぜません')
+})


### PR DESCRIPTION
Refs #202.

Before: production stores separate physical and BGA RuleSets, but GamePage exposes a single legacy rules body without identifying which RuleSet it represents.

After: the existing rule-help surface reads the canonical `/rule-sets` API, matches the visible legacy rule text to its RuleSet metadata, and shows the displayed edition/platform/language/revision plus other available RuleSets. It explicitly states that alternate-edition information is not merged into the visible body.

For Pili Pili this identifies the displayed rules as `BGA implementation / Board Game Arena / ja / 260623-1715` and keeps `ATM Gaming physical product / physical / fr` separate.

No new schema, dependency, or rule authority. Includes a Playwright regression fixture for the physical/BGA boundary.