### PR TITLE
Add versioned RuleOps source manifest validation

### DIFF
--- a/.github/workflows/test-ruleops.yml
+++ b/.github/workflows/test-ruleops.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "backend/app/scripts/ruleops_*.py"
+      - "backend/app/ruleops/**"
       - "backend/tests/test_ruleops_*.py"
       - ".github/workflows/test-ruleops.yml"
   push:
@@ -11,6 +12,7 @@ on:
       - main
     paths:
       - "backend/app/scripts/ruleops_*.py"
+      - "backend/app/ruleops/**"
       - "backend/tests/test_ruleops_*.py"
       - ".github/workflows/test-ruleops.yml"
 
@@ -31,9 +33,12 @@ jobs:
         run: uv sync --frozen --dev
 
       - name: Compile RuleOps
-        run: uv run python -m compileall -q backend/app/scripts/ruleops_candidates.py
+        run: uv run python -m compileall -q backend/app/scripts/ruleops_candidates.py backend/app/scripts/ruleops_manifest.py
+
+      - name: Validate manifest schema JSON
+        run: uv run python -m json.tool backend/app/ruleops/source-manifest.schema.json > /dev/null
 
       - name: Run RuleOps regression tests
         env:
           PYTHONPATH: backend
-        run: uv run pytest -q backend/tests/test_ruleops_candidates.py
+        run: uv run pytest -q backend/tests/test_ruleops_*.py

--- a/backend/app/ruleops/source-manifest.schema.json
+++ b/backend/app/ruleops/source-manifest.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/KAFKA2306/rule-scribe-games/backend/app/ruleops/source-manifest.schema.json",
+  "title": "RuleOps Source Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "batch_id", "games"],
+  "properties": {
+    "schema_version": {"const": "1.0"},
+    "batch_id": {"type": "string", "minLength": 1},
+    "games": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/game"}
+    }
+  },
+  "$defs": {
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["title", "edition", "language", "platform", "revision"],
+      "properties": {
+        "title": {"type": "string", "minLength": 1},
+        "edition": {"type": "string", "minLength": 1},
+        "language": {"type": "string", "minLength": 1},
+        "platform": {"enum": ["physical", "digital", "vrchat"]},
+        "revision": {"type": "string", "minLength": 1}
+      }
+    },
+    "scope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["included_product", "excluded_products"],
+      "properties": {
+        "included_product": {"type": "string", "minLength": 1},
+        "excluded_products": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_id",
+        "url",
+        "source_type",
+        "review_status",
+        "applies_to_revision",
+        "applies_to_platform"
+      ],
+      "properties": {
+        "source_id": {"type": "string", "minLength": 1},
+        "url": {"type": "string", "format": "uri"},
+        "source_type": {
+          "enum": [
+            "publisher_rulebook",
+            "publisher_faq",
+            "publisher_errata",
+            "publisher_product_page",
+            "designer_rulebook",
+            "creator_rulebook",
+            "creator_listing"
+          ]
+        },
+        "revision_label": {"type": ["string", "null"]},
+        "review_status": {"const": "reviewed"},
+        "applies_to_revision": {"type": "string", "minLength": 1},
+        "applies_to_platform": {"enum": ["physical", "digital", "vrchat"]}
+      }
+    },
+    "rule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rule_id", "node_type", "claim", "source_id", "evidence_locator", "review_status"],
+      "properties": {
+        "rule_id": {"type": "string", "minLength": 1},
+        "node_type": {
+          "enum": ["setup", "turn", "action", "condition", "effect", "scoring", "round_end", "victory"]
+        },
+        "claim": {"type": "string", "minLength": 1},
+        "source_id": {"type": "string", "minLength": 1},
+        "evidence_locator": {"type": "string", "minLength": 1},
+        "review_status": {"const": "reviewed"}
+      }
+    },
+    "game": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "slug",
+        "identity",
+        "scope",
+        "review_status",
+        "remove_legacy_authority",
+        "sources",
+        "rules"
+      ],
+      "properties": {
+        "slug": {"type": "string", "minLength": 1},
+        "identity": {"$ref": "#/$defs/identity"},
+        "scope": {"$ref": "#/$defs/scope"},
+        "review_status": {"const": "reviewed"},
+        "remove_legacy_authority": {"type": "boolean"},
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/source"}
+        },
+        "rules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/rule"}
+        }
+      }
+    }
+  }
+}

