### PR TITLE
Correct Jumble Derby release metadata

### DIFF
--- a/backend/app/db/migrations/064_correct_jumble_derby_release_metadata.sql
+++ b/backend/app/db/migrations/064_correct_jumble_derby_release_metadata.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+-- Align residual catalog metadata with the creator's 2023秋 release identity.
+-- No authoritative BoardGameGeek record was verified during the source audit, so do not retain the stale imported link as canonical metadata.
+UPDATE public.games
+SET published_year=2023,
+    bgg_url=NULL,
+    updated_at=now()
+WHERE slug='jumble-derby'
+  AND identity_status='verified'
+  AND identity_source='https://gamemarket.jp/game/181906';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM public.games
+    WHERE slug='jumble-derby'
+      AND (published_year IS DISTINCT FROM 2023 OR bgg_url IS NOT NULL)
+  ) THEN
+    RAISE EXCEPTION 'Jumble Derby release metadata must be 2023 with no unverified BGG URL';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
Production readback after #441 still exposed two stale import fields on the now-verified Jumble Derby record: `published_year=2019` and an unverified BoardGameGeek URL. The creator's Game Market listing identifies this product as a 2023秋 release.

This migration sets `published_year=2023` and clears the unverified BGG link. It does not change the source-bound RuleSet, views, or affiliate URL.

Acceptance: public API must report 2023, no BGG URL, retain verified creator identity, 18 views, affiliate URL, and the 3 source-bound rules from #441.