### PR TITLE
Restore repaired HacKClaD discovery and hide retired identity

### DIFF
--- a/backend/app/services/directory_query.py
+++ b/backend/app/services/directory_query.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 import anyio
 
 from app.core import local_db, supabase
+from app.services.search_visibility import EXCLUDED_GAME_SLUGS, should_hide_game_from_search
 
 DirectorySort = Literal["recent", "title", "year", "play_time"]
 DirectoryTime = Literal["30-", "30-60", "60-120", "120+"]
@@ -72,7 +73,8 @@ def _filter_rows(
     return [
         game
         for game in rows
-        if _matches_players(game, players)
+        if not should_hide_game_from_search(str(game.get("slug") or ""))
+        and _matches_players(game, players)
         and _matches_time(game, time_filter)
         and (not tier or game.get("strategy_tier") == tier)
     ]
@@ -110,7 +112,8 @@ def _query_local(
     filtered = [
         game
         for game in rows
-        if _matches_query(game, q or "")
+        if not should_hide_game_from_search(str(game.get("slug") or ""))
+        and _matches_query(game, q or "")
         and _matches_players(game, players)
         and _matches_time(game, time_filter)
         and (not tier or game.get("strategy_tier") == tier)
@@ -157,6 +160,9 @@ async def list_directory_games(
 
     def _q() -> dict[str, Any]:
         query = supabase._get_client().table("games").select("*", count="exact")
+
+        for excluded_slug in sorted(EXCLUDED_GAME_SLUGS):
+            query = query.neq("slug", excluded_slug)
 
         if players:
             if players == "5+":

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -6,6 +6,7 @@ import anyio
 
 from app.core import supabase
 from app.services.identity_coherence import audit_title_work_coherence
+from app.services.search_visibility import should_hide_game_from_search
 
 logger = logging.getLogger("agents.game_service")
 _TITLE_FIELDS = ("title", "title_ja", "title_en")
@@ -136,7 +137,8 @@ class GameService:
             local_db.init_db()
 
     async def search_games(self, query: str) -> list[dict[str, Any]]:
-        return await supabase.search(query)
+        rows = await supabase.search(query)
+        return [row for row in rows if not should_hide_game_from_search(str(row.get("slug") or ""))]
 
     async def get_game_by_slug(self, slug: str) -> dict[str, Any] | None:
         return await supabase.get_by_slug(slug)

--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,11 +1,11 @@
-# These records are known to mix fields from different game identities.
-# Keep them out of search indexing and block normal mutation until the
-# underlying records are repaired through an explicit reviewed workflow.
-EXCLUDED_GAME_SLUGS = frozenset({"game", "hack-clad"})
+# Public discovery must exclude records whose canonical identity is intentionally
+# retired or still known to mix multiple works. Keep this list limited to active
+# conflicts; repaired titles must return to normal search and mutation paths.
+EXCLUDED_GAME_SLUGS = frozenset({"game"})
 
 # `game` mixed two different games and has no single correct canonical target.
-# Its two source-backed works now exist separately, so public reads must not
-# continue serving the contaminated historical row.
+# Its two source-backed works exist separately, so public reads must not continue
+# serving the contaminated historical row.
 GONE_GAME_SLUGS = frozenset({"game"})
 
 

--- a/backend/tests/test_game_identity_conflict_guard.py
+++ b/backend/tests/test_game_identity_conflict_guard.py
@@ -3,6 +3,7 @@ from fastapi import HTTPException
 
 from app.main import game_seo_page
 from app.routers.games import get_game_details, update_game
+from app.services.search_visibility import has_known_identity_conflict
 
 
 class _MutationMustNotRun:
@@ -19,11 +20,10 @@ class _ReadMustNotRun:
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("slug", ["game", "hack-clad"])
-async def test_known_identity_conflict_blocks_regeneration(slug: str) -> None:
+async def test_known_identity_conflict_blocks_regeneration() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await update_game(
-            slug=slug,
+            slug="game",
             game_update=None,
             regenerate=True,
             fill_missing_only=False,
@@ -33,6 +33,10 @@ async def test_known_identity_conflict_blocks_regeneration(slug: str) -> None:
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.detail == "Game identity conflict requires reviewed repair before mutation"
+
+
+def test_repaired_hackclad_is_not_kept_in_identity_conflict_registry() -> None:
+    assert has_known_identity_conflict("hack-clad") is False
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_search_visibility.py
+++ b/backend/tests/test_search_visibility.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app.core import supabase
+from app.services.directory_query import _filter_rows
+from app.services.game_service import GameService
+from app.services.search_visibility import has_known_identity_conflict, should_hide_game_from_search
+
+
+@pytest.mark.asyncio
+async def test_canonical_search_hides_retired_mixed_identity_but_keeps_repaired_game(monkeypatch) -> None:
+    async def _search(_query: str):
+        return [
+            {"slug": "game", "title": "mixed historical row"},
+            {"slug": "hack-clad", "title": "HacKClaD"},
+        ]
+
+    monkeypatch.setattr(supabase, "search", _search)
+    service = GameService.__new__(GameService)
+
+    results = await service.search_games("hack")
+
+    assert [row["slug"] for row in results] == ["hack-clad"]
+    assert has_known_identity_conflict("game") is True
+    assert has_known_identity_conflict("hack-clad") is False
+
+
+def test_directory_filter_uses_same_identity_visibility_contract() -> None:
+    rows = [
+        {"slug": "game", "title": "mixed historical row"},
+        {"slug": "hack-clad", "title": "HacKClaD"},
+    ]
+
+    filtered = _filter_rows(rows, players=None, time_filter=None, tier=None)
+
+    assert [row["slug"] for row in filtered] == ["hack-clad"]
+    assert should_hide_game_from_search("game") is True
+    assert should_hide_game_from_search("hack-clad") is False

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -98,16 +98,14 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert "\\u003cscript" in rendered
 
 
-@pytest.mark.parametrize("slug", ["game", "hack-clad"])
 @pytest.mark.asyncio
-async def test_known_mixed_game_records_are_noindex(
+async def test_known_mixed_game_record_is_noindex(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    slug: str,
 ) -> None:
     async def game(_slug: str):
         return {
-            "slug": slug,
+            "slug": "game",
             "title": "Mixed record",
             "identity_status": "unverified",
             "summary": "mixed identity fixture",
@@ -124,7 +122,7 @@ async def test_known_mixed_game_records_are_noindex(
     monkeypatch.setattr(seo_renderer, "get_by_slug", game)
     monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
 
-    rendered = await seo_renderer.generate_seo_html(slug)
+    rendered = await seo_renderer.generate_seo_html("game")
 
     assert rendered is not None
     assert '<meta name="robots" content="noindex, follow" />' in rendered

--- a/backend/tests/test_sitemap.py
+++ b/backend/tests/test_sitemap.py
@@ -65,12 +65,11 @@ async def test_invalid_game_slugs_are_not_emitted(monkeypatch: pytest.MonkeyPatc
 
 
 @pytest.mark.asyncio
-async def test_known_mixed_game_records_are_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_retired_mixed_game_record_is_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_list_for_sitemap() -> list[dict[str, str | None]]:
         return [
             {"slug": "game", "title": "Mixed", "updated_at": None, "image_url": None},
-            {"slug": "hack-clad", "title": "Mixed Hack Clad", "updated_at": None, "image_url": None},
-            {"slug": "hackclad", "title": "HacKClaD", "updated_at": None, "image_url": None},
+            {"slug": "hack-clad", "title": "HacKClaD", "updated_at": None, "image_url": None},
             {"slug": "raise-your-goblets", "title": "Raise Your Goblets", "updated_at": None, "image_url": None},
         ]
 
@@ -80,6 +79,5 @@ async def test_known_mixed_game_records_are_not_emitted(monkeypatch: pytest.Monk
     xml_text = await sitemap.get_sitemap_xml()
 
     assert "https://example.test/games/game" not in xml_text
-    assert "https://example.test/games/hack-clad" not in xml_text
-    assert "https://example.test/games/hackclad" in xml_text
+    assert "https://example.test/games/hack-clad" in xml_text
     assert "https://example.test/games/raise-your-goblets" in xml_text


### PR DESCRIPTION
## Player-facing outcome
- HacKClaD has already been repaired into a source-bound canonical game, so it must no longer remain in the identity-conflict exclusion registry.
- The retired mixed-identity `game` row must remain unavailable and must not leak through canonical search or directory discovery.

## Change
- keep only `game` in the active identity-conflict exclusion registry
- apply the same visibility contract to canonical `/api/search` results and directory filtering
- exclude retired identities from server-side directory queries
- add regression coverage for repaired HacKClaD vs retired `game`

## Success condition
Searching/browsing can return `hack-clad`, while `game` remains hidden from discovery and HTTP 410 on direct reads.

Refs #256 #388