### PR TITLE
Fail closed on unsupported comparison metadata evidence

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ const TIME_FILTERS = [
 const SORT_OPTIONS = ['recent', 'title', 'year', 'play_time']
 const PAGE_SIZE = 48
 const NO_IMAGE_URL = '/assets/no-image.webp'
+const UNVERIFIED_COMPARISON_EVIDENCE = '根拠未登録'
 
 function gameImageUrl(game) {
   const configured = game.image_url?.trim()
@@ -302,14 +303,23 @@ function App() {
               <div className="battle-attr">
                 <div className="battle-attr-label">基本情報</div>
                 <div className="pro-stats-grid comparison-specs">
-                  <div className="pro-stat-card"><div className="pro-stat-label">人数</div><div className="pro-stat-value comparison-stat">{comparisonPlayers(game)}</div></div>
-                  <div className="pro-stat-card"><div className="pro-stat-label">時間</div><div className="pro-stat-value comparison-stat">{comparisonPlayTime(game)}</div></div>
+                  <div className="pro-stat-card">
+                    <div className="pro-stat-label">人数</div>
+                    <div className="pro-stat-value comparison-stat">{comparisonPlayers(game)}</div>
+                    <div className="meta-item" aria-label="人数の根拠">{UNVERIFIED_COMPARISON_EVIDENCE}</div>
+                  </div>
+                  <div className="pro-stat-card">
+                    <div className="pro-stat-label">時間</div>
+                    <div className="pro-stat-value comparison-stat">{comparisonPlayTime(game)}</div>
+                    <div className="meta-item" aria-label="時間の根拠">{UNVERIFIED_COMPARISON_EVIDENCE}</div>
+                  </div>
                 </div>
               </div>
 
               {game.structured_data?.mechanics && (
                 <div className="battle-attr">
                   <div className="battle-attr-label">メカニクス</div>
+                  <div className="meta-item" aria-label="メカニクスの根拠">{UNVERIFIED_COMPARISON_EVIDENCE}</div>
                   <div className="tag-list">
                     {game.structured_data.mechanics.slice(0, 5).map((mechanic) => <span key={mechanic} className="tag-item">{mechanic}</span>)}
                   </div>

--- a/frontend/tests/directory-source-trust.spec.js
+++ b/frontend/tests/directory-source-trust.spec.js
@@ -13,6 +13,7 @@ const GAMES = [
     min_players: 2,
     max_players: 4,
     play_time: 30,
+    structured_data: { mechanics: ['Set Collection'] },
   },
   {
     id: '22222222-2222-4222-8222-222222222222',
@@ -65,10 +66,13 @@ test('source provenance remains visible in directory and comparison', async ({ p
   await expect(unknownCard.getByText('出典未確認', { exact: true })).toBeVisible()
   await expect(thirdPartyCard.getByText('第三者出典', { exact: true })).toBeVisible()
 
+  await page.getByRole('button', { name: '公式ゲームを比較に追加' }).click()
   await page.getByRole('button', { name: '出典未確認ゲームを比較に追加' }).click()
-  await page.getByRole('button', { name: '第三者出典ゲームを比較に追加' }).click()
   await page.getByRole('button', { name: '比較する' }).click()
 
   await expect(page.getByText('出典未確認', { exact: true })).toBeVisible()
-  await expect(page.getByText('第三者出典', { exact: true })).toBeVisible()
+  await expect(page.getByLabel('人数の根拠')).toHaveCount(2)
+  await expect(page.getByLabel('時間の根拠')).toHaveCount(2)
+  await expect(page.getByLabel('メカニクスの根拠')).toHaveCount(1)
+  await expect(page.getByText('根拠未登録', { exact: true })).toHaveCount(5)
 })


### PR DESCRIPTION
## Player outcome

Comparison currently renders Players / Time / Mechanics as plain facts even though no field-level `GAME_METADATA` evidence is registered for those values. This makes game-level trust look like field-level verification.

Observable success condition: every compared Players / Time / Mechanics value explicitly shows `根拠未登録` until canonical field-level evidence exists; no value is silently promoted from game-level trust.

## Changes

- mark Players, Time, and Mechanics provenance independently in Comparison Battle
- keep existing values visible for utility, but fail closed on evidence status
- add accessible per-field provenance labels
- extend the existing Directory/Comparison Playwright regression; no new workflow

## Boundaries

- no game rules or edition data changed
- no new evidence schema or shadow provenance store
- existing `EvidenceTargetType.GAME_METADATA` remains the canonical future evidence target
- no production data mutation

Refs #260