### PR TITLE
Remove legacy Supabase game upsert alias

### DIFF
--- a/backend/app/core/supabase.py
+++ b/backend/app/core/supabase.py
@@ -243,11 +243,6 @@ async def increment_view_count(game_id: str) -> None:
     await anyio.to_thread.run_sync(_q)
 
 
-# Legacy alias
-async def upsert(data: dict[str, Any]) -> List[dict[str, Any]]:
-    return [await upsert_game(data)]
-
-
 async def list_for_sitemap() -> list[dict[str, Any]]:
     if is_local():
         res = local_db.list_recent(limit=50000)

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -154,7 +154,4 @@ class GameService:
         await _validate_manual_title_update(game, merged, safe_updates)
         await _validate_manual_source_update(game, safe_updates)
         merged["updated_at"] = datetime.now(UTC).isoformat()
-        out = await supabase.upsert(merged)
-        if not out:
-            raise RuntimeError(f"Update failed for game: {slug}")
-        return out[0]
+        return await supabase.upsert_game(merged)


### PR DESCRIPTION
Continue #386 by removing the remaining live `supabase.upsert()` compatibility alias from canonical game mutation.

Player-facing success condition: authorized manual game corrections continue to return the updated canonical game through the existing `upsert_game()` path, with no duplicate write contract remaining in the runtime.

Changes:
- call `supabase.upsert_game()` directly from `GameService.update_game_manual()`
- remove the legacy list-returning `supabase.upsert()` wrapper
- preserve existing identity/source coherence validation and public read behavior

No schema, rule content, game identity, or public route semantics are changed.