### PR TITLE
Align Catan 2026 play time with GP Games

### DIFF
--- a/backend/app/db/migrations/027_align_catan_2026_play_time.sql
+++ b/backend/app/db/migrations/027_align_catan_2026_play_time.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- Align the production metadata with the GP Games Japanese 2026 renewed
+-- Standard Edition. Do not reuse this value for older Japanese editions.
+DO $$
+DECLARE
+  v_updated integer;
+BEGIN
+  UPDATE public.games
+  SET
+    play_time = 60,
+    updated_at = now()
+  WHERE slug = 'catan'
+    AND identity_status = 'verified'
+    AND identity_source = 'https://www.gp-inc.jp/boardgame_catan_new_s.html'
+    AND edition_label = 'GP Games 日本語版 スタンダード版 (2026リニューアル)';
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  IF v_updated <> 1 THEN
+    RAISE EXCEPTION 'Expected exactly one verified GP Games 2026 Catan row, updated %', v_updated;
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Refs #388.

Player-facing success condition: `/games/catan` shows the GP Games 2026 renewed Japanese Standard Edition play time as about 60 minutes, matching the official product page, while retaining the source-backed canonical rules introduced by #391.

Production read-back after #391 showed a stale legacy value of 75 minutes even though the identity is now bound to GP Games' 2026 renewed Standard Edition. This migration updates only the verified row with the exact GP Games identity source and edition label and fails unless exactly one row matches.

Official source: https://www.gp-inc.jp/boardgame_catan_new_s.html (3-4 players, age 8+, play time about 60 minutes, JAN 4543471004512).

Production application remains separate from merge/CI and must be verified by direct GamePage read-back.