### PR TITLE
Keep Pili Pili rule answers inside the selected RuleSet

### DIFF
--- a/frontend/src/components/game/RuleAskPanel.jsx
+++ b/frontend/src/components/game/RuleAskPanel.jsx
@@ -34,11 +34,21 @@ function ruleSetLabel(ruleset) {
   return ruleset.edition_label || ruleset.variant_label || ruleset.platform || ruleset.ruleset_id
 }
 
+function ruleSetOptionLabel(ruleset) {
+  return [
+    ruleSetLabel(ruleset),
+    ruleset.platform,
+    ruleset.language_code,
+    ruleset.revision_label,
+  ].filter(Boolean).join(' · ')
+}
+
 export function RuleAskPanel() {
   const { slug } = useParams()
   const [question, setQuestion] = useState('')
   const [result, setResult] = useState(null)
   const [ruleSetContext, setRuleSetContext] = useState(null)
+  const [selectedRuleSetId, setSelectedRuleSetId] = useState(null)
 
   useEffect(() => {
     let cancelled = false
@@ -53,16 +63,28 @@ export function RuleAskPanel() {
 
         const displayed = findDisplayedRuleSet(game, rulesetResponse.rulesets)
         setRuleSetContext({ displayed, rulesets: rulesetResponse.rulesets })
+        setSelectedRuleSetId(displayed?.ruleset_id || rulesetResponse.rulesets[0].ruleset_id)
       })
       .catch(() => {
-        if (!cancelled) setRuleSetContext(null)
+        if (!cancelled) {
+          setRuleSetContext(null)
+          setSelectedRuleSetId(null)
+        }
       })
 
     return () => { cancelled = true }
   }, [slug])
 
+  const selectedRuleSet = ruleSetContext?.rulesets?.find(
+    (ruleset) => ruleset.ruleset_id === selectedRuleSetId,
+  ) || null
+  const selectedUsesDisplayedProjection = Boolean(
+    !ruleSetContext?.displayed || selectedRuleSetId === ruleSetContext.displayed.ruleset_id,
+  )
+
   const submit = (event) => {
     event.preventDefault()
+    if (!selectedUsesDisplayedProjection) return
     setResult(askRule(slug, question))
   }
 
