### PR TITLE
Fix curated release provenance ownership after source-bound cutover

### DIFF
--- a/backend/app/scripts/curated_release_verification.py
+++ b/backend/app/scripts/curated_release_verification.py
@@ -12,9 +12,11 @@ from app.scripts.curated_game_fast_path_v2 import (
 )
 from app.scripts.curated_game_workflow import CuratedGameSpec, WorkflowError, load_all_specs
 
-# Curated specs still own product identity and provenance. Player-facing rule/editorial
-# content can move independently through the source-bound RuleSet pipeline and must not
-# become a second release authority here.
+# Curated specs still own product identity and stable catalog metadata. Player-facing
+# rule/editorial content and the legacy game.source_url can move independently through
+# the source-bound RuleSet pipeline and must not become a second release authority here.
+# Rulebook provenance belongs to RuleSet/EvidenceSource; product identity remains
+# fail-closed through identity_source and the other immutable catalog fields.
 MUTABLE_PLAYER_CONTENT_FIELDS = frozenset(
     {
         "description",
@@ -25,6 +27,7 @@ MUTABLE_PLAYER_CONTENT_FIELDS = frozenset(
         "end_game_summary",
         "structured_data",
         "content_review_status",
+        "source_url",
     }
 )
 
@@ -56,8 +59,6 @@ def verify_catalog_release_live(spec: CuratedGameSpec, base_url: str) -> None:
 
     if payload.get("slug") != spec.slug:
         raise WorkflowError(f"production API returned the wrong slug for {spec.slug}")
-    if payload.get("source_url") != spec.source.url:
-        raise WorkflowError(f"production API source provenance mismatch for {spec.slug}")
     if not payload.get("work_id"):
         raise WorkflowError(f"production API record has no canonical work_id for {spec.slug}")
     validate_release_catalog_fields(spec.game, payload)

--- a/backend/tests/test_curated_release_verification.py
+++ b/backend/tests/test_curated_release_verification.py
@@ -7,12 +7,13 @@ from app.scripts.curated_release_verification import (
 )
 
 
-def test_release_contract_excludes_mutable_player_content():
+def test_release_contract_excludes_mutable_player_content_and_legacy_source_url():
     contract = release_catalog_contract(
         {
             "slug": "game",
             "title": "Game",
             "source_url": "https://publisher.example/rules",
+            "identity_source": "https://publisher.example/products/game",
             "identity_status": "verified",
             "description": "old description",
             "summary": "old summary",
@@ -28,16 +29,17 @@ def test_release_contract_excludes_mutable_player_content():
     assert contract == {
         "slug": "game",
         "title": "Game",
-        "source_url": "https://publisher.example/rules",
+        "identity_source": "https://publisher.example/products/game",
         "identity_status": "verified",
     }
 
 
-def test_mutable_source_bound_content_can_change_without_release_failure():
+def test_source_bound_rulebook_provenance_can_move_without_release_failure():
     expected = {
         "slug": "game",
         "title": "Game",
-        "source_url": "https://publisher.example/rules",
+        "source_url": "https://publisher.example/rules.pdf",
+        "identity_source": "https://publisher.example/products/game",
         "identity_status": "verified",
         "description": "curated description",
         "rules_content": "curated legacy rules",
@@ -46,7 +48,8 @@ def test_mutable_source_bound_content_can_change_without_release_failure():
     production = {
         "slug": "game",
         "title": "Game",
-        "source_url": "https://publisher.example/rules",
+        "source_url": "https://publisher.example/products/game",
+        "identity_source": "https://publisher.example/products/game",
         "identity_status": "verified",
         "description": "source-bound description",
         "rules_content": None,
@@ -60,15 +63,35 @@ def test_identity_drift_still_fails_release_verification():
     expected = {
         "slug": "game",
         "title": "Game",
-        "source_url": "https://publisher.example/rules",
+        "source_url": "https://publisher.example/rules.pdf",
+        "identity_source": "https://publisher.example/products/game",
         "identity_status": "verified",
     }
     production = {
         "slug": "game",
         "title": "Different Game",
-        "source_url": "https://publisher.example/rules",
+        "source_url": "https://publisher.example/products/game",
+        "identity_source": "https://publisher.example/products/game",
         "identity_status": "verified",
     }
 
     with pytest.raises(WorkflowError, match="game.title"):
+        validate_release_catalog_fields(expected, production)
+
+
+def test_identity_source_drift_still_fails_release_verification():
+    expected = {
+        "slug": "game",
+        "title": "Game",
+        "identity_source": "https://publisher.example/products/game",
+        "identity_status": "verified",
+    }
+    production = {
+        "slug": "game",
+        "title": "Game",
+        "identity_source": "https://other.example/game",
+        "identity_status": "verified",
+    }
+
+    with pytest.raises(WorkflowError, match="game.identity_source"):
         validate_release_catalog_fields(expected, production)


### PR DESCRIPTION
## Player-facing success condition

Release verification must pass when a curated game keeps the same canonical product identity but its legacy `games.source_url` moves from a rulebook URL to the product identity URL under the source-bound RuleSet model. A changed `identity_source` must still fail closed.

## Root cause

`curated_release_verification.py` compared production `source_url` directly with `spec.source.url`. For source-bound games such as `flip-7-with-a-vengeance`, `spec.source.url` is the official rulebook while production `source_url` now represents the canonical product identity. Rulebook provenance is already owned by RuleSet/EvidenceSource, so this became duplicate authority and caused the exact-main release verification to fail despite healthy production.

## Change

- remove legacy `source_url` from the curated catalog release contract
- keep `identity_source`, title, identity status, and other stable catalog identity fields fail-closed
- add regression coverage proving source URL movement is allowed only while identity provenance remains stable

No game data or player-facing content is changed by this PR.