### PR TITLE
Collapse duplicate 3 Second Try identity

### DIFF
--- a/backend/app/db/migrations/052_verify_3_second_try_identity.sql
+++ b/backend/app/db/migrations/052_verify_3_second_try_identity.sql
@@ -1,0 +1,16 @@
+-- Bind the canonical `3-second-try` record to the publisher's current product page.
+-- The legacy generic slug `3` is a duplicate and is retired by the public visibility contract.
+UPDATE games
+SET identity_status = 'verified',
+    identity_source = 'https://www.itten-store.com/items/61574694',
+    source_url = 'https://www.itten-store.com/items/61574694',
+    source_trust = 'official_publisher',
+    title = '3秒トライ！',
+    title_ja = '3秒トライ！',
+    title_en = '3 Second Try!',
+    min_players = 2,
+    max_players = 7,
+    play_time = 10,
+    min_age = 8,
+    updated_at = NOW()
+WHERE slug = '3-second-try';

--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,12 +1,13 @@
 # Public discovery must exclude records whose canonical identity is intentionally
 # retired or still known to mix multiple works. Keep this list limited to active
 # conflicts; repaired titles must return to normal search and mutation paths.
-EXCLUDED_GAME_SLUGS = frozenset({"game", "hackclad"})
+EXCLUDED_GAME_SLUGS = frozenset({"game", "hackclad", "3"})
 
 # `game` mixed two different games and has no single correct canonical target.
 # `hackclad` is a superseded duplicate of the verified `hack-clad` canonical work.
-# Public reads must not continue serving either retired record as canonical content.
-GONE_GAME_SLUGS = frozenset({"game", "hackclad"})
+# `3` is a superseded duplicate of the source-backed `3-second-try` work.
+# Public reads must not continue serving retired records as canonical content.
+GONE_GAME_SLUGS = frozenset({"game", "hackclad", "3"})
 
 
 def has_known_identity_conflict(slug: str) -> bool:

--- a/backend/tests/test_search_visibility.py
+++ b/backend/tests/test_search_visibility.py
@@ -7,23 +7,27 @@ from app.services.search_visibility import has_known_identity_conflict, should_h
 
 
 @pytest.mark.asyncio
-async def test_canonical_search_hides_retired_records_and_keeps_verified_hackclad(monkeypatch) -> None:
+async def test_canonical_search_hides_retired_records_and_keeps_verified_games(monkeypatch) -> None:
     async def _search(_query: str):
         return [
             {"slug": "game", "title": "mixed historical row"},
             {"slug": "hackclad", "title": "legacy HacKClaD duplicate"},
             {"slug": "hack-clad", "title": "HacKClaD"},
+            {"slug": "3", "title": "3秒トライ！"},
+            {"slug": "3-second-try", "title": "3秒トライ！"},
         ]
 
     monkeypatch.setattr(supabase, "search", _search)
     service = GameService.__new__(GameService)
 
-    results = await service.search_games("hack")
+    results = await service.search_games("game")
 
-    assert [row["slug"] for row in results] == ["hack-clad"]
+    assert [row["slug"] for row in results] == ["hack-clad", "3-second-try"]
     assert has_known_identity_conflict("game") is True
     assert has_known_identity_conflict("hackclad") is True
+    assert has_known_identity_conflict("3") is True
     assert has_known_identity_conflict("hack-clad") is False
+    assert has_known_identity_conflict("3-second-try") is False
 
 
 def test_directory_filter_uses_same_identity_visibility_contract() -> None:
@@ -31,11 +35,15 @@ def test_directory_filter_uses_same_identity_visibility_contract() -> None:
         {"slug": "game", "title": "mixed historical row"},
         {"slug": "hackclad", "title": "legacy HacKClaD duplicate"},
         {"slug": "hack-clad", "title": "HacKClaD"},
+        {"slug": "3", "title": "3秒トライ！"},
+        {"slug": "3-second-try", "title": "3秒トライ！"},
     ]
 
     filtered = _filter_rows(rows, players=None, time_filter=None, tier=None)
 
