### PR TITLE
Restore GamePage detailed rules read contract

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -37,11 +37,24 @@ class KeyElement(BaseSchema):
     reason: str
 
 
+class PersonaReview(BaseSchema):
+    persona: str
+    review_text: str
+    rating: float
+
+
 class StructuredData(BaseSchema):
     keywords: list[Keyword] = []
     key_elements: list[KeyElement] = []
     mechanics: list[str] = []
     best_player_count: str | None = None
+
+
+class GamePageStructuredData(StructuredData):
+    pro_tips: list[str] = []
+    rule_mistakes: list[str] = []
+    strategy_analysis: str | None = None
+    persona_reviews: list[PersonaReview] = []
 
 
 class GameDetail(BaseSchema):
@@ -78,6 +91,17 @@ class GameDetail(BaseSchema):
     updated_at: str | None = None
 
     _validate_bga_url = field_validator("bga_url")(validate_bga_url)
+
+
+class GamePageDetail(GameDetail):
+    """Player-facing detail fields retained until canonical presentation covers the catalog."""
+
+    rules_content: str | None = None
+    setup_summary: str | None = None
+    gameplay_summary: str | None = None
+    end_game_summary: str | None = None
+    structured_data: GamePageStructuredData | None = None
+    infographics: dict[str, str] | None = None
 
 
 class GameUpdate(BaseSchema):

--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import ValidationError
 
 from app.core.rate_limiter import RateLimiter
-from app.models import GameDetail, GameListResponse, GameUpdate
+from app.models import GameDetail, GameListResponse, GamePageDetail, GameUpdate
 from app.models.component_catalog import (
     ComponentDetailResponse,
     ComponentKind,
@@ -244,7 +244,7 @@ async def get_game_rule_graph(
     return graph
 
 
-@router.get("/games/{slug}", response_model=GameDetail)
+@router.get("/games/{slug}", response_model=GamePageDetail)
 async def get_game_details(slug: str, service: GameService = Depends(get_game_service)):
     if should_return_gone(slug):
         raise HTTPException(status_code=status.HTTP_410_GONE, detail="Game record retired after identity repair")

--- a/backend/tests/test_gamepage_detail_contract.py
+++ b/backend/tests/test_gamepage_detail_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from app.models import GamePageDetail
+
+
+def test_gamepage_detail_schema_covers_fields_consumed_by_frontend():
+    source = Path("frontend/src/pages/GamePage.jsx").read_text(encoding="utf-8")
+    required_fields = {
+        "rules_content",
+        "setup_summary",
+        "gameplay_summary",
+        "end_game_summary",
+        "structured_data",
+    }
+
+    model_fields = set(GamePageDetail.model_fields)
+    assert required_fields <= model_fields
+    for field in required_fields - {"structured_data"}:
+        assert f"game.{field}" in source

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -24,7 +24,28 @@ class PublicReadService:
         return [{"id": "game-1", "slug": "example", "title": "Example", "work_id": "work-1"}]
 
     async def get_game_by_slug(self, slug: str):
-        return {"id": "game-1", "slug": slug, "title": "Example", "work_id": "work-1"}
+        return {
+            "id": "game-1",
+            "slug": slug,
+            "title": "Example",
+            "work_id": "work-1",
+            "rules_content": "# Example\n\nDetailed player-facing rules.",
+            "setup_summary": "Set up the example.",
+            "gameplay_summary": "Take turns.",
+            "end_game_summary": "Finish the example.",
+            "structured_data": {
+                "keywords": [],
+                "key_elements": [],
+                "mechanics": [],
+                "best_player_count": None,
+                "strategy_analysis": "Example strategy.",
+                "persona_reviews": [
+                    {"persona": "planner", "review_text": "Readable rules matter.", "rating": 8.0}
+                ],
+                "pro_tips": ["Example tip."],
+                "rule_mistakes": ["Example mistake."],
+            },
+        }
 
 
 def _app_with_service(service):
@@ -40,6 +61,24 @@ def test_missing_game_slug_returns_404_instead_of_response_validation_500():
 
     assert response.status_code == 404
     assert response.json() == {"detail": "Game not found"}
+
+
+def test_game_detail_preserves_player_facing_rule_fields_without_bloating_search():
+    client = TestClient(_app_with_service(PublicReadService()))
+
+    detail = client.get("/api/games/example")
+    assert detail.status_code == 200
+    payload = detail.json()
+    assert payload["rules_content"] == "# Example\n\nDetailed player-facing rules."
+    assert payload["setup_summary"] == "Set up the example."
+    assert payload["gameplay_summary"] == "Take turns."
+    assert payload["end_game_summary"] == "Finish the example."
+    assert payload["structured_data"]["strategy_analysis"] == "Example strategy."
+    assert payload["structured_data"]["persona_reviews"][0]["persona"] == "planner"
+
+    search = client.get("/api/search?q=example")
+    assert search.status_code == 200
+    assert "rules_content" not in search.json()[0]
 
 
 def test_catalog_patch_requires_authentication_before_mutation():


### PR DESCRIPTION
## Player-facing success condition
`/games/terraforming-mars-the-dice-game` and every other game with stored `rules_content` must show the detailed-rules view again, while `/api/search` and `/api/games` remain lean and do not carry full rule text.

## Root cause
Commit `dc626336a72566c2ce456af6a911eaa3f2f2d942` (#387) removed `rules_content` and other GamePage fields from the public `GameDetail` response model. `frontend/src/pages/GamePage.jsx` still reads `game.rules_content`, setup/gameplay/end summaries, and secondary-view structured fields. FastAPI/Pydantic therefore filtered those values from `GET /api/games/{slug}` even though the database rows still contained them.

## Fix
- add a detail-only `GamePageDetail` response model containing the fields the current GamePage consumes
- keep search/list on the smaller `GameDetail` model
- restore nested strategy/review/tip fields consumed by the detail page
- add route regression coverage proving detailed rule text survives the detail response but is absent from search results
- add a direct frontend/backend contract guard for the fields consumed by `GamePage.jsx`

This does not restore generation endpoints or mutation compatibility. It only restores the read contract required by the current player-facing UI until canonical Presentation coverage can replace it safely.

Refs #386.