--- a/backend/app/scripts/ruleops_manifest.py
+++ b/backend/app/scripts/ruleops_manifest.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+SCHEMA_VERSION = "1.0"
+REVIEWED = "reviewed"
+PRIMARY_SOURCE_TYPES = {
+    "publisher_rulebook",
+    "publisher_faq",
+    "publisher_errata",
+    "publisher_product_page",
+    "designer_rulebook",
+    "creator_rulebook",
+    "creator_listing",
+}
+RULE_SOURCE_TYPES = PRIMARY_SOURCE_TYPES - {"publisher_product_page", "creator_listing"}
+CANONICAL_NODE_TYPES = {
+    "setup",
+    "turn",
+    "action",
+    "condition",
+    "effect",
+    "scoring",
+    "round_end",
+    "victory",
+}
+PLATFORMS = {"physical", "digital", "vrchat"}
+
+
+@dataclass(frozen=True)
+class ValidationError:
+    slug: str
+    code: str
+    path: str
+    message: str
+
+
+def _nonempty(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _http_url(value: Any) -> bool:
+    if not _nonempty(value):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def _error(errors: list[ValidationError], slug: str, code: str, path: str, message: str) -> None:
+    errors.append(ValidationError(slug=slug, code=code, path=path, message=message))
+
+
+def validate_game_manifest(game: dict[str, Any]) -> list[ValidationError]:
+    slug = str(game.get("slug") or "<missing-slug>")
+    errors: list[ValidationError] = []
+
+    identity = game.get("identity")
+    if not isinstance(identity, dict):
+        _error(errors, slug, "missing_identity", "identity", "identity object is required")
+        return errors
+
+    for field in ("title", "edition", "language", "platform", "revision"):
+        if not _nonempty(identity.get(field)):
+            _error(errors, slug, "missing_identity_field", f"identity.{field}", f"{field} is required")
+
+    if identity.get("platform") not in PLATFORMS:
+        _error(
+            errors,
+            slug,
+            "invalid_platform",
+            "identity.platform",
+            f"platform must be one of {sorted(PLATFORMS)}",
+        )
+
+    if game.get("review_status") != REVIEWED:
+        _error(errors, slug, "game_not_reviewed", "review_status", "game manifest must be reviewed")
+
+    scope = game.get("scope")
+    if not isinstance(scope, dict):
+        _error(errors, slug, "missing_scope", "scope", "scope object is required")
+    else:
+        if not _nonempty(scope.get("included_product")):
+            _error(errors, slug, "missing_included_product", "scope.included_product", "included product is required")
+        excluded = scope.get("excluded_products")
+        if not isinstance(excluded, list):
+            _error(errors, slug, "missing_excluded_products", "scope.excluded_products", "excluded_products must be a list")
+        elif any(not _nonempty(item) for item in excluded):
+            _error(errors, slug, "invalid_excluded_product", "scope.excluded_products", "excluded products must be non-empty strings")
+
+    sources = game.get("sources")
+    if not isinstance(sources, list) or not sources:
+        _error(errors, slug, "missing_primary_source", "sources", "at least one primary source is required")
+        sources = []
+
+    source_by_id: dict[str, dict[str, Any]] = {}
+    for index, source in enumerate(sources):
+        path = f"sources[{index}]"
+        if not isinstance(source, dict):
+            _error(errors, slug, "invalid_source", path, "source must be an object")
+            continue
+        source_id = source.get("source_id")
+        if not _nonempty(source_id):
+            _error(errors, slug, "missing_source_id", f"{path}.source_id", "source_id is required")
+            continue
+        if source_id in source_by_id:
+            _error(errors, slug, "duplicate_source", f"{path}.source_id", f"duplicate source_id {source_id}")
+        source_by_id[source_id] = source
+        if source.get("source_type") not in PRIMARY_SOURCE_TYPES:
+            _error(
+                errors,
+                slug,
+                "invalid_source_type",
+                f"{path}.source_type",
+                f"source_type must be one of {sorted(PRIMARY_SOURCE_TYPES)}",
+            )
+        if not _http_url(source.get("url")):
+            _error(errors, slug, "invalid_source_url", f"{path}.url", "source URL must be absolute http(s)")
+        if source.get("review_status") != REVIEWED:
+            _error(errors, slug, "source_not_reviewed", f"{path}.review_status", "source must be reviewed")
+        if source.get("applies_to_revision") != identity.get("revision"):
+            _error(
+                errors,
+                slug,
+                "revision_mismatch",
+                f"{path}.applies_to_revision",
+                "source revision binding must exactly match identity.revision",
+            )
+        if source.get("applies_to_platform") != identity.get("platform"):
+            _error(
+                errors,
+                slug,
+                "platform_mismatch",
+                f"{path}.applies_to_platform",
+                "source platform binding must exactly match identity.platform",
+            )
+
+    rules = game.get("rules")
+    if not isinstance(rules, list) or not rules:
+        _error(errors, slug, "missing_rules", "rules", "at least one reviewed rule is required")
+        rules = []
+
+    rule_ids: set[str] = set()
+    claims: set[str] = set()
+    binding_keys: set[tuple[str, str, str]] = set()
+    for index, rule in enumerate(rules):
+        path = f"rules[{index}]"
+        if not isinstance(rule, dict):
+            _error(errors, slug, "invalid_rule", path, "rule must be an object")
+            continue
+
+        rule_id = rule.get("rule_id")
+        if not _nonempty(rule_id):
+            _error(errors, slug, "missing_rule_id", f"{path}.rule_id", "rule_id is required")
+        elif rule_id in rule_ids:
+            _error(errors, slug, "duplicate_rule", f"{path}.rule_id", f"duplicate rule_id {rule_id}")
+        else:
+            rule_ids.add(rule_id)
+
+        node_type = rule.get("node_type")
+        if node_type not in CANONICAL_NODE_TYPES:
+            _error(
+                errors,
+                slug,
+                "invalid_node_type",
+                f"{path}.node_type",
+                f"node_type must be one of {sorted(CANONICAL_NODE_TYPES)}",
+            )
+
+        claim = rule.get("claim")
+        if not _nonempty(claim):
+            _error(errors, slug, "missing_claim", f"{path}.claim", "claim text is required")
+        elif claim in claims:
+            _error(errors, slug, "duplicate_claim", f"{path}.claim", "duplicate claim text")
+        else:
+            claims.add(claim)
+
+        if rule.get("review_status") != REVIEWED:
+            _error(errors, slug, "rule_not_reviewed", f"{path}.review_status", "rule must be reviewed")
+
+        source_id = rule.get("source_id")
+        source = source_by_id.get(str(source_id))
+        if source is None:
+            _error(errors, slug, "missing_rule_source", f"{path}.source_id", "rule must reference a declared source")
+        elif source.get("source_type") not in RULE_SOURCE_TYPES:
+            _error(
+                errors,
+                slug,
+                "non_rule_source",
+                f"{path}.source_id",
+                "rule claims require a rulebook/FAQ/errata/creator rule source, not identity-only evidence",
+            )
+
+        locator = rule.get("evidence_locator")
+        if not _nonempty(locator):
+            _error(errors, slug, "missing_evidence_locator", f"{path}.evidence_locator", "evidence locator is required")
+
+        binding_key = (str(rule_id), str(source_id), str(locator))
+        if binding_key in binding_keys:
+            _error(errors, slug, "duplicate_binding", path, "duplicate rule/source/locator binding")
+        else:
+            binding_keys.add(binding_key)
+
+    if bool(game.get("remove_legacy_authority")) and not rules:
+        _error(
+            errors,
+            slug,
+            "empty_replacement_coverage",
+            "remove_legacy_authority",
+            "legacy authority cannot be removed without reviewed source-bound rules",
+        )
+
+    return errors
+
+
+def validate_manifest(payload: dict[str, Any]) -> dict[str, Any]:
+    batch_errors: list[ValidationError] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        batch_errors.append(
+            ValidationError(
+                slug="<batch>",
+                code="unsupported_schema_version",
+                path="schema_version",
+                message=f"schema_version must be {SCHEMA_VERSION}",
+            )
+        )
+
+    games = payload.get("games")
+    if not isinstance(games, list) or not games:
+        batch_errors.append(
+            ValidationError(
+                slug="<batch>", code="missing_games", path="games", message="games must be a non-empty list"
+            )
+        )
+        games = []
+
+    seen_slugs: set[str] = set()
+    game_results: list[dict[str, Any]] = []
+    for game in games:
+        slug = str(game.get("slug") or "<missing-slug>") if isinstance(game, dict) else "<invalid-game>"
+        errors = validate_game_manifest(game) if isinstance(game, dict) else [
+            ValidationError(slug=slug, code="invalid_game", path="games", message="game must be an object")
+        ]
+        if slug in seen_slugs:
+            errors.append(ValidationError(slug=slug, code="duplicate_game", path="slug", message="duplicate game slug"))
+        seen_slugs.add(slug)
+        game_results.append({
+            "slug": slug,
+            "status": "ready" if not errors else "blocked",
+            "errors": [asdict(error) for error in errors],
+        })
+
+    all_errors = batch_errors + [
+        ValidationError(**error)
+        for result in game_results
+        for error in result["errors"]
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ready" if not all_errors else "blocked",
+        "ready_games": sum(1 for result in game_results if result["status"] == "ready"),
+        "blocked_games": sum(1 for result in game_results if result["status"] == "blocked"),
+        "batch_errors": [asdict(error) for error in batch_errors],
+        "games": game_results,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate reviewed RuleOps source manifests before SQL generation")
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    payload = json.loads(args.manifest.read_text(encoding="utf-8"))
+    report = validate_manifest(payload)
+    rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    raise SystemExit(0 if report["status"] == "ready" else 2)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_ruleops_manifest.py
+++ b/backend/tests/test_ruleops_manifest.py
@@ -1,0 +1,157 @@
+from app.scripts.ruleops_manifest import validate_manifest
+
+
+def valid_game(slug: str = "example-game"):
+    revision = "publisher-2026-base"
+    return {
+        "slug": slug,
+        "identity": {
+            "title": "Example Game",
+            "edition": "Base Game 2026",
+            "language": "ja",
+            "platform": "physical",
+            "revision": revision,
+        },
+        "scope": {
+            "included_product": "Base Game 2026",
+            "excluded_products": ["Expansion", "Digital Edition"],
+        },
+        "review_status": "reviewed",
+        "remove_legacy_authority": True,
+        "sources": [
+            {
+                "source_id": "publisher:example:rulebook",
+                "url": "https://publisher.example/rules.pdf",
+                "source_type": "publisher_rulebook",
+                "revision_label": "2026 rules",
+                "review_status": "reviewed",
+                "applies_to_revision": revision,
+                "applies_to_platform": "physical",
+            }
+        ],
+        "rules": [
+            {
+                "rule_id": "setup.base",
+                "node_type": "setup",
+                "claim": "各プレイヤーに初期手札を配る。",
+                "source_id": "publisher:example:rulebook",
+                "evidence_locator": "p.2 Setup",
+                "review_status": "reviewed",
+            }
+        ],
+    }
+
+
+def test_valid_reviewed_manifest_is_ready():
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-001", "games": [valid_game()]}
+    )
+
+    assert report["status"] == "ready"
+    assert report["ready_games"] == 1
+    assert report["blocked_games"] == 0
+
+
+def test_invalid_game_does_not_hide_ready_sibling():
+    bad = valid_game("bad-game")
+    bad["identity"]["revision"] = "other-revision"
+
+    report = validate_manifest(
+        {
+            "schema_version": "1.0",
+            "batch_id": "pilot-002",
+            "games": [valid_game("good-game"), bad],
+        }
+    )
+
+    assert report["status"] == "blocked"
+    assert report["ready_games"] == 1
+    assert report["blocked_games"] == 1
+    bad_result = next(game for game in report["games"] if game["slug"] == "bad-game")
+    assert any(error["code"] == "revision_mismatch" for error in bad_result["errors"])
+
+
+def test_identity_only_source_cannot_support_rule_claim():
+    game = valid_game()
+    game["sources"][0]["source_type"] = "publisher_product_page"
+
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-003", "games": [game]}
+    )
+
+    errors = report["games"][0]["errors"]
+    assert any(error["code"] == "non_rule_source" for error in errors)
+
+
+def test_invalid_node_type_is_rejected_before_sql_generation():
+    game = valid_game()
+    game["rules"][0]["node_type"] = "penalty"
+
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-004", "games": [game]}
+    )
+
+    errors = report["games"][0]["errors"]
+    assert any(error["code"] == "invalid_node_type" for error in errors)
+
+
+def test_missing_evidence_and_duplicate_binding_are_rejected():
+    game = valid_game()
+    game["rules"].append(
+        {
+            "rule_id": "setup.second",
+            "node_type": "setup",
+            "claim": "別の準備を行う。",
+            "source_id": "publisher:example:rulebook",
+            "evidence_locator": "p.2 Setup",
+            "review_status": "reviewed",
+        }
+    )
+    game["rules"][0]["evidence_locator"] = ""
+
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-005", "games": [game]}
+    )
+
+    errors = report["games"][0]["errors"]
+    assert any(error["code"] == "missing_evidence_locator" for error in errors)
+
+
+def test_duplicate_rule_claim_and_source_are_rejected():
+    game = valid_game()
+    duplicate = dict(game["rules"][0])
+    game["rules"].append(duplicate)
+    game["sources"].append(dict(game["sources"][0]))
+
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-006", "games": [game]}
+    )
+
+    codes = {error["code"] for error in report["games"][0]["errors"]}
+    assert "duplicate_source" in codes
+    assert "duplicate_rule" in codes
+    assert "duplicate_claim" in codes
+    assert "duplicate_binding" in codes
+
+
+def test_unreviewed_game_source_or_rule_is_blocked():
+    game = valid_game()
+    game["review_status"] = "needs_review"
+    game["sources"][0]["review_status"] = "needs_review"
+    game["rules"][0]["review_status"] = "needs_review"
+
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-007", "games": [game]}
+    )
+
+    codes = {error["code"] for error in report["games"][0]["errors"]}
+    assert {"game_not_reviewed", "source_not_reviewed", "rule_not_reviewed"} <= codes
+
+
+def test_unsupported_schema_version_blocks_batch():
+    report = validate_manifest(
+        {"schema_version": "2.0", "batch_id": "pilot-008", "games": [valid_game()]}
+    )
+
+    assert report["status"] == "blocked"
+    assert report["batch_errors"][0]["code"] == "unsupported_schema_version"


### PR DESCRIPTION
Continues #451 after the merged candidate report.

Player-facing success condition: a batch can contain multiple reviewed game migrations while invalid edition/source/evidence work is blocked before SQL generation, without hiding ready sibling games.

This PR adds:
- versioned `source-manifest.schema.json` for identity, edition, language, platform, revision, source, scope, and rule claims;
- a pure-stdlib dry-run validator with game-level `ready/blocked` results;
- rejection of unreviewed manifests, revision/platform mismatch, identity-only evidence used for rule claims, invalid RuleNode types, missing locators, duplicate sources/rules/claims/bindings, and empty replacement coverage;
- RuleOps CI coverage for the manifest schema and validator.

No DB write, migration generator, game-specific helper, API, or workflow is added. A blocked game does not discard validation results for ready games in the same batch.