### PR TITLE
Generate batch RuleOps migrations from reviewed manifests

### DIFF
--- a/.github/workflows/test-ruleops.yml
+++ b/.github/workflows/test-ruleops.yml
@@ -33,7 +33,7 @@ jobs:
         run: uv sync --frozen --dev
 
       - name: Compile RuleOps
-        run: uv run python -m compileall -q backend/app/scripts/ruleops_candidates.py backend/app/scripts/ruleops_manifest.py
+        run: uv run python -m compileall -q backend/app/scripts/ruleops_candidates.py backend/app/scripts/ruleops_manifest.py backend/app/scripts/ruleops_generate_migration.py
 
       - name: Validate manifest schema JSON
         run: uv run python -m json.tool backend/app/ruleops/source-manifest.schema.json > /dev/null

--- a/backend/app/scripts/ruleops_generate_migration.py
+++ b/backend/app/scripts/ruleops_generate_migration.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from app.scripts.ruleops_manifest import validate_manifest
+
+
+def sql_literal(value: str | None) -> str:
+    if value is None:
+        return "NULL"
+    return "'" + value.replace("'", "''") + "'"
+
+
+def sql_text_array(values: list[str]) -> str:
+    return "ARRAY[" + ",".join(sql_literal(value) for value in values) + "]::text[]"
+
+
+def safe_identifier(value: str) -> str:
+    rendered = re.sub(r"[^a-zA-Z0-9]+", "_", value).strip("_").lower()
+    return rendered or "batch"
+
+
+def source_trust(source_type: str) -> str:
+    if source_type.startswith("publisher_"):
+        return "official_publisher"
+    if source_type.startswith("designer_"):
+        return "official_designer"
+    return "official_creator"
+
+
+def _render_source_rows(game: dict[str, Any]) -> str:
+    identity = game["identity"]
+    rows = []
+    for source in game["sources"]:
+        revision_label = source.get("revision_label") or identity["revision"]
+        trust = json.dumps(
+            {
+                "authority": source["source_type"],
+                "ruleops": True,
+                "scope": game["scope"]["included_product"],
+            },
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+        rows.append(
+            "(" + ",".join(
+                [
+                    sql_literal(source["source_id"]),
+                    sql_literal(source["url"]),
+                    sql_literal(f"{identity['title']} — {source['source_type']}"),
+                    sql_literal(source["source_type"]),
+                    "NULL",
+                    sql_literal(identity["platform"]),
+                    sql_literal(identity["language"]),
+                    sql_literal(revision_label),
+                    sql_literal(trust) + "::jsonb",
+                ]
+            ) + ")"
+        )
+    return ",\n".join(rows)
+
+
+def _render_locator_rows(game: dict[str, Any]) -> str:
+    rows = []
+    slug = game["slug"]
+    for rule in game["rules"]:
+        locator_id = f"{slug}:locator:{rule['rule_id']}"
+        rows.append(
+            "(" + ",".join(
+                [
+                    sql_literal(locator_id),
+                    sql_literal(rule["source_id"]),
+                    sql_literal(rule["evidence_locator"]),
+                    sql_literal(rule["evidence_locator"]),
+                ]
+            ) + ")"
+        )
+    return ",\n".join(rows)
+
+
+def _render_rule_rows(game: dict[str, Any]) -> str:
+    source_by_id = {source["source_id"]: source for source in game["sources"]}
+    rows = []
+    slug = game["slug"]
+    for index, rule in enumerate(game["rules"], start=1):
+        source = source_by_id[rule["source_id"]]
+        metadata = json.dumps({"ruleops_batch": True}, separators=(",", ":"))
+        rows.append(
+            "(" + ",".join(
+                [
+                    "v_ruleset_id",
+                    sql_literal(rule["rule_id"]),
+                    sql_literal(rule["node_type"]),
+                    sql_literal(rule["claim"]),
+                    str(index * 10),
+                    sql_literal("source_bound"),
+                    sql_literal(f"{slug}:rule:{rule['rule_id']}"),
+                    sql_literal(f"{slug}:binding:{rule['rule_id']}"),
+                    sql_literal(source["url"]),
+                    sql_literal(f"{slug}:locator:{rule['rule_id']}"),
+                    sql_literal(metadata) + "::jsonb",
+                ]
+            ) + ")"
+        )
+    return ",\n".join(rows)
+
+
+def render_game_sql(game: dict[str, Any], batch_id: str) -> str:
+    slug = game["slug"]
+    identity = game["identity"]
+    first_source = game["sources"][0]
+    source_ids = [source["source_id"] for source in game["sources"]]
+    count = len(game["rules"])
+    legacy_reset = ""
+    if game.get("remove_legacy_authority"):
+        legacy_reset = (
+            ", rules='{}'::jsonb, rules_content=NULL, structured_data='{}'::jsonb, "
+            "setup_summary=NULL, gameplay_summary=NULL, end_game_summary=NULL"
+        )
+
+    binding_values = []
+    for rule in game["rules"]:
+        binding_values.append(
+            "(" + ",".join(
+                [
+                    sql_literal(f"{slug}:binding:{rule['rule_id']}"),
+                    sql_literal(f"{slug}:rule:{rule['rule_id']}"),
+                    sql_literal(rule["source_id"]),
+                    sql_literal(f"{slug}:locator:{rule['rule_id']}"),
+                    sql_literal("supports"),
+                    sql_literal('{"review":"ruleops_reviewed_manifest"}') + "::jsonb",
+                    sql_literal(json.dumps({"batch_id": batch_id}, separators=(",", ":"))) + "::jsonb",
+                    "now()",
+                ]
+            ) + ")"
+        )
+
+    source_revision = identity["revision"]
+    trust = source_trust(first_source["source_type"])
+    return f"""
+-- RuleOps game: {slug} / {identity['edition']} / {identity['revision']}
+INSERT INTO public.evidence_sources (
+  source_id,url,document_identity,source_type,publisher_name,platform,language_code,revision_label,trust_metadata
+) VALUES
+{_render_source_rows(game)}
+ON CONFLICT (source_id) DO UPDATE SET
+  url=EXCLUDED.url,document_identity=EXCLUDED.document_identity,source_type=EXCLUDED.source_type,
+  publisher_name=EXCLUDED.publisher_name,platform=EXCLUDED.platform,language_code=EXCLUDED.language_code,
+  revision_label=EXCLUDED.revision_label,trust_metadata=EXCLUDED.trust_metadata,updated_at=now();
+
+INSERT INTO public.source_locators(locator_id,source_id,section_heading,external_reference) VALUES
+{_render_locator_rows(game)}
+ON CONFLICT (locator_id) DO UPDATE SET
+  source_id=EXCLUDED.source_id,section_heading=EXCLUDED.section_heading,external_reference=EXCLUDED.external_reference;
+
+DO $$
+DECLARE v_game_id uuid; v_work_id uuid; v_ruleset_id uuid;
+BEGIN
+  SELECT id,work_id INTO v_game_id,v_work_id FROM public.games WHERE slug={sql_literal(slug)} LIMIT 1;
+  IF v_game_id IS NULL THEN RAISE NOTICE 'RuleOps game {slug} absent; skipping'; RETURN; END IF;
+  IF v_work_id IS NULL THEN RAISE EXCEPTION 'Canonical Work row is required for {slug}'; END IF;
+
+  UPDATE public.games SET
+    title={sql_literal(identity['title'])},
+    identity_status='verified', identity_source={sql_literal(first_source['url'])},
+    source_url={sql_literal(first_source['url'])}, source_trust={sql_literal(trust)},
+    content_review_status='review_required', is_official=true,
+    edition_label={sql_literal(identity['edition'])}, language_code={sql_literal(identity['language'])},
+    source_revision={sql_literal(source_revision)}, updated_at=now(){legacy_reset}
+  WHERE id=v_game_id;
+
+  SELECT id INTO v_ruleset_id FROM public.rule_sets
+  WHERE game_id=v_game_id AND COALESCE(language_code,'')={sql_literal(identity['language'])}
+    AND COALESCE(edition_label,'')={sql_literal(identity['edition'])}
+    AND COALESCE(platform,'')={sql_literal(identity['platform'])}
+    AND COALESCE(revision_label,'')={sql_literal(identity['revision'])}
+    AND COALESCE(variant_label,'')='' AND version=1 LIMIT 1;
+
+  IF v_ruleset_id IS NULL THEN
+    INSERT INTO public.rule_sets(
+      game_id,work_id,version,schema_version,language_code,edition_label,source_revision,is_active,
+      revision_label,platform,publisher_name,status,verification_status,source_ids
+    ) VALUES(
+      v_game_id,v_work_id,1,'1.0',{sql_literal(identity['language'])},{sql_literal(identity['edition'])},
+      {sql_literal(source_revision)},true,{sql_literal(identity['revision'])},{sql_literal(identity['platform'])},NULL,
+      'active','source_bound',{sql_text_array(source_ids)}
+    ) RETURNING id INTO v_ruleset_id;
+  ELSE
+    UPDATE public.rule_sets SET
+      work_id=v_work_id,is_active=true,status='active',verification_status='source_bound',
+      source_revision={sql_literal(source_revision)},source_ids={sql_text_array(source_ids)},updated_at=now()
+    WHERE id=v_ruleset_id;
+  END IF;
+
+  INSERT INTO public.rule_nodes(
+    rule_set_id,rule_id,node_type,normalized_statement,sequence,verification_status,
+    source_claim_ref,evidence_ref,source_url,source_locator,metadata
+  ) VALUES
+{_render_rule_rows(game)}
+  ON CONFLICT(rule_set_id,rule_id) DO UPDATE SET
+    node_type=EXCLUDED.node_type,normalized_statement=EXCLUDED.normalized_statement,sequence=EXCLUDED.sequence,
+    verification_status=EXCLUDED.verification_status,source_claim_ref=EXCLUDED.source_claim_ref,
+    evidence_ref=EXCLUDED.evidence_ref,source_url=EXCLUDED.source_url,source_locator=EXCLUDED.source_locator,
+    metadata=EXCLUDED.metadata,updated_at=now();
+
+  INSERT INTO public.claims(
+    claim_id,rule_set_id,claim_type,normalized_payload,target_type,rule_id,lifecycle_status,generator_provenance
+  )
+  SELECT {sql_literal(slug + ':rule:')}||rule_id,v_ruleset_id,'normalized_rule_statement',
+    jsonb_build_object('statement',normalized_statement),'rule_node',rule_id,'accepted',
+    {sql_literal(json.dumps({'method': 'ruleops_reviewed_manifest', 'batch_id': batch_id}, separators=(',', ':')))}::jsonb
+  FROM public.rule_nodes WHERE rule_set_id=v_ruleset_id
+  ON CONFLICT(claim_id) DO UPDATE SET
+    rule_set_id=EXCLUDED.rule_set_id,claim_type=EXCLUDED.claim_type,normalized_payload=EXCLUDED.normalized_payload,
+    target_type=EXCLUDED.target_type,rule_id=EXCLUDED.rule_id,lifecycle_status=EXCLUDED.lifecycle_status,
+    generator_provenance=EXCLUDED.generator_provenance,updated_at=now();
+
+  INSERT INTO public.evidence_bindings(
+    binding_id,claim_id,source_id,locator_id,relation,reviewer_provenance,generator_provenance,verified_at
+  ) VALUES
+{','.join(chr(10) + value for value in binding_values).lstrip()}
+  ON CONFLICT(binding_id) DO UPDATE SET
+    claim_id=EXCLUDED.claim_id,source_id=EXCLUDED.source_id,locator_id=EXCLUDED.locator_id,
+    relation=EXCLUDED.relation,reviewer_provenance=EXCLUDED.reviewer_provenance,
+    generator_provenance=EXCLUDED.generator_provenance,verified_at=EXCLUDED.verified_at;
+
+  IF (SELECT count(*) FROM public.rule_nodes WHERE rule_set_id=v_ruleset_id AND verification_status='source_bound') <> {count}
+    THEN RAISE EXCEPTION 'RuleOps {slug} RuleNode count must be {count}'; END IF;
+  IF (SELECT count(*) FROM public.claims WHERE rule_set_id=v_ruleset_id AND target_type='rule_node' AND lifecycle_status='accepted') <> {count}
+    THEN RAISE EXCEPTION 'RuleOps {slug} Claim count must be {count}'; END IF;
+  IF (SELECT count(*) FROM public.evidence_bindings eb JOIN public.claims c ON c.claim_id=eb.claim_id WHERE c.rule_set_id=v_ruleset_id AND eb.relation='supports') <> {count}
+    THEN RAISE EXCEPTION 'RuleOps {slug} EvidenceBinding count must be {count}'; END IF;
+END $$;
+""".strip()
+
+
+def generate_migration(payload: dict[str, Any], migration_number: str) -> tuple[str, dict[str, Any]]:
+    validation = validate_manifest(payload)
+    result_by_slug = {result["slug"]: result for result in validation["games"]}
+    ready_games = [game for game in payload.get("games", []) if result_by_slug.get(game.get("slug"), {}).get("status") == "ready"]
+    blocked_games = [result for result in validation["games"] if result["status"] == "blocked"]
+    if not ready_games:
+        raise ValueError("manifest has no ready games; migration was not generated")
+
+    batch_id = payload["batch_id"]
+    sections = [render_game_sql(game, batch_id) for game in ready_games]
+    sql = "BEGIN;\n\n" + "\n\n".join(sections) + "\n\nCOMMIT;\n"
+    report = {
+        "schema_version": payload.get("schema_version"),
+        "batch_id": batch_id,
+        "migration_number": migration_number,
+        "generated_games": [game["slug"] for game in ready_games],
+        "blocked_games": blocked_games,
+        "status": "generated_with_blocks" if blocked_games else "generated",
+    }
+    return sql, report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate reviewed RuleOps source-bound SQL without writing to production")
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--migration-number", required=True)
+    parser.add_argument("--output-dir", type=Path, default=Path("backend/app/db/migrations"))
+    parser.add_argument("--report", type=Path)
+    args = parser.parse_args()
+
+    payload = json.loads(args.manifest.read_text(encoding="utf-8"))
+    sql, report = generate_migration(payload, args.migration_number)
+    filename = f"{args.migration_number}_ruleops_{safe_identifier(payload['batch_id'])}.sql"
+    output = args.output_dir / filename
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(sql, encoding="utf-8")
+    report["output"] = str(output)
+    rendered = json.dumps(report, ensure_ascii=False, indent=2) + "\n"
+    if args.report:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_ruleops_generate_migration.py
+++ b/backend/tests/test_ruleops_generate_migration.py
@@ -1,0 +1,118 @@
+import pytest
+
+from app.scripts.ruleops_generate_migration import generate_migration, safe_identifier
+from app.scripts.ruleops_manifest import validate_manifest
+
+
+def valid_game(slug: str, claim: str = "手番ではカードを1枚引く。"):
+    revision = f"publisher-2026-{slug}"
+    return {
+        "slug": slug,
+        "identity": {
+            "title": f"Game {slug}",
+            "edition": "Base Game 2026",
+            "language": "ja",
+            "platform": "physical",
+            "revision": revision,
+        },
+        "scope": {
+            "included_product": "Base Game 2026",
+            "excluded_products": ["Expansion", "Digital Edition"],
+        },
+        "review_status": "reviewed",
+        "remove_legacy_authority": True,
+        "sources": [
+            {
+                "source_id": f"publisher:{slug}:rulebook",
+                "url": f"https://publisher.example/{slug}/rules.pdf",
+                "source_type": "publisher_rulebook",
+                "revision_label": "2026 rules",
+                "review_status": "reviewed",
+                "applies_to_revision": revision,
+                "applies_to_platform": "physical",
+            }
+        ],
+        "rules": [
+            {
+                "rule_id": "turn.draw",
+                "node_type": "turn",
+                "claim": claim,
+                "source_id": f"publisher:{slug}:rulebook",
+                "evidence_locator": "p.2 Turn",
+                "review_status": "reviewed",
+            }
+        ],
+    }
+
+
+def manifest(*games):
+    return {"schema_version": "1.0", "batch_id": "pilot batch/001", "games": list(games)}
+
+
+def test_generator_emits_one_transaction_for_multiple_ready_games():
+    payload = manifest(valid_game("alpha"), valid_game("beta", "手番ではカードを1枚出す。"))
+
+    sql, report = generate_migration(payload, "071")
+
+    assert report["status"] == "generated"
+    assert report["generated_games"] == ["alpha", "beta"]
+    assert sql.startswith("BEGIN;")
+    assert sql.rstrip().endswith("COMMIT;")
+    assert "RuleOps game: alpha" in sql
+    assert "RuleOps game: beta" in sql
+    assert "INSERT INTO public.evidence_sources" in sql
+    assert "INSERT INTO public.rule_sets" in sql
+    assert "INSERT INTO public.rule_nodes" in sql
+    assert "INSERT INTO public.claims" in sql
+    assert "INSERT INTO public.evidence_bindings" in sql
+    assert "RuleOps alpha RuleNode count must be 1" in sql
+    assert "RuleOps beta EvidenceBinding count must be 1" in sql
+
+
+def test_blocked_game_is_reported_and_not_rendered_into_sql():
+    good = valid_game("good")
+    bad = valid_game("bad")
+    bad["identity"]["revision"] = "wrong-revision"
+    payload = manifest(good, bad)
+
+    validation = validate_manifest(payload)
+    assert validation["ready_games"] == 1
+    assert validation["blocked_games"] == 1
+
+    sql, report = generate_migration(payload, "071")
+
+    assert report["status"] == "generated_with_blocks"
+    assert report["generated_games"] == ["good"]
+    assert report["blocked_games"][0]["slug"] == "bad"
+    assert "RuleOps game: good" in sql
+    assert "RuleOps game: bad" not in sql
+
+
+def test_generator_refuses_manifest_without_ready_game():
+    bad = valid_game("bad")
+    bad["rules"][0]["node_type"] = "penalty"
+
+    with pytest.raises(ValueError, match="no ready games"):
+        generate_migration(manifest(bad), "071")
+
+
+def test_generated_sql_preserves_edition_boundary_and_removes_legacy_authority():
+    game = valid_game("gamma")
+    game["identity"]["edition"] = "Second Edition"
+    game["scope"]["excluded_products"] = ["First Edition", "Digital Edition"]
+
+    sql, _ = generate_migration(manifest(game), "071")
+
+    assert "edition_label='Second Edition'" in sql
+    assert "rules_content=NULL" in sql
+    assert "structured_data='{}'::jsonb" in sql
+    assert "revision_label,'publisher-2026-gamma'" in sql
+
+
+def test_sql_literals_escape_quotes_and_batch_name_is_filename_safe():
+    game = valid_game("quote-game", "カードを'1枚'引く。")
+
+    sql, _ = generate_migration(manifest(game), "071")
+
+    assert "カードを''1枚''引く。" in sql
+    assert safe_identifier("pilot batch/001") == "pilot_batch_001"

--- a/backend/tests/test_ruleops_generate_migration.py
+++ b/backend/tests/test_ruleops_generate_migration.py
@@ -104,9 +104,10 @@ def test_generated_sql_preserves_edition_boundary_and_removes_legacy_authority()
     sql, _ = generate_migration(manifest(game), "071")
 
     assert "edition_label='Second Edition'" in sql
+    assert "COALESCE(revision_label,'')='publisher-2026-gamma'" in sql
+    assert "'publisher-2026-gamma','physical'" in sql
     assert "rules_content=NULL" in sql
     assert "structured_data='{}'::jsonb" in sql
-    assert "revision_label,'publisher-2026-gamma'" in sql
 
 
 def test_sql_literals_escape_quotes_and_batch_name_is_filename_safe():


### PR DESCRIPTION
Continues #451 after candidate ranking and source-manifest validation.

Player-facing success condition: multiple reviewed games can be emitted as one reviewable ordered migration while blocked siblings are reported and omitted, preserving the same RuleSet → RuleNode → Claim → EvidenceBinding contract and per-game cardinality assertions used by manual migrations.

This PR adds a pure generator that:
- consumes the existing reviewed source manifest;
- emits one transaction containing multiple game migrations;
- upserts EvidenceSource / SourceLocator / RuleSet / RuleNode / Claim / EvidenceBinding rows;
- removes legacy rule authority only when the reviewed manifest requests it;
- preserves edition/language/platform/revision boundaries;
- includes per-game RuleNode/Claim/EvidenceBinding assertions;
- never writes to production itself;
- reports blocked games without discarding ready siblings;
- refuses generation when no game is ready.

Regression tests cover multi-game output, partial batches, zero-ready refusal, edition boundary/legacy cleanup, and SQL escaping. No game-specific helper, API, renderer, workflow, or database table is added.