### PR TITLE
Apply trusted summary projection to SSR game pages

### DIFF
--- a/.github/workflows/test-games-router.yml
+++ b/.github/workflows/test-games-router.yml
@@ -7,10 +7,13 @@ on:
       - "backend/app/routers/games.py"
       - "backend/app/services/directory_query.py"
       - "backend/app/services/game_service.py"
+      - "backend/app/services/player_summary.py"
       - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
       - "backend/tests/test_directory_query.py"
       - "backend/tests/test_games_router.py"
+      - "backend/tests/test_seo_renderer.py"
+      - "backend/tests/test_seo_renderer_canonical_rules.py"
       - "backend/tests/test_web_not_found.py"
       - ".github/workflows/test-games-router.yml"
       - "vercel.json"
@@ -24,10 +27,13 @@ on:
       - "backend/app/routers/games.py"
       - "backend/app/services/directory_query.py"
       - "backend/app/services/game_service.py"
+      - "backend/app/services/player_summary.py"
       - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
       - "backend/tests/test_directory_query.py"
       - "backend/tests/test_games_router.py"
+      - "backend/tests/test_seo_renderer.py"
+      - "backend/tests/test_seo_renderer_canonical_rules.py"
       - "backend/tests/test_web_not_found.py"
       - ".github/workflows/test-games-router.yml"
       - "vercel.json"
@@ -46,7 +52,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uv sync --frozen --dev
-      - name: Run game route regression tests
-        run: uv run pytest -q backend/tests/test_directory_query.py backend/tests/test_games_router.py backend/tests/test_web_not_found.py
+      - name: Run game route and SSR regression tests
+        run: uv run pytest -q backend/tests/test_directory_query.py backend/tests/test_games_router.py backend/tests/test_seo_renderer.py backend/tests/test_seo_renderer_canonical_rules.py backend/tests/test_web_not_found.py
         env:
           PYTHONPATH: backend

--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -6,6 +6,7 @@ import re
 from pathlib import Path
 
 from app.core.supabase import get_by_slug
+from app.services.player_summary import project_player_summary
 from app.services.presentation_projection import PresentationProjectionReadError, PresentationProjectionService
 from app.services.rulesets import RuleSetService
 from app.services.search_visibility import should_hide_game_from_search
@@ -78,11 +79,7 @@ def _render_projection_rules(projection) -> str | None:
 
 
 async def _canonical_rule_text(slug: str) -> str | None:
-    try:
-        rulesets = await RuleSetService().get_by_slug(slug)
-    except Exception:
-        logger.exception("Canonical SSR RuleSet lookup failed for %s; using legacy fallback", slug)
-        return None
+    rulesets = await RuleSetService().get_by_slug(slug)
     if not rulesets or rulesets.status != "available":
         return None
 
@@ -100,7 +97,7 @@ async def _canonical_rule_text(slug: str) -> str | None:
             )
         except PresentationProjectionReadError:
             logger.exception("Canonical SSR projection failed for %s/%s", slug, ruleset.ruleset_id)
-            continue
+            raise
         if projection is None or projection.status != "available":
             continue
         rendered = _render_projection_rules(projection)
@@ -113,6 +110,9 @@ async def generate_seo_html(slug: str) -> str | None:
     game = await get_by_slug(slug)
     if not game:
         return None
+
+    canonical_rules = await _canonical_rule_text(slug)
+    game = project_player_summary(game, source_bound=canonical_rules is not None)
 
     title = str(game.get("title_ja") or game.get("title") or game.get("name") or "Untitled")
     description = str(game.get("summary") or game.get("description") or "")
@@ -220,7 +220,6 @@ async def generate_seo_html(slug: str) -> str | None:
 
     safe_title = html.escape(title)
     safe_summary = html.escape(str(game.get("summary") or ""))
-    canonical_rules = await _canonical_rule_text(slug)
     if canonical_rules:
         safe_rules = html.escape(canonical_rules)
         rules_heading = "出典付きルール要約"

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -48,6 +48,10 @@ class PublicReadService:
         }
 
 
+async def _no_canonical_rules(_slug: str):
+    return None
+
+
 def _app_with_service(service):
     app = FastAPI()
     app.include_router(games.router, prefix="/api")
@@ -63,7 +67,8 @@ def test_missing_game_slug_returns_404_instead_of_response_validation_500():
     assert response.json() == {"detail": "Game not found"}
 
 
-def test_game_detail_preserves_player_facing_rule_fields_without_bloating_search():
+def test_game_detail_preserves_player_facing_rule_fields_without_bloating_search(monkeypatch):
+    monkeypatch.setattr(games, "_canonical_rule_text", _no_canonical_rules)
     client = TestClient(_app_with_service(PublicReadService()))
 
     detail = client.get("/api/games/example")
