### PR TITLE
Collapse duplicate Heart of Crown 2nd Edition identity

### DIFF
--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -1,14 +1,27 @@
 # Public discovery must exclude records whose canonical identity is intentionally
 # retired or still known to mix multiple works. Keep this list limited to active
 # conflicts; repaired titles must return to normal search and mutation paths.
-EXCLUDED_GAME_SLUGS = frozenset({"game", "hackclad", "3", "little-town-builders"})
+EXCLUDED_GAME_SLUGS = frozenset({
+    "game",
+    "hackclad",
+    "3",
+    "little-town-builders",
+    "heart-of-crown",
+})
 
 # `game` mixed two different games and has no single correct canonical target.
 # `hackclad` is a superseded duplicate of the verified `hack-clad` canonical work.
 # `3` is a superseded duplicate of the source-backed `3-second-try` work.
 # `little-town-builders` is a superseded duplicate of verified `little-town`.
+# `heart-of-crown` duplicates the explicitly edition-scoped `heart-of-crown-2nd-edition` record.
 # Public reads must not continue serving retired records as canonical content.
-GONE_GAME_SLUGS = frozenset({"game", "hackclad", "3", "little-town-builders"})
+GONE_GAME_SLUGS = frozenset({
+    "game",
+    "hackclad",
+    "3",
+    "little-town-builders",
+    "heart-of-crown",
+})
 
 
 def has_known_identity_conflict(slug: str) -> bool:

--- a/backend/tests/test_search_visibility.py
+++ b/backend/tests/test_search_visibility.py
@@ -17,6 +17,8 @@ async def test_canonical_search_hides_retired_records_and_keeps_verified_games(m
             {"slug": "3-second-try", "title": "3秒トライ！"},
             {"slug": "little-town-builders", "title": "リトルタウンビルダーズ"},
             {"slug": "little-town", "title": "リトルタウンビルダーズ"},
+            {"slug": "heart-of-crown", "title": "Heart of Crown 2nd Edition"},
+            {"slug": "heart-of-crown-2nd-edition", "title": "Heart of Crown 2nd Edition"},
         ]
 
     monkeypatch.setattr(supabase, "search", _search)
@@ -24,14 +26,21 @@ async def test_canonical_search_hides_retired_records_and_keeps_verified_games(m
 
     results = await service.search_games("game")
 
-    assert [row["slug"] for row in results] == ["hack-clad", "3-second-try", "little-town"]
+    assert [row["slug"] for row in results] == [
+        "hack-clad",
+        "3-second-try",
+        "little-town",
+        "heart-of-crown-2nd-edition",
+    ]
     assert has_known_identity_conflict("game") is True
     assert has_known_identity_conflict("hackclad") is True
     assert has_known_identity_conflict("3") is True
     assert has_known_identity_conflict("little-town-builders") is True
+    assert has_known_identity_conflict("heart-of-crown") is True
     assert has_known_identity_conflict("hack-clad") is False
     assert has_known_identity_conflict("3-second-try") is False
     assert has_known_identity_conflict("little-town") is False
+    assert has_known_identity_conflict("heart-of-crown-2nd-edition") is False
 
 
 def test_directory_filter_uses_same_identity_visibility_contract() -> None:
@@ -43,15 +52,24 @@ def test_directory_filter_uses_same_identity_visibility_contract() -> None:
         {"slug": "3-second-try", "title": "3秒トライ！"},
         {"slug": "little-town-builders", "title": "リトルタウンビルダーズ"},
         {"slug": "little-town", "title": "リトルタウンビルダーズ"},
+        {"slug": "heart-of-crown", "title": "Heart of Crown 2nd Edition"},
+        {"slug": "heart-of-crown-2nd-edition", "title": "Heart of Crown 2nd Edition"},
     ]
 
     filtered = _filter_rows(rows, players=None, time_filter=None, tier=None)
 
-    assert [row["slug"] for row in filtered] == ["hack-clad", "3-second-try", "little-town"]
+    assert [row["slug"] for row in filtered] == [
+        "hack-clad",
+        "3-second-try",
+        "little-town",
+        "heart-of-crown-2nd-edition",
+    ]
     assert should_hide_game_from_search("game") is True
     assert should_hide_game_from_search("hackclad") is True
     assert should_hide_game_from_search("3") is True
     assert should_hide_game_from_search("little-town-builders") is True
+    assert should_hide_game_from_search("heart-of-crown") is True
     assert should_hide_game_from_search("hack-clad") is False
     assert should_hide_game_from_search("3-second-try") is False
     assert should_hide_game_from_search("little-town") is False
+    assert should_hide_game_from_search("heart-of-crown-2nd-edition") is False

--- a/vercel.json
+++ b/vercel.json
@@ -17,6 +17,11 @@
       "source": "/games/little-town-builders",
       "destination": "/games/little-town",
       "permanent": true
+    },
+    {
+      "source": "/games/heart-of-crown",
+      "destination": "/games/heart-of-crown-2nd-edition",
+      "permanent": true
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Continue #256 by collapsing two public records that both identify the same product, `Heart of Crown 2nd Edition`, into the edition-scoped canonical route.

Player-facing success condition: searching `Heart of Crown 2nd Edition` returns only `heart-of-crown-2nd-edition`; `/games/heart-of-crown` redirects to `/games/heart-of-crown-2nd-edition`; Fairy Garden remains a distinct expansion; no rule content or edition metadata is merged across records.

Current production evidence:
- `heart-of-crown`: 94 views, title_ja/title_en both identify `Heart of Crown 2nd Edition`, unverified identity
- `heart-of-crown-2nd-edition`: 8 views, same Japanese and English product title, unverified identity
- `heart-of-crown-fairy-garden`: distinct expansion and remains public

Primary product identity evidence:
- PLAYISM states that HEART of CROWN Online is based on `Heart of Crown 2nd Edition`, relaunched in 2022: https://playism.com/game/heart-of-crown/

The change is intentionally limited to discovery and routing:
- retire the ambiguous generic `heart-of-crown` record from search/directory/sitemap/API canonical reads
- redirect the generic public slug to the explicit `heart-of-crown-2nd-edition` route
- extend the shared visibility regression coverage

No rules, edition-specific metadata, view counts, or product-family records are merged. Both records remain unverified until a first-party physical Second Edition source is available. Fairy Garden is not collapsed into the base product.