### PR TITLE
Add final Terraforming Mars Dice base errata

### DIFF
--- a/backend/app/db/migrations/050_add_terraforming_mars_dice_final_base_errata.sql
+++ b/backend/app/db/migrations/050_add_terraforming_mars_dice_final_base_errata.sql
@@ -6,7 +6,7 @@ BEGIN;
 INSERT INTO public.source_locators (
   locator_id, source_id, page_number, section_heading, external_reference
 ) VALUES
-  ('tm-dice:errata:milestone-acquisition-timing','publisher:arclight:tm-dice:errata-2024',2,'ルール説明書 8ページ 最終得点計算','A milestone tile is acquired immediately when its condition is satisfied; the corrected text removes the restriction that this must happen during the player\'s own turn.'),
+  ('tm-dice:errata:milestone-acquisition-timing','publisher:arclight:tm-dice:errata-2024',2,'ルール説明書 8ページ 最終得点計算','A milestone tile is acquired immediately when its condition is satisfied; the corrected text removes any requirement that acquisition happen during a turn of the acquiring player.'),
   ('tm-dice:errata:solo-milestone-cost-icons','publisher:arclight:tm-dice:errata-2024',3,'ルール説明書 9ページ 1人ゲームのルール 2）称号（褒賞）','In solo play, milestone qualification counts cost icons on cards the player has played, not resource icons on cards in a play space.'),
   ('tm-dice:errata:solo-score-59-or-less','publisher:arclight:tm-dice:errata-2024',3,'ルール説明書 9ページ アナタの獲得勝利点は？','The corrected lowest solo score band is 59 points or fewer, not 60 points or fewer.')
 ON CONFLICT (locator_id) DO UPDATE SET

