### PR TITLE
Collapse duplicate HacKClaD discovery to canonical work

### DIFF
--- a/backend/app/db/migrations/051_consolidate_hackclad_canonical_affiliate.sql
+++ b/backend/app/db/migrations/051_consolidate_hackclad_canonical_affiliate.sql
@@ -1,0 +1,11 @@
+-- Preserve monetization when retiring the legacy `hackclad` duplicate.
+-- The verified canonical work is `hack-clad`; copy the existing affiliate URL only
+-- when the canonical record does not already have one.
+UPDATE games AS canonical
+SET amazon_url = legacy.amazon_url,
+    updated_at = NOW()
+FROM games AS legacy
+WHERE canonical.slug = 'hack-clad'
+  AND legacy.slug = 'hackclad'
+  AND canonical.amazon_url IS NULL
+  AND legacy.amazon_url IS NOT NULL;

--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,12 +1,12 @@
 # Public discovery must exclude records whose canonical identity is intentionally
 # retired or still known to mix multiple works. Keep this list limited to active
 # conflicts; repaired titles must return to normal search and mutation paths.
-EXCLUDED_GAME_SLUGS = frozenset({"game"})
+EXCLUDED_GAME_SLUGS = frozenset({"game", "hackclad"})
 
 # `game` mixed two different games and has no single correct canonical target.
-# Its two source-backed works exist separately, so public reads must not continue
-# serving the contaminated historical row.
-GONE_GAME_SLUGS = frozenset({"game"})
+# `hackclad` is a superseded duplicate of the verified `hack-clad` canonical work.
+# Public reads must not continue serving either retired record as canonical content.
+GONE_GAME_SLUGS = frozenset({"game", "hackclad"})
 
 
 def has_known_identity_conflict(slug: str) -> bool:

--- a/backend/tests/test_search_visibility.py
+++ b/backend/tests/test_search_visibility.py
@@ -7,10 +7,11 @@ from app.services.search_visibility import has_known_identity_conflict, should_h
 
 
 @pytest.mark.asyncio
-async def test_canonical_search_hides_retired_mixed_identity_but_keeps_repaired_game(monkeypatch) -> None:
+async def test_canonical_search_hides_retired_records_and_keeps_verified_hackclad(monkeypatch) -> None:
     async def _search(_query: str):
         return [
             {"slug": "game", "title": "mixed historical row"},
+            {"slug": "hackclad", "title": "legacy HacKClaD duplicate"},
             {"slug": "hack-clad", "title": "HacKClaD"},
         ]
 
@@ -21,12 +22,14 @@ async def test_canonical_search_hides_retired_mixed_identity_but_keeps_repaired_
 
     assert [row["slug"] for row in results] == ["hack-clad"]
     assert has_known_identity_conflict("game") is True
+    assert has_known_identity_conflict("hackclad") is True
     assert has_known_identity_conflict("hack-clad") is False
 
 
 def test_directory_filter_uses_same_identity_visibility_contract() -> None:
     rows = [
         {"slug": "game", "title": "mixed historical row"},
+        {"slug": "hackclad", "title": "legacy HacKClaD duplicate"},
         {"slug": "hack-clad", "title": "HacKClaD"},
     ]
 
@@ -34,4 +37,5 @@ def test_directory_filter_uses_same_identity_visibility_contract() -> None:
 
     assert [row["slug"] for row in filtered] == ["hack-clad"]
     assert should_hide_game_from_search("game") is True
+    assert should_hide_game_from_search("hackclad") is True
     assert should_hide_game_from_search("hack-clad") is False

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import './index.css'
@@ -32,6 +32,10 @@ const router = createBrowserRouter([
             <App />
           </Suspense>
         ),
+      },
+      {
+        path: '/games/hackclad',
+        element: <Navigate to="/games/hack-clad" replace />,
       },
       {
         path: '/games/:slug',


### PR DESCRIPTION
## Player-facing outcome
Searching or browsing HacKClaD resolves to the verified `hack-clad` work only. Legacy `/games/hackclad` traffic is redirected to the canonical page, and the retired duplicate is removed from discovery/API reads.

## Revenue preservation
The legacy duplicate currently holds the Amazon affiliate URL while the verified canonical row does not. Migration 051 copies that URL to `hack-clad` only when the canonical value is empty.

## Evidence
SUSABI GAMES/HacKClaD official sources identify the base game as HacKClaD, 1–4 players, 90–120 minutes. Production currently returns both `hack-clad` and `hackclad` for HacKClaD search despite `hack-clad` being the verified source-bound row.

Refs #256 #388