### PR TITLE
Collapse duplicate Little Town Builders identity

### DIFF
--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,13 +1,14 @@
 # Public discovery must exclude records whose canonical identity is intentionally
 # retired or still known to mix multiple works. Keep this list limited to active
 # conflicts; repaired titles must return to normal search and mutation paths.
-EXCLUDED_GAME_SLUGS = frozenset({"game", "hackclad", "3"})
+EXCLUDED_GAME_SLUGS = frozenset({"game", "hackclad", "3", "little-town-builders"})
 
 # `game` mixed two different games and has no single correct canonical target.
 # `hackclad` is a superseded duplicate of the verified `hack-clad` canonical work.
 # `3` is a superseded duplicate of the source-backed `3-second-try` work.
+# `little-town-builders` is a superseded duplicate of verified `little-town`.
 # Public reads must not continue serving retired records as canonical content.
-GONE_GAME_SLUGS = frozenset({"game", "hackclad", "3"})
+GONE_GAME_SLUGS = frozenset({"game", "hackclad", "3", "little-town-builders"})
 
 
 def has_known_identity_conflict(slug: str) -> bool:

--- a/backend/tests/test_search_visibility.py
+++ b/backend/tests/test_search_visibility.py
@@ -15,6 +15,8 @@ async def test_canonical_search_hides_retired_records_and_keeps_verified_games(m
             {"slug": "hack-clad", "title": "HacKClaD"},
             {"slug": "3", "title": "3秒トライ！"},
             {"slug": "3-second-try", "title": "3秒トライ！"},
+            {"slug": "little-town-builders", "title": "リトルタウンビルダーズ"},
+            {"slug": "little-town", "title": "リトルタウンビルダーズ"},
         ]
 
     monkeypatch.setattr(supabase, "search", _search)
@@ -22,12 +24,14 @@ async def test_canonical_search_hides_retired_records_and_keeps_verified_games(m
 
     results = await service.search_games("game")
 
-    assert [row["slug"] for row in results] == ["hack-clad", "3-second-try"]
+    assert [row["slug"] for row in results] == ["hack-clad", "3-second-try", "little-town"]
     assert has_known_identity_conflict("game") is True
     assert has_known_identity_conflict("hackclad") is True
     assert has_known_identity_conflict("3") is True
+    assert has_known_identity_conflict("little-town-builders") is True
     assert has_known_identity_conflict("hack-clad") is False
     assert has_known_identity_conflict("3-second-try") is False
+    assert has_known_identity_conflict("little-town") is False
 
 
 def test_directory_filter_uses_same_identity_visibility_contract() -> None:
@@ -37,13 +41,17 @@ def test_directory_filter_uses_same_identity_visibility_contract() -> None:
         {"slug": "hack-clad", "title": "HacKClaD"},
         {"slug": "3", "title": "3秒トライ！"},
         {"slug": "3-second-try", "title": "3秒トライ！"},
+        {"slug": "little-town-builders", "title": "リトルタウンビルダーズ"},
+        {"slug": "little-town", "title": "リトルタウンビルダーズ"},
     ]
 
     filtered = _filter_rows(rows, players=None, time_filter=None, tier=None)
 
-    assert [row["slug"] for row in filtered] == ["hack-clad", "3-second-try"]
+    assert [row["slug"] for row in filtered] == ["hack-clad", "3-second-try", "little-town"]
     assert should_hide_game_from_search("game") is True
     assert should_hide_game_from_search("hackclad") is True
     assert should_hide_game_from_search("3") is True
+    assert should_hide_game_from_search("little-town-builders") is True
     assert should_hide_game_from_search("hack-clad") is False
     assert should_hide_game_from_search("3-second-try") is False
+    assert should_hide_game_from_search("little-town") is False

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,11 @@
       "source": "/games/3",
       "destination": "/games/3-second-try",
       "permanent": true
+    },
+    {
+      "source": "/games/little-town-builders",
+      "destination": "/games/little-town",
+      "permanent": true
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Continue #256 by collapsing duplicate `little-town` / `little-town-builders` discovery into the verified canonical record.

Player-facing success condition: searching リトルタウンビルダーズ returns only `little-town`; `/games/little-town-builders` redirects to `/games/little-town`; the canonical record remains the Arclight-backed 2020 Japanese release with its existing affiliate path.

Primary evidence:
- Arclight official product page: https://arclightgames.jp/product/%E3%83%AA%E3%83%88%E3%83%AB%E3%82%BF%E3%82%A6%E3%83%B3%E3%83%93%E3%83%AB%E3%83%80%E3%83%BC%E3%82%BA/
- Production currently exposes two records with the same Japanese title and English identity; `little-town` is verified against that official page and has all 37 observed views, while `little-town-builders` is unverified with 0 views.

The change:
- retires `little-town-builders` from canonical search/directory/API reads
- redirects the legacy slug to `little-town`
- extends the existing shared visibility regression coverage

No destructive row merge, duplicate rule store, or new game-specific API is introduced. Refs #256.