--- a/backend/app/db/migrations/050_add_terraforming_mars_dice_final_base_errata.sql
+++ b/backend/app/db/migrations/050_add_terraforming_mars_dice_final_base_errata.sql
@@ -1,0 +1,124 @@
+BEGIN;
+
+-- Add the remaining base-game errata that changes milestone/scoring outcomes.
+-- Corporate Era, promo-card corrections, and terminology-only fixes remain outside this base RuleSet.
+
+INSERT INTO public.source_locators (
+  locator_id, source_id, page_number, section_heading, external_reference
+) VALUES
+  ('tm-dice:errata:milestone-acquisition-timing','publisher:arclight:tm-dice:errata-2024',2,'ルール説明書 8ページ 最終得点計算','A milestone tile is acquired immediately when its condition is satisfied; the corrected text removes the restriction that this must happen during the player\'s own turn.'),
+  ('tm-dice:errata:solo-milestone-cost-icons','publisher:arclight:tm-dice:errata-2024',3,'ルール説明書 9ページ 1人ゲームのルール 2）称号（褒賞）','In solo play, milestone qualification counts cost icons on cards the player has played, not resource icons on cards in a play space.'),
+  ('tm-dice:errata:solo-score-59-or-less','publisher:arclight:tm-dice:errata-2024',3,'ルール説明書 9ページ アナタの獲得勝利点は？','The corrected lowest solo score band is 59 points or fewer, not 60 points or fewer.')
+ON CONFLICT (locator_id) DO UPDATE SET
+  source_id=EXCLUDED.source_id,
+  page_number=EXCLUDED.page_number,
+  section_heading=EXCLUDED.section_heading,
+  external_reference=EXCLUDED.external_reference;
+
+DO $$
+DECLARE
+  v_game_id uuid;
+  v_ruleset_id uuid;
+BEGIN
+  SELECT g.id INTO v_game_id
+  FROM public.games g
+  WHERE g.slug='terraforming-mars-the-dice-game'
+  LIMIT 1;
+
+  IF v_game_id IS NULL THEN
+    RAISE NOTICE 'Terraforming Mars: The Dice Game row not present in this fixture; skipping final base errata extension';
+    RETURN;
+  END IF;
+
+  SELECT rs.id INTO v_ruleset_id
+  FROM public.rule_sets rs
+  WHERE rs.game_id=v_game_id
+    AND COALESCE(rs.language_code,'')='ja'
+    AND COALESCE(rs.edition_label,'')='アークライト日本語版 改訂版 第2刷'
+    AND COALESCE(rs.platform,'')='physical'
+    AND COALESCE(rs.revision_label,'')='2024-05-30'
+    AND COALESCE(rs.variant_label,'')=''
+    AND rs.version=1
+  LIMIT 1;
+
+  IF v_ruleset_id IS NULL THEN
+    RAISE EXCEPTION 'Canonical Terraforming Mars Dice Japanese revised RuleSet is required';
+  END IF;
+
+  INSERT INTO public.rule_nodes(
+    rule_set_id,rule_id,node_type,normalized_statement,sequence,verification_status,
+    source_claim_ref,evidence_ref,source_url,source_locator,metadata
+  ) VALUES
+    (v_ruleset_id,'scoring.milestone-acquisition-timing','scoring','称号タイルは、その条件を満たした時点でただちに獲得する。獲得条件は自分の手番中に満たした場合だけに限定されない。',87,'source_bound','tm-dice:rule:scoring.milestone-acquisition-timing','tm-dice:binding:scoring.milestone-acquisition-timing','https://arclightgames.jp/wp-content/uploads/2023/12/3086b3fad2b13c82efd8eec9cd9907b9.pdf','tm-dice:errata:milestone-acquisition-timing','{"errata":true,"scope":"base_game_scoring"}'::jsonb),
+    (v_ruleset_id,'solo.milestone-cost-icons','scoring','1人ゲームで称号の条件を判定するときは、自分がプレイしたカードに描かれているコストのアイコン数を数える。プレイスペース上のカードにある資源アイコン数では判定しない。',92,'source_bound','tm-dice:rule:solo.milestone-cost-icons','tm-dice:binding:solo.milestone-cost-icons','https://arclightgames.jp/wp-content/uploads/2023/12/3086b3fad2b13c82efd8eec9cd9907b9.pdf','tm-dice:errata:solo-milestone-cost-icons','{"errata":true,"player_count":1,"scope":"solo_scoring"}'::jsonb),
+    (v_ruleset_id,'solo.score-band.lowest','scoring','1人ゲームの得点評価表で最下位の区分は59点以下である。60点はこの区分には含まれない。',93,'source_bound','tm-dice:rule:solo.score-band.lowest','tm-dice:binding:solo.score-band.lowest','https://arclightgames.jp/wp-content/uploads/2023/12/3086b3fad2b13c82efd8eec9cd9907b9.pdf','tm-dice:errata:solo-score-59-or-less','{"errata":true,"player_count":1,"scope":"solo_score_table"}'::jsonb)
+  ON CONFLICT(rule_set_id,rule_id) DO UPDATE SET
+    node_type=EXCLUDED.node_type,
+    normalized_statement=EXCLUDED.normalized_statement,
+    sequence=EXCLUDED.sequence,
+    verification_status=EXCLUDED.verification_status,
+    source_claim_ref=EXCLUDED.source_claim_ref,
+    evidence_ref=EXCLUDED.evidence_ref,
+    source_url=EXCLUDED.source_url,
+    source_locator=EXCLUDED.source_locator,
+    metadata=EXCLUDED.metadata,
+    updated_at=now();
+
+  INSERT INTO public.claims(
+    claim_id,rule_set_id,claim_type,normalized_payload,target_type,rule_id,lifecycle_status,generator_provenance
+  )
+  SELECT
+    'tm-dice:rule:'||rn.rule_id,
+    v_ruleset_id,
+    'normalized_rule_statement',
+    jsonb_build_object('statement',rn.normalized_statement),
+    'rule_node',
+    rn.rule_id,
+    'accepted',
+    '{"method":"publisher_errata_normalization","audit_date":"2026-08-24","scope":"arclight_japanese_base_game"}'::jsonb
+  FROM public.rule_nodes rn
+  WHERE rn.rule_set_id=v_ruleset_id
+    AND rn.rule_id IN ('scoring.milestone-acquisition-timing','solo.milestone-cost-icons','solo.score-band.lowest')
+  ON CONFLICT(claim_id) DO UPDATE SET
+    rule_set_id=EXCLUDED.rule_set_id,
+    claim_type=EXCLUDED.claim_type,
+    normalized_payload=EXCLUDED.normalized_payload,
+    target_type=EXCLUDED.target_type,
+    rule_id=EXCLUDED.rule_id,
+    lifecycle_status=EXCLUDED.lifecycle_status,
+    generator_provenance=EXCLUDED.generator_provenance,
+    updated_at=now();
+
+  INSERT INTO public.evidence_bindings(
+    binding_id,claim_id,source_id,locator_id,relation,reviewer_provenance,generator_provenance,verified_at
+  ) VALUES
+    ('tm-dice:binding:scoring.milestone-acquisition-timing','tm-dice:rule:scoring.milestone-acquisition-timing','publisher:arclight:tm-dice:errata-2024','tm-dice:errata:milestone-acquisition-timing','supports','{"reviewed":"2026-08-24"}'::jsonb,'{"method":"manual_primary_source_review"}'::jsonb,now()),
+    ('tm-dice:binding:solo.milestone-cost-icons','tm-dice:rule:solo.milestone-cost-icons','publisher:arclight:tm-dice:errata-2024','tm-dice:errata:solo-milestone-cost-icons','supports','{"reviewed":"2026-08-24"}'::jsonb,'{"method":"manual_primary_source_review"}'::jsonb,now()),
+    ('tm-dice:binding:solo.score-band.lowest','tm-dice:rule:solo.score-band.lowest','publisher:arclight:tm-dice:errata-2024','tm-dice:errata:solo-score-59-or-less','supports','{"reviewed":"2026-08-24"}'::jsonb,'{"method":"manual_primary_source_review"}'::jsonb,now())
+  ON CONFLICT(binding_id) DO UPDATE SET
+    claim_id=EXCLUDED.claim_id,
+    source_id=EXCLUDED.source_id,
+    locator_id=EXCLUDED.locator_id,
+    relation=EXCLUDED.relation,
+    reviewer_provenance=EXCLUDED.reviewer_provenance,
+    generator_provenance=EXCLUDED.generator_provenance,
+    verified_at=EXCLUDED.verified_at;
+
+  IF (SELECT count(*) FROM public.rule_nodes WHERE rule_set_id=v_ruleset_id AND verification_status='source_bound') < 20 THEN
+    RAISE EXCEPTION 'Terraforming Mars Dice requires at least 20 source-bound player-facing RuleNodes after final base errata extension';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.rule_nodes rn
+    WHERE rn.rule_set_id=v_ruleset_id AND rn.verification_status='source_bound'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.claims c
+        JOIN public.evidence_bindings eb ON eb.claim_id=c.claim_id AND eb.relation='supports'
+        WHERE c.rule_set_id=v_ruleset_id AND c.rule_id=rn.rule_id AND c.lifecycle_status='accepted'
+      )
+  ) THEN
+    RAISE EXCEPTION 'Every Terraforming Mars Dice source-bound RuleNode requires accepted supporting evidence';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Continue #206 by source-binding the remaining base-game errata that change player outcomes: milestone acquisition timing, solo milestone qualification, and the corrected solo 59-point score-band boundary. Corporate Era, promo-card corrections, and terminology-only fixes remain outside this physical base RuleSet.