### PR TITLE
Validate RuleOps manifests and support publisher rules pages

### DIFF
--- a/.github/workflows/test-ruleops.yml
+++ b/.github/workflows/test-ruleops.yml
@@ -38,6 +38,14 @@ jobs:
       - name: Validate manifest schema JSON
         run: uv run python -m json.tool backend/app/ruleops/source-manifest.schema.json > /dev/null
 
+      - name: Validate versioned RuleOps manifests
+        env:
+          PYTHONPATH: backend
+        run: |
+          for manifest in backend/app/ruleops/manifests/*.json; do
+            uv run python backend/app/scripts/ruleops_manifest.py "$manifest" > /dev/null
+          done
+
       - name: Run RuleOps regression tests
         env:
           PYTHONPATH: backend

--- a/backend/app/ruleops/manifests/2026-08-26-batch-03.json
+++ b/backend/app/ruleops/manifests/2026-08-26-batch-03.json
@@ -25,9 +25,9 @@
       "remove_legacy_authority": true,
       "sources": [
         {
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "url": "https://arclightgames.jp/product/ito/",
-          "source_type": "publisher_product_page",
+          "source_type": "publisher_rules_page",
           "revision_label": "current official base-product rules page accessed 2026-08-26",
           "review_status": "reviewed",
           "applies_to_revision": "arclight-ito-base-2019-accessed-2026-08-26",
@@ -39,7 +39,7 @@
           "rule_id": "kumonoito-setup",
           "node_type": "setup",
           "claim": "クモノイトではナンバーカードを混ぜて各プレイヤーに1枚ずつ配り、テーマカードを山札にし、共有ライフを3に設定してクモノシートを場にする。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > ゲームの概要 > ゲームの準備",
           "review_status": "reviewed"
         },
@@ -47,7 +47,7 @@
           "rule_id": "kumonoito-theme",
           "node_type": "action",
           "claim": "クモノイトではテーマカードから候補を出して今回のテーマを決め、そのテーマに沿って自分のナンバーを数字そのものを言わずに表現する。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > テーマ決定 / ナンバーの表現",
           "review_status": "reviewed"
         },
@@ -55,7 +55,7 @@
           "rule_id": "kumonoito-no-turn-order",
           "node_type": "turn",
           "claim": "クモノイトのナンバー表現には手番順がなく、全員の表現後は相談しながらカードを小さい順になるよう1枚ずつ場へ出す。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > ナンバーの表現 / カードを出す",
           "review_status": "reviewed"
         },
@@ -63,7 +63,7 @@
           "rule_id": "kumonoito-failure-life",
           "node_type": "effect",
           "claim": "クモノイトで順番を誤った場合、その時点で正しく出せなくなったカードを脇へ置き、その枚数ぶん共有ライフを失う。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > カードを出す / 失敗時の処理",
           "review_status": "reviewed"
         },
@@ -71,7 +71,7 @@
           "rule_id": "kumonoito-stage-clear",
           "node_type": "condition",
           "claim": "クモノイトでは全員の手札を出し切り、ライフが残っていればそのステージをクリアする。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > ステージクリア",
           "review_status": "reviewed"
         },
@@ -79,7 +79,7 @@
           "rule_id": "kumonoito-stage-progression",
           "node_type": "setup",
           "claim": "次のステージでは共有ライフを最大3まで1回復し（2人プレイでは回復しない）、ナンバーカードを混ぜ直して第2ステージは2枚、第3ステージは3枚ずつ配る。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > 次のステージの準備",
           "review_status": "reviewed"
         },
@@ -87,7 +87,7 @@
           "rule_id": "kumonoito-third-stage",
           "node_type": "effect",
           "claim": "クモノイトの第3ステージでは追加のナンバーカード1枚を表向きにする『モモちゃん』を加える。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > 第3ステージ / モモちゃん",
           "review_status": "reviewed"
         },
@@ -95,7 +95,7 @@
           "rule_id": "kumonoito-victory",
           "node_type": "victory",
           "claim": "クモノイトは第3ステージをクリアすれば全員の勝利で、途中で共有ライフが0になれば全員の敗北となる。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "クモノイト > ゲーム終了",
           "review_status": "reviewed"
         },
@@ -103,7 +103,7 @@
           "rule_id": "akaito-mode",
           "node_type": "action",
           "claim": "アカイイトでは手札は常に1枚で、スタートプレイヤーがテーマを決め、時計回りにナンバーを表現し、2人のナンバー合計が100になる相手を探す。",
-          "source_id": "ito:arclight-product-rules",
+          "source_id": "ito:arclight-rules-page",
           "evidence_locator": "アカイイト > クモノイトルールとの違い / 運命の相手",
           "review_status": "reviewed"
         }

--- a/backend/app/ruleops/source-manifest.schema.json
+++ b/backend/app/ruleops/source-manifest.schema.json
@@ -56,6 +56,7 @@
         "source_type": {
           "enum": [
             "publisher_rulebook",
+            "publisher_rules_page",
             "publisher_faq",
             "publisher_errata",
             "publisher_product_page",

--- a/backend/app/scripts/ruleops_manifest.py
+++ b/backend/app/scripts/ruleops_manifest.py
@@ -11,6 +11,7 @@ SCHEMA_VERSION = "1.0"
 REVIEWED = "reviewed"
 PRIMARY_SOURCE_TYPES = {
     "publisher_rulebook",
+    "publisher_rules_page",
     "publisher_faq",
     "publisher_errata",
     "publisher_product_page",
@@ -192,7 +193,7 @@ def validate_game_manifest(game: dict[str, Any]) -> list[ValidationError]:
                 slug,
                 "non_rule_source",
                 f"{path}.source_id",
-                "rule claims require a rulebook/FAQ/errata/creator rule source, not identity-only evidence",
+                "rule claims require a rulebook/rules page/FAQ/errata/creator rule source, not identity-only evidence",
             )
 
         locator = rule.get("evidence_locator")

--- a/backend/tests/test_ruleops_manifest.py
+++ b/backend/tests/test_ruleops_manifest.py
@@ -52,6 +52,19 @@ def test_valid_reviewed_manifest_is_ready():
     assert report["blocked_games"] == 0
 
 
+def test_publisher_rules_page_can_support_rule_claim():
+    game = valid_game()
+    game["sources"][0]["source_type"] = "publisher_rules_page"
+    game["sources"][0]["url"] = "https://publisher.example/game/rules"
+
+    report = validate_manifest(
+        {"schema_version": "1.0", "batch_id": "pilot-rules-page", "games": [game]}
+    )
+
+    assert report["status"] == "ready"
+    assert report["ready_games"] == 1
+
+
 def test_invalid_game_does_not_hide_ready_sibling():
     bad = valid_game("bad-game")
     bad["identity"]["revision"] = "other-revision"


### PR DESCRIPTION
## Player-facing success condition

Batch 03 can only progress when `ito` and `scythe` are both machine-validated against accurately classified first-party sources before SQL generation.

## Changes

- add `publisher_rules_page` as a rule-capable first-party source type
- keep `publisher_product_page` identity-only
- classify Arclight's ito page as a publisher rules page because the page itself contains the base-game play instructions
- add a regression test for publisher rules pages
- make `Test RuleOps` validate every checked-in versioned manifest, preventing green unit tests from hiding a production manifest that the generator would reject

No production data is written by this PR.