### PR TITLE
Fix canonical web analytics history persistence

### DIFF
--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -47,7 +47,10 @@ jobs:
         run: |
           mkdir -p data/analytics
           touch data/analytics/web-traffic.json
-          test "$(git check-ignore -v data/analytics/web-traffic.json || true)" = ""
+          if git check-ignore -q data/analytics/web-traffic.json; then
+            echo "data/analytics/web-traffic.json must remain trackable" >&2
+            exit 1
+          fi
 
   Snapshot-Production-Traffic:
     if: github.event_name != 'pull_request'

--- a/.github/workflows/web-analytics.yml
+++ b/.github/workflows/web-analytics.yml
@@ -6,6 +6,7 @@ on:
       - frontend/index.html
       - scripts/export_vercel_web_analytics.py
       - .github/workflows/web-analytics.yml
+      - .gitignore
       - vercel.json
   push:
     branches:
@@ -14,6 +15,7 @@ on:
       - frontend/index.html
       - scripts/export_vercel_web_analytics.py
       - .github/workflows/web-analytics.yml
+      - .gitignore
       - vercel.json
   schedule:
     # 09:24 JST / 00:24 UTC. Persist only completed UTC days.
@@ -41,6 +43,11 @@ jobs:
         run: python -m py_compile scripts/export_vercel_web_analytics.py
       - name: Test history merge
         run: python scripts/export_vercel_web_analytics.py --self-test
+      - name: Verify canonical history path is trackable
+        run: |
+          mkdir -p data/analytics
+          touch data/analytics/web-traffic.json
+          test "$(git check-ignore -v data/analytics/web-traffic.json || true)" = ""
 
   Snapshot-Production-Traffic:
     if: github.event_name != 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,9 @@ TTS-Voice-Wizard/
 data/*
 !data/curated-games/
 !data/curated-games/**
+!data/analytics/
+data/analytics/*
+!data/analytics/web-traffic.json
 .playwright_data/
 output_slides/
 frontend/public/output_slides/


### PR DESCRIPTION
Fix the production Web Analytics Snapshot failure where export succeeds but persistence fails because `data/*` ignores `data/analytics/web-traffic.json`.

This PR:
- makes only the canonical `data/analytics/web-traffic.json` history file trackable while keeping other analytics files ignored;
- includes `.gitignore` in Web Analytics workflow path filters;
- adds a PR validation step that fails if the canonical history path becomes ignored again.

Production success condition: the snapshot exports 31 completed days and persists the canonical history on `main` without force-adding ignored files or creating a second analytics store.

Related: #451.