### PR TITLE
Add batch RuleOps candidate report

### DIFF
--- a/.github/workflows/test-ruleops.yml
+++ b/.github/workflows/test-ruleops.yml
@@ -1,0 +1,39 @@
+name: Test RuleOps
+
+on:
+  pull_request:
+    paths:
+      - "backend/app/scripts/ruleops_*.py"
+      - "backend/tests/test_ruleops_*.py"
+      - ".github/workflows/test-ruleops.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/app/scripts/ruleops_*.py"
+      - "backend/tests/test_ruleops_*.py"
+      - ".github/workflows/test-ruleops.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  ruleops:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      - name: Install Python dependencies
+        run: uv sync --frozen --dev
+
+      - name: Compile RuleOps
+        run: uv run python -m compileall -q backend/app/scripts/ruleops_candidates.py
+
+      - name: Run RuleOps regression tests
+        env:
+          PYTHONPATH: backend
+        run: uv run pytest -q backend/tests/test_ruleops_candidates.py

--- a/backend/app/scripts/ruleops_candidates.py
+++ b/backend/app/scripts/ruleops_candidates.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import argparse
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+DEFAULT_BASE_URL = "https://bodoge-no-mikata.vercel.app"
+USER_AGENT = "rule-scribe-games-ruleops-candidates/1.0"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    slug: str
+    title: str
+    view_count: int
+    search_count: int
+    has_affiliate_path: bool
+    identity_status: str
+    source_url: str | None
+    source_trust: str
+    content_review_status: str
+    has_active_source_bound_ruleset: bool | None
+    has_legacy_rules_content: bool | None
+    triage_state: str
+    blocker_reason: str | None
+    read_error: str | None = None
+
+
+def _get_json(url: str, timeout_seconds: float) -> Any:
+    request = Request(
+        url,
+        headers={"Accept": "application/json", "User-Agent": USER_AGENT},
+    )
+    with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+        if response.status != 200:
+            raise RuntimeError(f"GET {url} returned HTTP {response.status}")
+        return json.load(response)
+
+
+def _active_source_bound(ruleset_payload: dict[str, Any]) -> bool:
+    return any(
+        bool(item.get("is_active", True))
+        and item.get("status") == "active"
+        and item.get("verification_status") in {"source_bound", "verified"}
+        for item in ruleset_payload.get("rulesets", [])
+        if isinstance(item, dict)
+    )
+
+
+def _affiliate_present(game: dict[str, Any]) -> bool:
+    if game.get("amazon_url"):
+        return True
+    affiliate_urls = game.get("affiliate_urls")
+    return isinstance(affiliate_urls, dict) and any(bool(value) for value in affiliate_urls.values())
+
+
+def _triage(
+    game: dict[str, Any],
+    has_source_bound: bool | None,
+    read_error: str | None,
+) -> tuple[str, str | None]:
+    if read_error:
+        return "blocked", "production_read_failed"
+    if has_source_bound:
+        return "already_source_bound", None
+    if game.get("identity_status") != "verified":
+        return "needs_review", "identity_not_verified"
+    if not game.get("source_url") or game.get("source_trust") not in {
+        "official_publisher",
+        "authorized_partner",
+    }:
+        return "needs_review", "primary_source_not_bound"
+    return "source_triage", None
+
+
+def build_candidate(
+    game: dict[str, Any],
+    *,
+    has_source_bound: bool | None,
+    has_legacy_rules_content: bool | None,
+    read_error: str | None = None,
+) -> Candidate:
+    triage_state, blocker_reason = _triage(game, has_source_bound, read_error)
+    return Candidate(
+        slug=str(game.get("slug") or ""),
+        title=str(game.get("title_ja") or game.get("title") or game.get("slug") or ""),
+        view_count=int(game.get("view_count") or 0),
+        search_count=int(game.get("search_count") or 0),
+        has_affiliate_path=_affiliate_present(game),
+        identity_status=str(game.get("identity_status") or "unverified"),
+        source_url=game.get("source_url"),
+        source_trust=str(game.get("source_trust") or "unknown"),
+        content_review_status=str(game.get("content_review_status") or "unknown"),
+        has_active_source_bound_ruleset=has_source_bound,
+        has_legacy_rules_content=has_legacy_rules_content,
+        triage_state=triage_state,
+        blocker_reason=blocker_reason,
+        read_error=read_error,
+    )
+
+
+def candidate_sort_key(candidate: Candidate) -> tuple[int, int, int, str]:
+    return (
+        -candidate.view_count,
+        -int(candidate.has_affiliate_path),
+        -candidate.search_count,
+        candidate.slug,
+    )
+
+
+def _fetch_catalog(base_url: str, timeout_seconds: float, page_size: int = 100) -> list[dict[str, Any]]:
+    games: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        query = urlencode({"limit": page_size, "offset": offset, "sort": "popular"})
+        payload = _get_json(f"{base_url.rstrip('/')}/api/games?{query}", timeout_seconds)
+        page = payload.get("games", [])
+        if not isinstance(page, list):
+            raise ValueError("/api/games response must contain a games array")
+        games.extend(item for item in page if isinstance(item, dict) and item.get("slug"))
+        total = int(payload.get("total") or 0)
+        offset += len(page)
+        if not page or offset >= total:
+            return games
+
+
+def _fetch_state(base_url: str, slug: str, timeout_seconds: float) -> tuple[bool, bool]:
+    escaped_slug = quote(slug, safe="")
+    detail = _get_json(f"{base_url.rstrip('/')}/api/games/{escaped_slug}", timeout_seconds)
+    rulesets = _get_json(f"{base_url.rstrip('/')}/api/games/{escaped_slug}/rule-sets", timeout_seconds)
+    return _active_source_bound(rulesets), bool(detail.get("rules_content"))
+
+
+def generate_report(
+    base_url: str = DEFAULT_BASE_URL,
+    *,
+    timeout_seconds: float = 20.0,
+    workers: int = 8,
+    include_source_bound: bool = False,
+) -> dict[str, Any]:
+    games = _fetch_catalog(base_url, timeout_seconds)
+    by_slug = {str(game["slug"]): game for game in games}
+    candidates: list[Candidate] = []
+
+    with ThreadPoolExecutor(max_workers=max(1, workers)) as executor:
+        future_to_slug = {
+            executor.submit(_fetch_state, base_url, slug, timeout_seconds): slug for slug in by_slug
+        }
+        for future in as_completed(future_to_slug):
+            slug = future_to_slug[future]
+            game = by_slug[slug]
+            try:
+                has_source_bound, has_legacy = future.result()
+                candidate = build_candidate(
+                    game,
+                    has_source_bound=has_source_bound,
+                    has_legacy_rules_content=has_legacy,
+                )
+            except Exception as exc:  # keep the rest of the batch observable
+                candidate = build_candidate(
+                    game,
+                    has_source_bound=None,
+                    has_legacy_rules_content=None,
+                    read_error=f"{type(exc).__name__}: {exc}",
+                )
+            if include_source_bound or candidate.triage_state != "already_source_bound":
+                candidates.append(candidate)
+
+    candidates.sort(key=candidate_sort_key)
+    return {
+        "schema_version": "1.0",
+        "source": base_url.rstrip("/"),
+        "catalog_games": len(games),
+        "candidate_games": len(candidates),
+        "candidates": [asdict(candidate) for candidate in candidates],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Rank public catalog games that still need source-bound RuleSet work"
+    )
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    parser.add_argument("--workers", type=int, default=8)
+    parser.add_argument("--include-source-bound", action="store_true")
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    report = generate_report(
+        args.base_url,
+        timeout_seconds=args.timeout_seconds,
+        workers=args.workers,
+        include_source_bound=args.include_source_bound,
+    )
+    rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_ruleops_candidates.py
+++ b/backend/tests/test_ruleops_candidates.py
@@ -1,0 +1,143 @@
+from app.scripts.ruleops_candidates import build_candidate, candidate_sort_key
+
+
+def test_source_bound_game_is_not_a_candidate_for_migration():
+    game = {
+        "slug": "verified-game",
+        "title": "Verified Game",
+        "view_count": 7,
+        "identity_status": "verified",
+        "source_url": "https://publisher.example/rules",
+        "source_trust": "official_publisher",
+        "content_review_status": "human_reviewed",
+    }
+
+    candidate = build_candidate(
+        game,
+        has_source_bound=True,
+        has_legacy_rules_content=False,
+    )
+
+    assert candidate.triage_state == "already_source_bound"
+    assert candidate.blocker_reason is None
+
+
+def test_unverified_identity_requires_review_before_source_work():
+    game = {
+        "slug": "unknown-edition",
+        "title_ja": "版未確認",
+        "view_count": 20,
+        "amazon_url": "https://example.com/affiliate",
+        "identity_status": "unverified",
+        "source_url": "https://publisher.example/product",
+        "source_trust": "official_publisher",
+        "content_review_status": "review_required",
+    }
+
+    candidate = build_candidate(
+        game,
+        has_source_bound=False,
+        has_legacy_rules_content=True,
+    )
+
+    assert candidate.has_affiliate_path is True
+    assert candidate.triage_state == "needs_review"
+    assert candidate.blocker_reason == "identity_not_verified"
+
+
+def test_verified_primary_source_moves_to_source_triage_not_auto_verified():
+    game = {
+        "slug": "ready-for-research",
+        "title": "Ready for Research",
+        "view_count": 11,
+        "identity_status": "verified",
+        "source_url": "https://publisher.example/product",
+        "source_trust": "official_publisher",
+        "content_review_status": "review_required",
+    }
+
+    candidate = build_candidate(
+        game,
+        has_source_bound=False,
+        has_legacy_rules_content=True,
+    )
+
+    assert candidate.triage_state == "source_triage"
+    assert candidate.blocker_reason is None
+
+
+def test_primary_source_is_required_for_source_triage():
+    game = {
+        "slug": "missing-source",
+        "title": "Missing Source",
+        "view_count": 9,
+        "identity_status": "verified",
+        "source_url": None,
+        "source_trust": "unknown",
+        "content_review_status": "review_required",
+    }
+
+    candidate = build_candidate(
+        game,
+        has_source_bound=False,
+        has_legacy_rules_content=False,
+    )
+
+    assert candidate.triage_state == "needs_review"
+    assert candidate.blocker_reason == "primary_source_not_bound"
+
+
+def test_read_failure_is_reported_without_guessing_state():
+    game = {
+        "slug": "read-failed",
+        "title": "Read Failed",
+        "view_count": 12,
+        "identity_status": "verified",
+        "source_url": "https://publisher.example/product",
+        "source_trust": "official_publisher",
+    }
+
+    candidate = build_candidate(
+        game,
+        has_source_bound=None,
+        has_legacy_rules_content=None,
+        read_error="TimeoutError: timed out",
+    )
+
+    assert candidate.triage_state == "blocked"
+    assert candidate.blocker_reason == "production_read_failed"
+    assert candidate.has_active_source_bound_ruleset is None
+
+
+def test_priority_uses_direct_usage_then_commerce_then_search():
+    common = {
+        "identity_status": "verified",
+        "source_url": "https://publisher.example/product",
+        "source_trust": "official_publisher",
+    }
+    high_views = build_candidate(
+        {**common, "slug": "a", "title": "A", "view_count": 20, "search_count": 1},
+        has_source_bound=False,
+        has_legacy_rules_content=True,
+    )
+    commerce = build_candidate(
+        {
+            **common,
+            "slug": "b",
+            "title": "B",
+            "view_count": 10,
+            "search_count": 2,
+            "amazon_url": "https://example.com/affiliate",
+        },
+        has_source_bound=False,
+        has_legacy_rules_content=True,
+    )
+    no_commerce = build_candidate(
+        {**common, "slug": "c", "title": "C", "view_count": 10, "search_count": 99},
+        has_source_bound=False,
+        has_legacy_rules_content=True,
+    )
+
+    ranked = sorted([no_commerce, commerce, high_views], key=candidate_sort_key)
+
+    assert [candidate.slug for candidate in ranked] == ["a", "b", "c"]


### PR DESCRIPTION
Implements the first reusable slice of #451.

Player-facing success condition: operators can identify all public games that still need source-bound work from one machine-readable production report, without opening each game manually.

This PR adds a production-backed candidate CLI that:
- paginates the public catalog once;
- reads game detail + RuleSet state concurrently;
- reports view/search usage, affiliate presence, identity/source/review state, active source-bound state, and legacy rule presence;
- ranks by direct usage first, then existing commerce path and search usage;
- never auto-promotes a game to verified migration readiness;
- reports per-game read failures without losing the rest of the batch.

It adds pure regression tests for source-bound exclusion, identity/source review gates, read failures, and deterministic ranking, plus one shared RuleOps CI workflow for RuleOps scripts/tests.

No new API, database table, game-specific workflow, or game-specific helper is introduced.