### PR TITLE
Project trust-safe summaries in Directory results

### DIFF
--- a/backend/app/services/directory_query.py
+++ b/backend/app/services/directory_query.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 import anyio
 
 from app.core import local_db, supabase
+from app.services.player_summary import project_directory_summary
 from app.services.search_visibility import EXCLUDED_GAME_SLUGS, should_hide_game_from_search
 
 DirectorySort = Literal["recent", "title", "year", "play_time"]
@@ -63,6 +64,13 @@ def _sort_key(game: dict[str, Any], sort: DirectorySort):
     return str(game.get("created_at") or "")
 
 
+def _project_result(result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **result,
+        "data": [project_directory_summary(game) for game in result["data"]],
+    }
+
+
 def _filter_rows(
     rows: list[dict[str, Any]],
     *,
@@ -95,7 +103,7 @@ def _query_ranked_search_results(
     if sort != "recent":
         reverse = sort == "year"
         filtered.sort(key=lambda game: _sort_key(game, sort), reverse=reverse)
-    return {"data": filtered[offset : offset + limit], "total": len(filtered)}
+    return _project_result({"data": filtered[offset : offset + limit], "total": len(filtered)})
 
 
 def _query_local(
@@ -120,7 +128,7 @@ def _query_local(
     ]
     reverse = sort in {"recent", "year"}
     filtered.sort(key=lambda game: _sort_key(game, sort), reverse=reverse)
-    return {"data": filtered[offset : offset + limit], "total": len(filtered)}
+    return _project_result({"data": filtered[offset : offset + limit], "total": len(filtered)})
 
 
 async def list_directory_games(
@@ -193,6 +201,6 @@ async def list_directory_games(
             query = query.order("created_at", desc=True, nullsfirst=False)
 
         result = query.range(offset, offset + limit - 1).execute()
-        return {"data": result.data, "total": result.count or 0}
+        return _project_result({"data": result.data, "total": result.count or 0})
 
     return await anyio.to_thread.run_sync(_q)

--- a/backend/app/services/player_summary.py
+++ b/backend/app/services/player_summary.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 REVIEWED_SUMMARY_STATUSES = {"human_reviewed", "publisher_reviewed"}
+DIRECTORY_UNVERIFIED_SUMMARY = "概要は確認中です。"
 
 
 def project_player_summary(game: dict[str, Any], *, source_bound: bool) -> dict[str, Any]:
@@ -14,3 +15,18 @@ def project_player_summary(game: dict[str, Any], *, source_bound: bool) -> dict[
     title = game.get("title_ja") or game.get("title") or "このゲーム"
     neutral = f"「{title}」の出典付きルール要約と出典情報を確認できます。"
     return {**game, "summary": neutral, "description": neutral}
+
+
+def project_directory_summary(game: dict[str, Any]) -> dict[str, Any]:
+    """Hide unverified catalog prose at the discovery decision point."""
+    if (
+        game.get("identity_status") == "verified"
+        and game.get("content_review_status") in REVIEWED_SUMMARY_STATUSES
+    ):
+        return game
+
+    return {
+        **game,
+        "summary": DIRECTORY_UNVERIFIED_SUMMARY,
+        "description": DIRECTORY_UNVERIFIED_SUMMARY,
+    }

--- a/backend/tests/test_directory_query.py
+++ b/backend/tests/test_directory_query.py
@@ -13,6 +13,8 @@ def _game(
     year: int,
     created_at: str,
     tier: str | None = None,
+    identity_status: str = "verified",
+    content_review_status: str = "human_reviewed",
 ):
     return {
         "id": game_id,
@@ -27,6 +29,8 @@ def _game(
         "published_year": year,
         "created_at": created_at,
         "strategy_tier": tier,
+        "identity_status": identity_status,
+        "content_review_status": content_review_status,
     }
 
 
@@ -112,6 +116,57 @@ def test_ranked_search_keeps_canonical_relevance_for_default_sort():
     )
 
     assert [game["id"] for game in result["data"]] == ["exact", "summary"]
+
+
+def test_directory_hides_unverified_and_unreviewed_prose(monkeypatch):
+    rows = [
+        _game(
+            "unverified",
+            title="Unverified",
+            minimum=2,
+            maximum=4,
+            play_time=30,
+            year=2026,
+            created_at="2026-01-03",
+            identity_status="unverified",
+            content_review_status="unknown",
+        ),
+        _game(
+            "needs-review",
+            title="Needs Review",
+            minimum=2,
+            maximum=4,
+            play_time=30,
+            year=2026,
+            created_at="2026-01-02",
+            content_review_status="review_required",
+        ),
+        _game(
+            "reviewed",
+            title="Reviewed",
+            minimum=2,
+            maximum=4,
+            play_time=30,
+            year=2026,
+            created_at="2026-01-01",
+        ),
+    ]
+    monkeypatch.setattr(directory_query.local_db, "list_recent", lambda limit, offset: {"data": rows, "total": len(rows)})
+
+    result = directory_query._query_local(
+        q=None,
+        players=None,
+        time_filter=None,
+        tier=None,
+        sort="recent",
+        limit=48,
+        offset=0,
+    )
+
+    projected = {game["id"]: game for game in result["data"]}
+    assert projected["unverified"]["summary"] == "概要は確認中です。"
+    assert projected["needs-review"]["summary"] == "概要は確認中です。"
+    assert projected["reviewed"]["summary"] == "Reviewed summary"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes the remaining player-facing summary portion of #267 without adding a second frontend trust model.

Observable success condition: Directory and comparison results must not expose stored summary/description prose when identity is unverified or content review is not human/publisher reviewed; reviewed entries keep their existing summary.

Changes:
- reuse `player_summary` as the single summary projection authority
- project Directory API rows after filtering/ranking/pagination
- return neutral `概要は確認中です。` instead of unverified stored prose
- keep search matching on stored catalog text so discovery recall is unchanged
- add regression coverage for unverified, review-required, and reviewed states

No production data, rule facts, affiliate links, schema, dependency, or game-specific exception is changed.