### PR TITLE
Prevent unreviewed source-bound summaries from appearing as fact

### DIFF
--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -25,6 +25,7 @@ from app.services.concept_taxonomy import ConceptTaxonomyService
 from app.services.directory_query import DirectorySort, DirectoryTime, list_directory_games
 from app.services.evidence import EvidenceService
 from app.services.game_service import GameIdentityConflictError, GameService
+from app.services.player_summary import project_player_summary
 from app.services.rule_graph import RuleGraphService
 from app.services.rulesets import RuleSetService
 from app.services.search_visibility import has_known_identity_conflict, should_return_gone
@@ -254,7 +255,10 @@ async def get_game_details(slug: str, service: GameService = Depends(get_game_se
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     canonical_rules = await _canonical_rule_text(slug)
     if canonical_rules:
-        game = {**game, "rules_content": canonical_rules}
+        game = project_player_summary(
+            {**game, "rules_content": canonical_rules},
+            source_bound=True,
+        )
     return game
 
 

--- a/backend/app/services/player_summary.py
+++ b/backend/app/services/player_summary.py
@@ -1,0 +1,16 @@
+from typing import Any
+
+REVIEWED_SUMMARY_STATUSES = {"human_reviewed", "publisher_reviewed"}
+
+
+def project_player_summary(game: dict[str, Any], *, source_bound: bool) -> dict[str, Any]:
+    """Project player-facing summary fields without changing stored catalog data."""
+    if not source_bound:
+        return game
+
+    if game.get("content_review_status") in REVIEWED_SUMMARY_STATUSES:
+        return game
+
+    title = game.get("title_ja") or game.get("title") or "このゲーム"
+    neutral = f"「{title}」の出典付きルール要約と出典情報を確認できます。"
+    return {**game, "summary": neutral, "description": neutral}

--- a/backend/tests/test_player_summary.py
+++ b/backend/tests/test_player_summary.py
@@ -1,0 +1,49 @@
+from app.services.player_summary import project_player_summary
+
+
+def test_source_bound_unreviewed_summary_is_neutralized():
+    game = {
+        "title": "Forest Shuffle",
+        "title_ja": "フォレストシャッフル",
+        "summary": "legacy summary",
+        "description": "legacy description",
+        "content_review_status": "unknown",
+    }
+
+    projected = project_player_summary(game, source_bound=True)
+
+    assert projected["summary"] == "「フォレストシャッフル」の出典付きルール要約と出典情報を確認できます。"
+    assert projected["description"] == projected["summary"]
+    assert game["summary"] == "legacy summary"
+
+
+def test_source_bound_human_reviewed_summary_is_preserved():
+    game = {
+        "title": "Fort",
+        "summary": "reviewed summary",
+        "description": "reviewed description",
+        "content_review_status": "human_reviewed",
+    }
+
+    assert project_player_summary(game, source_bound=True) is game
+
+
+def test_source_bound_publisher_reviewed_summary_is_preserved():
+    game = {
+        "title": "Papayoo",
+        "summary": "publisher summary",
+        "content_review_status": "publisher_reviewed",
+    }
+
+    assert project_player_summary(game, source_bound=True) is game
+
+
+def test_non_source_bound_legacy_summary_is_unchanged():
+    game = {
+        "title": "Legacy Game",
+        "summary": "legacy summary",
+        "description": "legacy description",
+        "content_review_status": "unknown",
+    }
+
+    assert project_player_summary(game, source_bound=False) is game


### PR DESCRIPTION
Closes #465.

Player-facing success condition: when canonical source-bound rules are available, unreviewed legacy summary/description content is replaced in the detail API response with a neutral statement before GamePage synopsis, meta description, or TTS can consume it.

Changes:
- add one shared player-summary projection
- preserve human_reviewed / publisher_reviewed summaries
- preserve non-source-bound legacy behavior
- apply the projection only when canonical rule text is available
- add regression tests for unreviewed, reviewed, and legacy cases

No stored game data, RuleSet, evidence, identity, or affiliate URL is mutated.