@@ -70,33 +92,37 @@ export function RuleAskPanel() {
     <section className="pro-card" aria-labelledby="rule-ask-title">
       {ruleSetContext?.rulesets?.length > 1 && (
         <div className="game-empty-note" aria-label="RuleSet context" style={{ marginBottom: '1rem' }}>
-          <strong>表示中のルール版:</strong>{' '}
-          {ruleSetContext.displayed ? (
-            <>
-              {ruleSetLabel(ruleSetContext.displayed)}
-              {ruleSetContext.displayed.platform ? ` · ${ruleSetContext.displayed.platform}` : ''}
-              {ruleSetContext.displayed.language_code ? ` · ${ruleSetContext.displayed.language_code}` : ''}
-              {ruleSetContext.displayed.revision_label ? ` · ${ruleSetContext.displayed.revision_label}` : ''}
-              {` · ${ruleSetContext.displayed.verification_status}`}
-            </>
-          ) : (
-            '既存本文とRuleSetの対応を確認できません'
+          <label htmlFor="rule-set-select"><strong>確認するルール版:</strong></label>{' '}
+          <select
+            id="rule-set-select"
+            value={selectedRuleSetId || ''}
+            onChange={(event) => {
+              setSelectedRuleSetId(event.target.value)
+              setResult(null)
+            }}
+          >
+            {ruleSetContext.rulesets.map((ruleset) => (
+              <option key={ruleset.ruleset_id} value={ruleset.ruleset_id}>
+                {ruleSetOptionLabel(ruleset)}
+              </option>
+            ))}
+          </select>
+          <div style={{ marginTop: '0.5rem' }}>
+            表示中の本文: {ruleSetContext.displayed
+              ? `${ruleSetOptionLabel(ruleSetContext.displayed)} · ${ruleSetContext.displayed.verification_status}`
+              : '既存本文とRuleSetの対応を確認できません'}
+          </div>
+          {selectedRuleSet && !selectedUsesDisplayedProjection && (
+            <div role="status" style={{ marginTop: '0.5rem' }}>
+              {ruleSetOptionLabel(selectedRuleSet)} の質問回答用projectionは未整備です。別版の登録済み回答を流用しません。
+            </div>
           )}
-          <div style={{ marginTop: '0.5rem' }}>
-            別版: {ruleSetContext.rulesets
-              .filter((ruleset) => ruleset.ruleset_id !== ruleSetContext.displayed?.ruleset_id)
-              .map((ruleset) => `${ruleSetLabel(ruleset)}${ruleset.platform ? ` · ${ruleset.platform}` : ''}${ruleset.language_code ? ` · ${ruleset.language_code}` : ''} · ${ruleset.verification_status}`)
-              .join(' / ')}
-          </div>
-          <div style={{ marginTop: '0.5rem' }}>
-            版ごとのRuleSetは分離されています。別版の情報を現在表示中の本文へ自動的に混ぜません。
-          </div>
         </div>
       )}
 
       <div className="pro-card-title" id="rule-ask-title">ルールを質問</div>
       <p className="summary-text">
-        確認済みの公式ルール根拠だけから回答します。回答は登録済み要約で、公式本文そのものではありません。
+        確認済みの登録済みルール根拠だけから回答します。回答は要約で、公式本文そのものではありません。
       </p>
       <form onSubmit={submit}>
         <label htmlFor="rule-question" className="sr-only">ルールの質問</label>
@@ -108,8 +134,14 @@ export function RuleAskPanel() {
           maxLength={200}
           placeholder="例: 同点ならどうなる？"
           onChange={(event) => setQuestion(event.target.value)}
+          disabled={!selectedUsesDisplayedProjection}
         />
-        <button type="submit" className="filter-btn" disabled={!question.trim()} style={{ marginTop: '0.75rem' }}>
+        <button
+          type="submit"
+          className="filter-btn"
+          disabled={!question.trim() || !selectedUsesDisplayedProjection}
+          style={{ marginTop: '0.75rem' }}
+        >
           根拠付きで確認
         </button>
       </form>

--- a/frontend/tests/pili_pili_ruleset_context.spec.js
+++ b/frontend/tests/pili_pili_ruleset_context.spec.js
@@ -12,8 +12,8 @@ const piliPili = {
   gameplay_summary: 'BGA版の流れ',
   end_game_summary: 'BGA版では誰かが6ピリで終了',
   structured_data: {},
-  source_url: 'https://atmgaming.com/product/pili-pili',
-  source_trust: 'official_publisher',
+  source_url: 'https://ja.boardgamearena.com/gamepanel?game=pilipili',
+  source_trust: 'authorized_partner',
   content_review_status: 'review_required',
   identity_status: 'verified',
 }
@@ -57,7 +57,7 @@ const ruleSets = {
   ],
 }
 
-test('Pili Pili identifies the displayed BGA RuleSet without merging the physical edition', async ({ page }) => {
+test('Pili Pili rule questions stay inside the selected RuleSet', async ({ page }) => {
   await page.route('**/api/games/pili-pili/rule-sets', route => route.fulfill({
     status: 200,
     contentType: 'application/json',
@@ -77,7 +77,21 @@ test('Pili Pili identifies the displayed BGA RuleSet without merging the physica
   await page.goto('/games/pili-pili')
 
   const context = page.getByLabel('RuleSet context')
-  await expect(context).toContainText('表示中のルール版: BGA implementation · Board Game Arena · ja · 260623-1715 · source_bound')
-  await expect(context).toContainText('別版: ATM Gaming physical product · physical · fr · source_bound')
-  await expect(context).toContainText('別版の情報を現在表示中の本文へ自動的に混ぜません')
+  const selector = page.getByLabel('確認するルール版:')
+  const question = page.getByLabel('ルールの質問')
+  const submit = page.getByRole('button', { name: '根拠付きで確認' })
+
+  await expect(selector).toHaveValue('bga-ruleset')
+  await expect(context).toContainText('表示中の本文: BGA implementation · Board Game Arena · ja · 260623-1715 · source_bound')
+  await expect(question).toBeEnabled()
+
+  await selector.selectOption('physical-ruleset')
+
+  await expect(context).toContainText('ATM Gaming physical product · physical · fr の質問回答用projectionは未整備です')
+  await expect(context).toContainText('別版の登録済み回答を流用しません')
+  await expect(question).toBeDisabled()
+  await expect(submit).toBeDisabled()
+
+  await selector.selectOption('bga-ruleset')
+  await expect(question).toBeEnabled()
 })


### PR DESCRIPTION
Refs #202

Before: Pili Pili exposed the BGA/physical RuleSet boundary, but the rule-question control still answered from the registered BGA projection regardless of which edition a player intended to check.

After:
- reuse the existing `/rule-sets` response as an actual edition selector;
- default to the RuleSet matched by the currently displayed legacy text;
- keep the existing registered answer path available only for that matched RuleSet;
- when another RuleSet is selected and no dedicated answer projection exists, fail closed and state that the other edition's answer will not be reused;
- extend the existing Pili Pili Playwright regression rather than adding a new test/workflow.

No rule facts, schema, dependency, workflow, or production data are changed. This is a presentation correctness fix: it prevents a BGA answer from being presented as the ATM Gaming physical edition.