### PR TITLE
Fix RuleOps candidate report against production API

### DIFF
--- a/backend/app/scripts/ruleops_candidates.py
+++ b/backend/app/scripts/ruleops_candidates.py
@@ -117,7 +117,9 @@ def _fetch_catalog(base_url: str, timeout_seconds: float, page_size: int = 100) 
     games: list[dict[str, Any]] = []
     offset = 0
     while True:
-        query = urlencode({"limit": page_size, "offset": offset, "sort": "popular"})
+        # The public catalog API does not expose a popularity sort. RuleOps ranks
+        # candidates locally from direct usage fields after fetching every page.
+        query = urlencode({"limit": page_size, "offset": offset})
         payload = _get_json(f"{base_url.rstrip('/')}/api/games?{query}", timeout_seconds)
         page = payload.get("games", [])
         if not isinstance(page, list):

--- a/backend/tests/test_ruleops_candidates.py
+++ b/backend/tests/test_ruleops_candidates.py
@@ -1,3 +1,4 @@
+from app.scripts import ruleops_candidates
 from app.scripts.ruleops_candidates import build_candidate, candidate_sort_key
 
 
@@ -141,3 +142,24 @@ def test_priority_uses_direct_usage_then_commerce_then_search():
     ranked = sorted([no_commerce, commerce, high_views], key=candidate_sort_key)
 
     assert [candidate.slug for candidate in ranked] == ["a", "b", "c"]
+
+
+def test_catalog_fetch_uses_only_supported_public_api_query(monkeypatch):
+    seen_urls: list[str] = []
+
+    def fake_get_json(url: str, timeout_seconds: float):
+        seen_urls.append(url)
+        if "offset=0" in url:
+            return {"games": [{"slug": "a"}], "total": 2}
+        return {"games": [{"slug": "b"}], "total": 2}
+
+    monkeypatch.setattr(ruleops_candidates, "_get_json", fake_get_json)
+
+    games = ruleops_candidates._fetch_catalog("https://example.test", 1.0, page_size=1)
+
+    assert [game["slug"] for game in games] == ["a", "b"]
+    assert seen_urls == [
+        "https://example.test/api/games?limit=1&offset=0",
+        "https://example.test/api/games?limit=1&offset=1",
+    ]
+    assert all("sort=" not in url for url in seen_urls)


### PR DESCRIPTION
Fix the canonical #451 RuleOps workline after production verification found that the candidate report could not run against the live catalog API.

Before: `_fetch_catalog()` sent `sort=popular`, but production `/api/games` accepts only `recent`, `title`, `year`, or `play_time`, causing HTTP 422 before any batch triage could begin.

After: fetch all catalog pages using only supported `limit`/`offset` parameters, then keep RuleOps priority local using direct `view_count`, affiliate presence, and `search_count` as already implemented.

Adds a regression test that asserts pagination never sends an unsupported sort parameter.

Success condition: the production catalog request used by RuleOps returns HTTP 200 and the report can proceed to title-level state reads instead of failing at catalog fetch.