### PR TITLE
Fix curated release verification authority boundary

### DIFF
--- a/.github/workflows/curated-game-release-verification.yml
+++ b/.github/workflows/curated-game-release-verification.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Verify deployed curated registry revision
         env:
           PYTHONPATH: backend
-        run: uv run python backend/app/scripts/curated_game_fast_path_v2.py release-check
+        run: uv run python backend/app/scripts/curated_release_verification.py

--- a/backend/app/scripts/curated_release_verification.py
+++ b/backend/app/scripts/curated_release_verification.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import httpx
+
+from app.scripts.curated_game_fast_path_v2 import (
+    DEFAULT_BASE_URL,
+    generate_artifacts,
+    verify_frontend_release,
+)
+from app.scripts.curated_game_workflow import CuratedGameSpec, WorkflowError, load_all_specs
+
+# Curated specs still own product identity and provenance. Player-facing rule/editorial
+# content can move independently through the source-bound RuleSet pipeline and must not
+# become a second release authority here.
+MUTABLE_PLAYER_CONTENT_FIELDS = frozenset(
+    {
+        "description",
+        "summary",
+        "rules_content",
+        "setup_summary",
+        "gameplay_summary",
+        "end_game_summary",
+        "structured_data",
+        "content_review_status",
+    }
+)
+
+
+def release_catalog_contract(game: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: value
+        for key, value in game.items()
+        if key not in MUTABLE_PLAYER_CONTENT_FIELDS
+    }
+
+
+def validate_release_catalog_fields(expected: dict[str, Any], actual: dict[str, Any]) -> None:
+    for key, expected_value in release_catalog_contract(expected).items():
+        # The public response intentionally omits some storage-only fields.
+        if key not in actual:
+            continue
+        if actual[key] != expected_value:
+            raise WorkflowError(f"production catalog mismatch at game.{key}")
+
+
+def verify_catalog_release_live(spec: CuratedGameSpec, base_url: str) -> None:
+    base = base_url.rstrip("/")
+    with httpx.Client(follow_redirects=True, timeout=20) as client:
+        response = client.get(f"{base}/api/games/{spec.slug}")
+        if response.status_code != 200:
+            raise WorkflowError(f"production API failed for {spec.slug}: HTTP {response.status_code}")
+        payload = response.json()
+
+    if payload.get("slug") != spec.slug:
+        raise WorkflowError(f"production API returned the wrong slug for {spec.slug}")
+    if payload.get("source_url") != spec.source.url:
+        raise WorkflowError(f"production API source provenance mismatch for {spec.slug}")
+    if not payload.get("work_id"):
+        raise WorkflowError(f"production API record has no canonical work_id for {spec.slug}")
+    validate_release_catalog_fields(spec.game, payload)
+
+
+def verify_release(specs: list[CuratedGameSpec], base_url: str) -> None:
+    generate_artifacts(specs)
+    verify_frontend_release(specs, base_url)
+    for spec in specs:
+        verify_catalog_release_live(spec, base_url)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    args = parser.parse_args()
+    verify_release(load_all_specs(), args.base_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_curated_release_verification.py
+++ b/backend/tests/test_curated_release_verification.py
@@ -1,0 +1,74 @@
+import pytest
+
+from app.scripts.curated_game_workflow import WorkflowError
+from app.scripts.curated_release_verification import (
+    release_catalog_contract,
+    validate_release_catalog_fields,
+)
+
+
+def test_release_contract_excludes_mutable_player_content():
+    contract = release_catalog_contract(
+        {
+            "slug": "game",
+            "title": "Game",
+            "source_url": "https://publisher.example/rules",
+            "identity_status": "verified",
+            "description": "old description",
+            "summary": "old summary",
+            "rules_content": "old rules",
+            "setup_summary": "old setup",
+            "gameplay_summary": "old gameplay",
+            "end_game_summary": "old end",
+            "structured_data": {"rule_mistakes": ["old"]},
+            "content_review_status": "ai_draft",
+        }
+    )
+
+    assert contract == {
+        "slug": "game",
+        "title": "Game",
+        "source_url": "https://publisher.example/rules",
+        "identity_status": "verified",
+    }
+
+
+def test_mutable_source_bound_content_can_change_without_release_failure():
+    expected = {
+        "slug": "game",
+        "title": "Game",
+        "source_url": "https://publisher.example/rules",
+        "identity_status": "verified",
+        "description": "curated description",
+        "rules_content": "curated legacy rules",
+        "content_review_status": "ai_draft",
+    }
+    production = {
+        "slug": "game",
+        "title": "Game",
+        "source_url": "https://publisher.example/rules",
+        "identity_status": "verified",
+        "description": "source-bound description",
+        "rules_content": None,
+        "content_review_status": "human_reviewed",
+    }
+
+    validate_release_catalog_fields(expected, production)
+
+
+def test_identity_drift_still_fails_release_verification():
+    expected = {
+        "slug": "game",
+        "title": "Game",
+        "source_url": "https://publisher.example/rules",
+        "identity_status": "verified",
+    }
+    production = {
+        "slug": "game",
+        "title": "Different Game",
+        "source_url": "https://publisher.example/rules",
+        "identity_status": "verified",
+    }
+
+    with pytest.raises(WorkflowError, match="game.title"):
+        validate_release_catalog_fields(expected, production)


### PR DESCRIPTION
Fix the failing curated production release gate by removing stale dual ownership between curated specs and the source-bound RuleSet pipeline.

Current failure: production catalog mismatch at `game.description` for Terraforming Mars: The Dice Game. Production rule/editorial content has legitimately moved through source-bound migrations, while the curated registry still contains older description/rules fields.

This PR:
- keeps curated release verification strict for product identity and provenance;
- excludes mutable player-facing rule/editorial fields from this release gate;
- keeps deployed curated manifest revision verification unchanged;
- keeps slug/source/work_id checks;
- adds regression tests proving source-bound content drift is allowed but identity drift still fails.

Player-facing success condition: production verification is green without reverting current source-bound content or weakening edition/source identity checks.

Related: #451.