@@ -171,6 +176,7 @@ def test_public_game_reads_use_standard_shared_cache_control(monkeypatch):
         }
 
     monkeypatch.setattr(games, "list_directory_games", fake_directory_query)
+    monkeypatch.setattr(games, "_canonical_rule_text", _no_canonical_rules)
     production_app.dependency_overrides[games.get_game_service] = lambda: PublicReadService()
     try:
         client = TestClient(production_app)

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -52,6 +52,9 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
             "image_url": "/images/game.webp",
         }
 
+    async def no_canonical_rules(_slug: str):
+        return None
+
     template_dir = tmp_path / "frontend" / "dist"
     template_dir.mkdir(parents=True)
     (template_dir / "index.html").write_text(
@@ -75,6 +78,7 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     )
 
     monkeypatch.setattr(seo_renderer, "get_by_slug", game)
+    monkeypatch.setattr(seo_renderer, "_canonical_rule_text", no_canonical_rules)
     monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
 
     rendered = await seo_renderer.generate_seo_html("safe-game")
@@ -111,6 +115,9 @@ async def test_known_mixed_game_record_is_noindex(
             "summary": "mixed identity fixture",
         }
 
+    async def no_canonical_rules(_slug: str):
+        return None
+
     template_dir = tmp_path / "frontend" / "dist"
     template_dir.mkdir(parents=True)
     (template_dir / "index.html").write_text(
@@ -120,6 +127,7 @@ async def test_known_mixed_game_record_is_noindex(
     )
 
     monkeypatch.setattr(seo_renderer, "get_by_slug", game)
+    monkeypatch.setattr(seo_renderer, "_canonical_rule_text", no_canonical_rules)
     monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
 
     rendered = await seo_renderer.generate_seo_html("game")

--- a/backend/tests/test_seo_renderer_canonical_rules.py
+++ b/backend/tests/test_seo_renderer_canonical_rules.py
@@ -1,5 +1,9 @@
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from app.services import seo_renderer
 from app.services.seo_renderer import _render_projection_rules
 
 
@@ -26,3 +30,44 @@ def test_render_projection_rules_keeps_player_facing_sections():
     assert "## 終了条件・勝利" in rendered
     assert "- end rule" in rendered
     assert "## 得点" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_source_bound_ssr_uses_same_neutral_summary_as_public_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    async def game(_slug: str):
+        return {
+            "slug": "ito",
+            "title": "ito",
+            "title_ja": "イト",
+            "summary": "unreviewed legacy summary",
+            "description": "unreviewed legacy description",
+            "content_review_status": "review_required",
+        }
+
+    async def canonical(_slug: str):
+        return "## ゲーム進行\n- 出典付きルール"
+
+    template_dir = tmp_path / "frontend" / "dist"
+    template_dir.mkdir(parents=True)
+    (template_dir / "index.html").write_text(
+        '<html lang="ja"><head><meta name="description" content="home" /></head>'
+        '<body><div id="root"></div></body></html>',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(seo_renderer, "get_by_slug", game)
+    monkeypatch.setattr(seo_renderer, "_canonical_rule_text", canonical)
+    monkeypatch.setenv("LAMBDA_TASK_ROOT", str(tmp_path))
+
+    rendered = await seo_renderer.generate_seo_html("ito")
+
+    neutral = "「イト」の出典付きルール要約と出典情報を確認できます。"
+    assert rendered is not None
+    assert neutral in rendered
+    assert 'name="description" content="「イト」の出典付きルール要約と出典情報を確認できます。"' in rendered
+    assert 'itemprop="description">「イト」の出典付きルール要約と出典情報を確認できます。</p>' in rendered
+    assert "unreviewed legacy summary" not in rendered
+    assert "unreviewed legacy description" not in rendered


### PR DESCRIPTION
## Player-facing success condition

For source-bound games whose summary is not human/publisher reviewed, `/api/games/{slug}` and SSR `/games/{slug}` expose the same neutral summary in visible synopsis, meta/OG/Twitter description, and JSON-LD while preserving the source-bound rule text.

## Root cause

The public API reused `project_player_summary()`, but `seo_renderer.generate_seo_html()` read raw catalog `summary`/`description` directly. Production readback on `ito` showed the API correctly neutralized the summary while SSR HTML still emitted the legacy summary as factual metadata and visible synopsis.

## Changes

- reuse the existing `project_player_summary()` in SSR rather than creating a second trust mapping
- determine source-bound state from the same canonical RuleSet projection used to render SSR rules
- fail loudly when canonical RuleSet/projection reads error instead of silently falling back to legacy rule text
- add regression coverage proving legacy summary/description do not leak into source-bound SSR metadata or synopsis

No stored game data or affiliate URLs are changed.