-    assert [row["slug"] for row in filtered] == ["hack-clad"]
+    assert [row["slug"] for row in filtered] == ["hack-clad", "3-second-try"]
     assert should_hide_game_from_search("game") is True
     assert should_hide_game_from_search("hackclad") is True
+    assert should_hide_game_from_search("3") is True
     assert should_hide_game_from_search("hack-clad") is False
+    assert should_hide_game_from_search("3-second-try") is False

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,11 @@
       "source": "/games/hackclad",
       "destination": "/games/hack-clad",
       "permanent": true
+    },
+    {
+      "source": "/games/3",
+      "destination": "/games/3-second-try",
+      "permanent": true
     }
   ],
   "rewrites": [
@@ -31,54 +36,15 @@
     {
       "source": "/(.*)",
       "headers": [
-        {
-          "key": "Content-Security-Policy",
-          "value": "base-uri 'self'; object-src 'none'; frame-ancestors 'none'"
-        },
-        {
-          "key": "X-Content-Type-Options",
-          "value": "nosniff"
-        },
-        {
-          "key": "X-Frame-Options",
-          "value": "DENY"
-        },
-        {
-          "key": "Referrer-Policy",
-          "value": "strict-origin-when-cross-origin"
-        },
-        {
-          "key": "Permissions-Policy",
-          "value": "camera=(), microphone=(), geolocation=()"
-        }
+        {"key": "Content-Security-Policy", "value": "base-uri 'self'; object-src 'none'; frame-ancestors 'none'"},
+        {"key": "X-Content-Type-Options", "value": "nosniff"},
+        {"key": "X-Frame-Options", "value": "DENY"},
+        {"key": "Referrer-Policy", "value": "strict-origin-when-cross-origin"},
+        {"key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()"}
       ]
     },
-    {
-      "source": "/output_slides/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    },
-    {
-      "source": "/assets/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    },
-    {
-      "source": "/images/(.*)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=31536000, immutable"
-        }
-      ]
-    }
+    {"source": "/output_slides/(.*)", "headers": [{"key": "Cache-Control", "value": "public, max-age=31536000, immutable"}]},
+    {"source": "/assets/(.*)", "headers": [{"key": "Cache-Control", "value": "public, max-age=31536000, immutable"}]},
+    {"source": "/images/(.*)", "headers": [{"key": "Cache-Control", "value": "public, max-age=31536000, immutable"}]}
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -36,15 +36,54 @@
     {
       "source": "/(.*)",
       "headers": [
-        {"key": "Content-Security-Policy", "value": "base-uri 'self'; object-src 'none'; frame-ancestors 'none'"},
-        {"key": "X-Content-Type-Options", "value": "nosniff"},
-        {"key": "X-Frame-Options", "value": "DENY"},
-        {"key": "Referrer-Policy", "value": "strict-origin-when-cross-origin"},
-        {"key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()"}
+        {
+          "key": "Content-Security-Policy",
+          "value": "base-uri 'self'; object-src 'none'; frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
       ]
     },
-    {"source": "/output_slides/(.*)", "headers": [{"key": "Cache-Control", "value": "public, max-age=31536000, immutable"}]},
-    {"source": "/assets/(.*)", "headers": [{"key": "Cache-Control", "value": "public, max-age=31536000, immutable"}]},
-    {"source": "/images/(.*)", "headers": [{"key": "Cache-Control", "value": "public, max-age=31536000, immutable"}]}
+    {
+      "source": "/output_slides/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/images/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Continue #256 by collapsing the duplicate `3` / `3-second-try` records into one player-facing identity.

Player-facing success condition: searching `3秒トライ！` returns only `3-second-try`; `/games/3` redirects to `/games/3-second-try`; the canonical record is source-bound to itten's current official product page.

Primary evidence:
- itten official store: https://www.itten-store.com/items/61574694
- Current production exposes two records with the same Japanese title and identical rule body; only `3-second-try` carries the complete English title and structured metadata.

The change:
- verifies `3-second-try` against the official publisher page (2–7 players, 10+ minutes, age 8+)
- retires generic slug `3` from search/directory/API canonical reads
- redirects legacy `/games/3` traffic to the canonical page
- adds regression coverage using the existing shared visibility contract

No destructive row merge is performed. Refs #256.