### PR TITLE
Repair ICE FALL identity and retire contaminated duplicate

### DIFF
--- a/backend/app/db/migrations/053_repair_ice_fall_identity.sql
+++ b/backend/app/db/migrations/053_repair_ice_fall_identity.sql
@@ -1,0 +1,21 @@
+-- Bind the canonical ICE FALL record to Smart Ape Games' first-party Game Market page.
+-- The legacy `icefall` record points to an unrelated game and is retired by the public visibility contract.
+UPDATE games
+SET identity_status = 'verified',
+    identity_source = 'https://gamemarket.jp/game/184994/',
+    official_url = 'https://gamemarket.jp/game/184994/',
+    source_url = 'https://gamemarket.jp/game/184994/',
+    source_trust = 'official_publisher',
+    title = 'ICE FALL',
+    title_ja = 'アイスフォール',
+    title_en = 'ICE FALL',
+    publisher = 'Smart Ape Games',
+    min_players = 3,
+    max_players = 5,
+    play_time = 45,
+    min_age = 10,
+    published_year = 2025,
+    rules_content = NULL,
+    content_review_status = 'review_required',
+    updated_at = NOW()
+WHERE slug = 'ice-fall';

--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -7,6 +7,7 @@ EXCLUDED_GAME_SLUGS = frozenset({
     "3",
     "little-town-builders",
     "heart-of-crown",
+    "icefall",
 })
 
 # `game` mixed two different games and has no single correct canonical target.
@@ -14,6 +15,7 @@ EXCLUDED_GAME_SLUGS = frozenset({
 # `3` is a superseded duplicate of the source-backed `3-second-try` work.
 # `little-town-builders` is a superseded duplicate of verified `little-town`.
 # `heart-of-crown` duplicates the explicitly edition-scoped `heart-of-crown-2nd-edition` record.
+# `icefall` points to an unrelated Game Market product and duplicates the repaired `ice-fall` title.
 # Public reads must not continue serving retired records as canonical content.
 GONE_GAME_SLUGS = frozenset({
     "game",
@@ -21,6 +23,7 @@ GONE_GAME_SLUGS = frozenset({
     "3",
     "little-town-builders",
     "heart-of-crown",
+    "icefall",
 })
 
 

--- a/backend/tests/test_search_visibility.py
+++ b/backend/tests/test_search_visibility.py
@@ -19,6 +19,8 @@ async def test_canonical_search_hides_retired_records_and_keeps_verified_games(m
             {"slug": "little-town", "title": "リトルタウンビルダーズ"},
             {"slug": "heart-of-crown", "title": "Heart of Crown 2nd Edition"},
             {"slug": "heart-of-crown-2nd-edition", "title": "Heart of Crown 2nd Edition"},
+            {"slug": "icefall", "title": "アイスフォール"},
+            {"slug": "ice-fall", "title": "ICE FALL"},
         ]
 
     monkeypatch.setattr(supabase, "search", _search)
@@ -31,16 +33,12 @@ async def test_canonical_search_hides_retired_records_and_keeps_verified_games(m
         "3-second-try",
         "little-town",
         "heart-of-crown-2nd-edition",
+        "ice-fall",
     ]
-    assert has_known_identity_conflict("game") is True
-    assert has_known_identity_conflict("hackclad") is True
-    assert has_known_identity_conflict("3") is True
-    assert has_known_identity_conflict("little-town-builders") is True
-    assert has_known_identity_conflict("heart-of-crown") is True
-    assert has_known_identity_conflict("hack-clad") is False
-    assert has_known_identity_conflict("3-second-try") is False
-    assert has_known_identity_conflict("little-town") is False
-    assert has_known_identity_conflict("heart-of-crown-2nd-edition") is False
+    for slug in ("game", "hackclad", "3", "little-town-builders", "heart-of-crown", "icefall"):
+        assert has_known_identity_conflict(slug) is True
+    for slug in ("hack-clad", "3-second-try", "little-town", "heart-of-crown-2nd-edition", "ice-fall"):
+        assert has_known_identity_conflict(slug) is False
 
 
 def test_directory_filter_uses_same_identity_visibility_contract() -> None:
@@ -54,6 +52,8 @@ def test_directory_filter_uses_same_identity_visibility_contract() -> None:
         {"slug": "little-town", "title": "リトルタウンビルダーズ"},
         {"slug": "heart-of-crown", "title": "Heart of Crown 2nd Edition"},
         {"slug": "heart-of-crown-2nd-edition", "title": "Heart of Crown 2nd Edition"},
+        {"slug": "icefall", "title": "アイスフォール"},
+        {"slug": "ice-fall", "title": "ICE FALL"},
     ]
 
     filtered = _filter_rows(rows, players=None, time_filter=None, tier=None)
@@ -63,13 +63,9 @@ def test_directory_filter_uses_same_identity_visibility_contract() -> None:
         "3-second-try",
         "little-town",
         "heart-of-crown-2nd-edition",
+        "ice-fall",
     ]
-    assert should_hide_game_from_search("game") is True
-    assert should_hide_game_from_search("hackclad") is True
-    assert should_hide_game_from_search("3") is True
-    assert should_hide_game_from_search("little-town-builders") is True
-    assert should_hide_game_from_search("heart-of-crown") is True
-    assert should_hide_game_from_search("hack-clad") is False
-    assert should_hide_game_from_search("3-second-try") is False
-    assert should_hide_game_from_search("little-town") is False
-    assert should_hide_game_from_search("heart-of-crown-2nd-edition") is False
+    for slug in ("game", "hackclad", "3", "little-town-builders", "heart-of-crown", "icefall"):
+        assert should_hide_game_from_search(slug) is True
+    for slug in ("hack-clad", "3-second-try", "little-town", "heart-of-crown-2nd-edition", "ice-fall"):
+        assert should_hide_game_from_search(slug) is False

--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,11 @@
       "source": "/games/heart-of-crown",
       "destination": "/games/heart-of-crown-2nd-edition",
       "permanent": true
+    },
+    {
+      "source": "/games/icefall",
+      "destination": "/games/ice-fall",
+      "permanent": true
     }
   ],
   "rewrites": [


### PR DESCRIPTION
Continue #256 with the remaining production exact-title duplicate `ice-fall` / `icefall`.

Player-facing success condition: searching or browsing ICE FALL resolves only to the Smart Ape Games 2025 climbing-race product; the unrelated legacy `icefall` record is retired and redirects to `/games/ice-fall`; the canonical page no longer exposes the incorrect penguin/ice-hammer rule body.

Primary evidence:
- Smart Ape Games official Game Market product page: https://gamemarket.jp/game/184994
- Smart Ape Games booth confirms ICEFALL as its 2025 spring title, 3–5 players, 30–45 minutes, age 10+.
- The legacy `icefall` row points to https://gamemarket.jp/game/179294, which is currently the unrelated game バーニング📛キョウト.

Changes:
- verify `ice-fall` against the first-party Smart Ape Games page
- correct title/language/publisher/basic metadata
- remove the demonstrably wrong penguin/ice-hammer legacy rule body and keep review_required until source-bound rules are added
- retire `icefall` from search/directory/API canonical reads
- permanently redirect `/games/icefall` to `/games/ice-fall`
- extend shared visibility regression coverage

No destructive row merge or inferred rule reconstruction is performed.