### PR TITLE
Expose source provenance in directory and comparison

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -108,6 +108,7 @@ jobs:
           tests/source_links.spec.js
           tests/rule_ask.spec.js
           tests/pili_pili_ruleset_context.spec.js
+          tests/directory-source-trust.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,7 +35,9 @@ function comparisonPlayTime(game) {
 
 function directoryTrustLabel(game) {
   if (game.identity_status !== 'verified') return '未検証'
-  if (['review_required', 'ai_draft', 'unknown'].includes(game.content_review_status)) return '内容要確認'
+  if (!['human_reviewed', 'publisher_reviewed'].includes(game.content_review_status)) return '内容要確認'
+  if (!game.source_trust || game.source_trust === 'unknown') return '出典未確認'
+  if (game.source_trust === 'third_party') return '第三者出典'
   return null
 }
 

--- a/frontend/tests/directory-source-trust.spec.js
+++ b/frontend/tests/directory-source-trust.spec.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test'
+
+const GAMES = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    slug: 'official-game',
+    title: 'Official Game',
+    title_ja: '公式ゲーム',
+    summary: '確認済み概要',
+    identity_status: 'verified',
+    content_review_status: 'human_reviewed',
+    source_trust: 'official_publisher',
+    min_players: 2,
+    max_players: 4,
+    play_time: 30,
+  },
+  {
+    id: '22222222-2222-4222-8222-222222222222',
+    slug: 'unknown-source-game',
+    title: 'Unknown Source Game',
+    title_ja: '出典未確認ゲーム',
+    summary: '確認済み概要',
+    identity_status: 'verified',
+    content_review_status: 'human_reviewed',
+    source_trust: 'unknown',
+    min_players: 2,
+    max_players: 4,
+    play_time: 30,
+  },
+  {
+    id: '33333333-3333-4333-8333-333333333333',
+    slug: 'third-party-game',
+    title: 'Third Party Game',
+    title_ja: '第三者出典ゲーム',
+    summary: '確認済み概要',
+    identity_status: 'verified',
+    content_review_status: 'publisher_reviewed',
+    source_trust: 'third_party',
+    min_players: 2,
+    max_players: 4,
+    play_time: 30,
+  },
+]
+
+async function mockDirectory(page) {
+  await page.route('**/api/games?*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games: GAMES, total: GAMES.length }),
+    })
+  })
+}
+
+test('source provenance remains visible in directory and comparison', async ({ page }) => {
+  await mockDirectory(page)
+  await page.goto('/')
+
+  const officialCard = page.locator('.asset-card-shell').filter({ hasText: '公式ゲーム' })
+  const unknownCard = page.locator('.asset-card-shell').filter({ hasText: '出典未確認ゲーム' })
+  const thirdPartyCard = page.locator('.asset-card-shell').filter({ hasText: '第三者出典ゲーム' })
+
+  await expect(officialCard.getByText('出典未確認', { exact: true })).toHaveCount(0)
+  await expect(officialCard.getByText('第三者出典', { exact: true })).toHaveCount(0)
+  await expect(unknownCard.getByText('出典未確認', { exact: true })).toBeVisible()
+  await expect(thirdPartyCard.getByText('第三者出典', { exact: true })).toBeVisible()
+
+  await page.getByRole('button', { name: '出典未確認ゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '第三者出典ゲームを比較に追加' }).click()
+  await page.getByRole('button', { name: '比較する' }).click()
+
+  await expect(page.getByText('出典未確認', { exact: true })).toBeVisible()
+  await expect(page.getByText('第三者出典', { exact: true })).toBeVisible()
+})


### PR DESCRIPTION
## Player outcome

A game with verified identity and reviewed content no longer appears fully settled in Directory/comparison when its source provenance is unknown or third-party.

## Observable success condition

- `verified + human/publisher reviewed + source_trust=unknown` -> `出典未確認`
- `verified + human/publisher reviewed + source_trust=third_party` -> `第三者出典`
- `official_publisher` / `authorized_partner` reviewed games remain un-warned
- the same trust label survives into comparison because comparison uses the same Directory game object and helper

## Changes

- make the existing Directory/comparison trust label fail closed on content review status
- include source provenance in the same shared label helper
- add Playwright regression coverage for official, unknown-source, and third-party fixtures

No game rules, stored catalog data, affiliate URLs, schemas, dependencies, or production data writes are changed.