### PR TITLE
Fix production redirect for legacy HacKClaD slug

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App.jsx'
 import './index.css'
@@ -32,10 +32,6 @@ const router = createBrowserRouter([
             <App />
           </Suspense>
         ),
-      },
-      {
-        path: '/games/hackclad',
-        element: <Navigate to="/games/hack-clad" replace />,
       },
       {
         path: '/games/:slug',

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,13 @@
   "buildCommand": "cd frontend && npm ci && npm run build",
   "outputDirectory": "frontend/dist",
   "ignoreCommand": "git diff HEAD^ HEAD --quiet -- . ':(exclude)data/analytics/**'",
+  "redirects": [
+    {
+      "source": "/games/hackclad",
+      "destination": "/games/hack-clad",
+      "permanent": true
+    }
+  ],
   "rewrites": [
     {
       "source": "/api/:path*",


### PR DESCRIPTION
Production verification found `/games/hackclad` returning HTTP 410 instead of redirecting to the verified canonical `/games/hack-clad` page. The cause is routing order: Vercel rewrites `/games/:slug` to the backend before React Router can execute the client-side redirect.

This change moves the redirect to `vercel.json`, ahead of the game rewrite, and removes the unreachable frontend-only redirect.

Player-facing success condition: requesting `/games/hackclad` in production reaches `/games/hack-clad` via an HTTP redirect while canonical search remains one-result-only and the canonical affiliate URL remains intact.