### PR TITLE
Render source-bound canonical rules in GamePage SSR

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 
 from app.core.supabase import get_by_slug
+from app.services.presentation_projection import PresentationProjectionReadError, PresentationProjectionService
+from app.services.rulesets import RuleSetService
 from app.services.search_visibility import should_hide_game_from_search
 
 logger = logging.getLogger(__name__)
@@ -58,6 +60,49 @@ def _player_count_projection(game: dict) -> tuple[dict[str, object] | None, str]
     else:
         label = f"最大{max_players}人"
     return quantitative_value, label
+
+
+def _render_projection_rules(projection) -> str | None:
+    sections = (
+        ("セットアップ", projection.setup),
+        ("ゲーム進行", projection.game_flow),
+        ("終了条件・勝利", projection.end_condition),
+        ("得点", projection.scoring),
+    )
+    rendered: list[str] = []
+    for label, section in sections:
+        if not section.items:
+            continue
+        rendered.append(f"## {label}\n" + "\n".join(f"- {item.text}" for item in section.items))
+    return "\n\n".join(rendered) or None
+
+
+async def _canonical_rule_text(slug: str) -> str | None:
+    rulesets = await RuleSetService().get_by_slug(slug)
+    if not rulesets or rulesets.status != "available":
+        return None
+
+    candidates = [
+        ruleset
+        for ruleset in rulesets.rulesets
+        if ruleset.is_active and ruleset.verification_status == "source_bound"
+    ]
+    for ruleset in candidates:
+        try:
+            projection = await PresentationProjectionService().get_by_slug(
+                slug,
+                rule_set_id=ruleset.ruleset_id,
+                language_code=ruleset.language_code or "ja",
+            )
+        except PresentationProjectionReadError:
+            logger.exception("Canonical SSR projection failed for %s/%s", slug, ruleset.ruleset_id)
+            continue
+        if projection is None or projection.status != "available":
+            continue
+        rendered = _render_projection_rules(projection)
+        if rendered:
+            return rendered
+    return None
 
 
 async def generate_seo_html(slug: str) -> str | None:
@@ -171,7 +216,13 @@ async def generate_seo_html(slug: str) -> str | None:
 
     safe_title = html.escape(title)
     safe_summary = html.escape(str(game.get("summary") or ""))
-    safe_rules = html.escape(str(game.get("rules_content") or "")[:2000])
+    canonical_rules = await _canonical_rule_text(slug)
+    if canonical_rules:
+        safe_rules = html.escape(canonical_rules)
+        rules_heading = "出典付きルール要約"
+    else:
+        safe_rules = html.escape(str(game.get("rules_content") or "")[:2000])
+        rules_heading = "ルール"
     players_info = ""
     if player_count_label:
         players_info = f"<p><strong>プレイ人数:</strong> {html.escape(player_count_label)}</p>"
@@ -198,7 +249,7 @@ async def generate_seo_html(slug: str) -> str | None:
       {time_info}
     </section>
     <section>
-      <h2>ルール</h2>
+      <h2>{rules_heading}</h2>
       <pre itemprop="text">{safe_rules}</pre>
     </section>
   </article>

--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -78,7 +78,11 @@ def _render_projection_rules(projection) -> str | None:
 
 
 async def _canonical_rule_text(slug: str) -> str | None:
-    rulesets = await RuleSetService().get_by_slug(slug)
+    try:
+        rulesets = await RuleSetService().get_by_slug(slug)
+    except Exception:
+        logger.exception("Canonical SSR RuleSet lookup failed for %s; using legacy fallback", slug)
+        return None
     if not rulesets or rulesets.status != "available":
         return None
 

--- a/backend/tests/test_seo_renderer_canonical_rules.py
+++ b/backend/tests/test_seo_renderer_canonical_rules.py
@@ -1,0 +1,28 @@
+from types import SimpleNamespace
+
+from app.services.seo_renderer import _render_projection_rules
+
+
+def _section(*texts: str):
+    return SimpleNamespace(items=[SimpleNamespace(text=text) for text in texts])
+
+
+def test_render_projection_rules_keeps_player_facing_sections():
+    projection = SimpleNamespace(
+        setup=_section("setup rule"),
+        game_flow=_section("flow rule one", "flow rule two"),
+        end_condition=_section("end rule"),
+        scoring=_section(),
+    )
+
+    rendered = _render_projection_rules(projection)
+
+    assert rendered is not None
+    assert "## セットアップ" in rendered
+    assert "- setup rule" in rendered
+    assert "## ゲーム進行" in rendered
+    assert "- flow rule one" in rendered
+    assert "- flow rule two" in rendered
+    assert "## 終了条件・勝利" in rendered
+    assert "- end rule" in rendered
+    assert "## 得点" not in rendered


### PR DESCRIPTION
## Player-facing success condition
For Splendor production, `/games/splendor` must render the canonical source-bound Presentation Projection instead of `games.rules_content`, while preserving setup, turn/actions, token limit, nobles, game-end and tiebreak coverage.

## Before
- Production deployment is current at main `0a87c09e1e158a69f9513192526d1f7deb378615`.
- Production DB migration 025 is now applied and `/api/games/splendor/rule-sets` returns an active source-bound 2024 Japanese revised RuleSet.
- `/api/games/splendor/presentation` is `available` with 14 accepted+supported projected rules.
- SSR `/games/splendor` still reads legacy `games.rules_content` in `seo_renderer.py`.

## Change
- Prefer active `verification_status=source_bound` RuleSets for SSR.
- Render only the canonical Presentation Projection sections (setup, game flow, end/victory, scoring) when available.
- Keep the existing legacy text only as a fail-closed fallback for games without a usable canonical projection.
- Label canonical content `出典付きルール要約` so normalized summaries are not presented as verbatim official rule text.
- Add a regression test for projection section rendering.

## Evidence boundary
The Splendor RuleSet is scoped to Hobby Japan Japanese revised edition (2024) plus the SPACE Cowboys/Asmodee 2024 refreshed base rulebook. 2015 edition, Duel, expansions and tournament rules remain excluded.

Refs #388.