### PR TITLE
Keep canonical rules in restored GamePage detail view

### DIFF
--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -28,6 +28,7 @@ from app.services.game_service import GameIdentityConflictError, GameService
 from app.services.rule_graph import RuleGraphService
 from app.services.rulesets import RuleSetService
 from app.services.search_visibility import has_known_identity_conflict, should_return_gone
+from app.services.seo_renderer import _canonical_rule_text
 
 router = APIRouter()
 search_limiter = RateLimiter.get_limiter("search", max_requests=100, window_seconds=60)
@@ -251,6 +252,9 @@ async def get_game_details(slug: str, service: GameService = Depends(get_game_se
     game = await service.get_game_by_slug(slug)
     if not game:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
+    canonical_rules = await _canonical_rule_text(slug)
+    if canonical_rules:
+        game = {**game, "rules_content": canonical_rules}
     return game
 
 

--- a/backend/tests/test_gamepage_canonical_detail.py
+++ b/backend/tests/test_gamepage_canonical_detail.py
@@ -1,0 +1,46 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import games
+
+
+class LegacyBackedGameService:
+    async def get_game_by_slug(self, slug: str):
+        return {
+            "id": "game-1",
+            "slug": slug,
+            "title": "Example",
+            "work_id": "work-1",
+            "rules_content": "legacy rule text",
+        }
+
+
+def test_detail_api_prefers_canonical_projection_over_legacy_rules(monkeypatch):
+    async def canonical_rule_text(slug: str):
+        assert slug == "example"
+        return "## セットアップ\n- source-backed canonical rule"
+
+    monkeypatch.setattr(games, "_canonical_rule_text", canonical_rule_text)
+    app = FastAPI()
+    app.include_router(games.router, prefix="/api")
+    app.dependency_overrides[games.get_game_service] = lambda: LegacyBackedGameService()
+
+    response = TestClient(app).get("/api/games/example")
+
+    assert response.status_code == 200
+    assert response.json()["rules_content"] == "## セットアップ\n- source-backed canonical rule"
+
+
+def test_detail_api_keeps_legacy_rules_when_canonical_projection_is_unavailable(monkeypatch):
+    async def canonical_rule_text(slug: str):
+        return None
+
+    monkeypatch.setattr(games, "_canonical_rule_text", canonical_rule_text)
+    app = FastAPI()
+    app.include_router(games.router, prefix="/api")
+    app.dependency_overrides[games.get_game_service] = lambda: LegacyBackedGameService()
+
+    response = TestClient(app).get("/api/games/example")
+
+    assert response.status_code == 200
+    assert response.json()["rules_content"] == "legacy rule text"


### PR DESCRIPTION
## Success condition
Restoring the detailed-rules view must not make already-migrated games fall back from source-bound Presentation rules to stale legacy row text after React hydration.

## Change
- `GET /api/games/{slug}` now uses the same canonical RuleSet → Presentation rule text already used by SSR when available.
- Stored `rules_content` remains the fallback only when canonical presentation is unavailable.
- Add regression tests for both canonical-first and legacy-fallback cases.

This complements #400: uncovered games regain their detailed rules, while migrated games keep source-backed canonical rules in both SSR and hydrated GamePage.