### PR TITLE
Project canonical field evidence into game comparison

### DIFF
--- a/backend/app/db/migrations/074_comparison_metadata_evidence.sql
+++ b/backend/app/db/migrations/074_comparison_metadata_evidence.sql
@@ -31,12 +31,14 @@ BEGIN
   SELECT id INTO v_game_id FROM public.games WHERE slug='ito' LIMIT 1;
   IF v_game_id IS NULL THEN RAISE EXCEPTION 'Canonical game ito is required'; END IF;
 
-  SELECT count(*), min(id) INTO v_ruleset_count, v_ruleset_id
+  SELECT count(*) INTO v_ruleset_count
   FROM public.rule_sets
   WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound';
   IF v_ruleset_count <> 1 THEN
     RAISE EXCEPTION 'ito requires exactly one active source-bound RuleSet, found %', v_ruleset_count;
   END IF;
+  SELECT id INTO v_ruleset_id FROM public.rule_sets
+  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound' LIMIT 1;
 
   INSERT INTO public.claims(
     claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance
@@ -70,12 +72,14 @@ BEGIN
   SELECT id INTO v_game_id FROM public.games WHERE slug='scythe' LIMIT 1;
   IF v_game_id IS NULL THEN RAISE EXCEPTION 'Canonical game scythe is required'; END IF;
 
-  SELECT count(*), min(id) INTO v_ruleset_count, v_ruleset_id
+  SELECT count(*) INTO v_ruleset_count
   FROM public.rule_sets
   WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound';
   IF v_ruleset_count <> 1 THEN
     RAISE EXCEPTION 'scythe requires exactly one active source-bound RuleSet, found %', v_ruleset_count;
   END IF;
+  SELECT id INTO v_ruleset_id FROM public.rule_sets
+  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound' LIMIT 1;
 
   INSERT INTO public.claims(
     claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance

--- a/backend/app/db/migrations/074_comparison_metadata_evidence.sql
+++ b/backend/app/db/migrations/074_comparison_metadata_evidence.sql
@@ -1,0 +1,103 @@
+BEGIN;
+
+INSERT INTO public.evidence_sources (
+  source_id,url,document_identity,source_type,publisher_name,platform,language_code,revision_label,trust_metadata
+) VALUES
+(
+  'scythe:arclight-product-page',
+  'https://arclightgames.jp/product/%E3%82%B5%E3%82%A4%E3%82%BA-%E5%A4%A7%E9%8E%8C%E6%88%A6%E5%BD%B9/',
+  'サイズ – 大鎌戦役 – 完全日本語版 — publisher product page',
+  'publisher_product_page','株式会社アークライト','physical','ja',
+  'current official product page accessed 2026-08-27',
+  '{"authority":"publisher_product_page","scope":"サイズ – 大鎌戦役 – 完全日本語版"}'::jsonb
+)
+ON CONFLICT (source_id) DO UPDATE SET
+  url=EXCLUDED.url,document_identity=EXCLUDED.document_identity,source_type=EXCLUDED.source_type,
+  publisher_name=EXCLUDED.publisher_name,platform=EXCLUDED.platform,language_code=EXCLUDED.language_code,
+  revision_label=EXCLUDED.revision_label,trust_metadata=EXCLUDED.trust_metadata,updated_at=now();
+
+INSERT INTO public.source_locators(locator_id,source_id,section_heading,external_reference) VALUES
+('ito:locator:product-overview','ito:arclight-rules-page','「ito」商品概要','プレイ人数：2～10人 / プレイ時間：約30分'),
+('scythe:locator:product-overview','scythe:arclight-product-page','「サイズ – 大鎌戦役 – 完全日本語版」商品概要','プレイ人数：1〜5人 / プレイ時間：115分')
+ON CONFLICT (locator_id) DO UPDATE SET
+  source_id=EXCLUDED.source_id,section_heading=EXCLUDED.section_heading,external_reference=EXCLUDED.external_reference;
+
+DO $$
+DECLARE
+  v_game_id uuid;
+  v_ruleset_id uuid;
+  v_ruleset_count integer;
+BEGIN
+  SELECT id INTO v_game_id FROM public.games WHERE slug='ito' LIMIT 1;
+  IF v_game_id IS NULL THEN RAISE EXCEPTION 'Canonical game ito is required'; END IF;
+
+  SELECT count(*), min(id) INTO v_ruleset_count, v_ruleset_id
+  FROM public.rule_sets
+  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound';
+  IF v_ruleset_count <> 1 THEN
+    RAISE EXCEPTION 'ito requires exactly one active source-bound RuleSet, found %', v_ruleset_count;
+  END IF;
+
+  INSERT INTO public.claims(
+    claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance
+  ) VALUES
+  ('ito:metadata:min_players',v_ruleset_id,'game_metadata_value','{"value":2,"display":"2～10人","unit":"players"}'::jsonb,'game_metadata','min_players','accepted','{"method":"human_reviewed_official_product_page"}'::jsonb),
+  ('ito:metadata:max_players',v_ruleset_id,'game_metadata_value','{"value":10,"display":"2～10人","unit":"players"}'::jsonb,'game_metadata','max_players','accepted','{"method":"human_reviewed_official_product_page"}'::jsonb),
+  ('ito:metadata:play_time',v_ruleset_id,'game_metadata_value','{"value":30,"display":"約30分","unit":"minutes","approximate":true}'::jsonb,'game_metadata','play_time','accepted','{"method":"human_reviewed_official_product_page"}'::jsonb)
+  ON CONFLICT(claim_id) DO UPDATE SET
+    rule_set_id=EXCLUDED.rule_set_id,claim_type=EXCLUDED.claim_type,normalized_payload=EXCLUDED.normalized_payload,
+    target_type=EXCLUDED.target_type,field_path=EXCLUDED.field_path,lifecycle_status=EXCLUDED.lifecycle_status,
+    generator_provenance=EXCLUDED.generator_provenance,updated_at=now();
+
+  INSERT INTO public.evidence_bindings(
+    binding_id,claim_id,source_id,locator_id,relation,reviewer_provenance,generator_provenance,verified_at
+  ) VALUES
+  ('ito:binding:metadata:min_players','ito:metadata:min_players','ito:arclight-rules-page','ito:locator:product-overview','supports','{"review":"official_product_page"}'::jsonb,'{}'::jsonb,now()),
+  ('ito:binding:metadata:max_players','ito:metadata:max_players','ito:arclight-rules-page','ito:locator:product-overview','supports','{"review":"official_product_page"}'::jsonb,'{}'::jsonb,now()),
+  ('ito:binding:metadata:play_time','ito:metadata:play_time','ito:arclight-rules-page','ito:locator:product-overview','supports','{"review":"official_product_page"}'::jsonb,'{}'::jsonb,now())
+  ON CONFLICT(binding_id) DO UPDATE SET
+    claim_id=EXCLUDED.claim_id,source_id=EXCLUDED.source_id,locator_id=EXCLUDED.locator_id,
+    relation=EXCLUDED.relation,reviewer_provenance=EXCLUDED.reviewer_provenance,
+    generator_provenance=EXCLUDED.generator_provenance,verified_at=EXCLUDED.verified_at;
+END $$;
+
+DO $$
+DECLARE
+  v_game_id uuid;
+  v_ruleset_id uuid;
+  v_ruleset_count integer;
+BEGIN
+  SELECT id INTO v_game_id FROM public.games WHERE slug='scythe' LIMIT 1;
+  IF v_game_id IS NULL THEN RAISE EXCEPTION 'Canonical game scythe is required'; END IF;
+
+  SELECT count(*), min(id) INTO v_ruleset_count, v_ruleset_id
+  FROM public.rule_sets
+  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound';
+  IF v_ruleset_count <> 1 THEN
+    RAISE EXCEPTION 'scythe requires exactly one active source-bound RuleSet, found %', v_ruleset_count;
+  END IF;
+
+  INSERT INTO public.claims(
+    claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance
+  ) VALUES
+  ('scythe:metadata:min_players',v_ruleset_id,'game_metadata_value','{"value":1,"display":"1～5人","unit":"players"}'::jsonb,'game_metadata','min_players','accepted','{"method":"human_reviewed_official_product_page"}'::jsonb),
+  ('scythe:metadata:max_players',v_ruleset_id,'game_metadata_value','{"value":5,"display":"1～5人","unit":"players"}'::jsonb,'game_metadata','max_players','accepted','{"method":"human_reviewed_official_product_page"}'::jsonb),
+  ('scythe:metadata:play_time',v_ruleset_id,'game_metadata_value','{"value":115,"display":"115分","unit":"minutes"}'::jsonb,'game_metadata','play_time','accepted','{"method":"human_reviewed_official_product_page"}'::jsonb)
+  ON CONFLICT(claim_id) DO UPDATE SET
+    rule_set_id=EXCLUDED.rule_set_id,claim_type=EXCLUDED.claim_type,normalized_payload=EXCLUDED.normalized_payload,
+    target_type=EXCLUDED.target_type,field_path=EXCLUDED.field_path,lifecycle_status=EXCLUDED.lifecycle_status,
+    generator_provenance=EXCLUDED.generator_provenance,updated_at=now();
+
+  INSERT INTO public.evidence_bindings(
+    binding_id,claim_id,source_id,locator_id,relation,reviewer_provenance,generator_provenance,verified_at
+  ) VALUES
+  ('scythe:binding:metadata:min_players','scythe:metadata:min_players','scythe:arclight-product-page','scythe:locator:product-overview','supports','{"review":"official_product_page"}'::jsonb,'{}'::jsonb,now()),
+  ('scythe:binding:metadata:max_players','scythe:metadata:max_players','scythe:arclight-product-page','scythe:locator:product-overview','supports','{"review":"official_product_page"}'::jsonb,'{}'::jsonb,now()),
+  ('scythe:binding:metadata:play_time','scythe:metadata:play_time','scythe:arclight-product-page','scythe:locator:product-overview','supports','{"review":"official_product_page"}'::jsonb,'{}'::jsonb,now())
+  ON CONFLICT(binding_id) DO UPDATE SET
+    claim_id=EXCLUDED.claim_id,source_id=EXCLUDED.source_id,locator_id=EXCLUDED.locator_id,
+    relation=EXCLUDED.relation,reviewer_provenance=EXCLUDED.reviewer_provenance,
+    generator_provenance=EXCLUDED.generator_provenance,verified_at=EXCLUDED.verified_at;
+END $$;
+
+COMMIT;

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -70,6 +70,7 @@ class GameDetail(BaseSchema):
     summary: str | None = None
     image_url: str | None = None
     structured_data: StructuredData | None = None
+    metadata_evidence: dict[str, Any] | None = None
     source_url: str | None = None
     source_trust: SourceTrust = "unknown"
     content_review_status: ContentReviewStatus = "unknown"

--- a/backend/app/services/directory_query.py
+++ b/backend/app/services/directory_query.py
@@ -4,6 +4,7 @@ from typing import Any, Literal
 import anyio
 
 from app.core import local_db, supabase
+from app.services.metadata_evidence_projection import project_metadata_evidence
 from app.services.player_summary import project_directory_summary
 from app.services.search_visibility import EXCLUDED_GAME_SLUGS, should_hide_game_from_search
 
@@ -69,6 +70,13 @@ def _project_result(result: dict[str, Any]) -> dict[str, Any]:
         **result,
         "data": [project_directory_summary(game) for game in result["data"]],
     }
+
+
+async def _project_evidence(result: dict[str, Any]) -> dict[str, Any]:
+    if supabase.is_local() or not result["data"]:
+        return result
+    projected = await anyio.to_thread.run_sync(project_metadata_evidence, result["data"])
+    return {**result, "data": projected}
 
 
 def _filter_rows(
@@ -144,7 +152,7 @@ async def list_directory_games(
     """Return one filtered directory page without loading the full catalog into the browser."""
     if q and q.strip():
         ranked = await supabase.search(q.strip())
-        return _query_ranked_search_results(
+        result = _query_ranked_search_results(
             ranked,
             players=players,
             time_filter=time_filter,
@@ -153,6 +161,7 @@ async def list_directory_games(
             limit=limit,
             offset=offset,
         )
+        return await _project_evidence(result)
 
     if supabase.is_local():
         local_db.init_db()
@@ -203,4 +212,5 @@ async def list_directory_games(
         result = query.range(offset, offset + limit - 1).execute()
         return _project_result({"data": result.data, "total": result.count or 0})
 
-    return await anyio.to_thread.run_sync(_q)
+    result = await anyio.to_thread.run_sync(_q)
+    return await _project_evidence(result)

--- a/backend/app/services/metadata_evidence_projection.py
+++ b/backend/app/services/metadata_evidence_projection.py
@@ -1,0 +1,123 @@
+from collections import defaultdict
+from typing import Any
+
+from app.core import supabase
+
+SUPPORTED_METADATA_FIELDS = {"min_players", "max_players", "play_time", "structured_data.mechanics"}
+
+
+def project_metadata_evidence(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Attach field-level metadata evidence without inferring trust from game-level state."""
+    if not rows or supabase.is_local():
+        return rows
+
+    client = supabase._get_client()
+    game_ids = [str(row["id"]) for row in rows if row.get("id")]
+    if not game_ids:
+        return rows
+
+    ruleset_rows = (
+        client.table("rule_sets")
+        .select("id,game_id")
+        .in_("game_id", game_ids)
+        .eq("is_active", True)
+        .eq("verification_status", "source_bound")
+        .execute()
+        .data
+    )
+    rulesets_by_game: dict[str, list[str]] = defaultdict(list)
+    for item in ruleset_rows:
+        rulesets_by_game[str(item["game_id"])].append(str(item["id"]))
+
+    unique_rulesets = {
+        game_id: ruleset_ids[0]
+        for game_id, ruleset_ids in rulesets_by_game.items()
+        if len(ruleset_ids) == 1
+    }
+    if not unique_rulesets:
+        return rows
+
+    ruleset_to_game = {ruleset_id: game_id for game_id, ruleset_id in unique_rulesets.items()}
+    claim_rows = (
+        client.table("claims")
+        .select("claim_id,rule_set_id,field_path,normalized_payload")
+        .in_("rule_set_id", list(ruleset_to_game))
+        .eq("target_type", "game_metadata")
+        .eq("lifecycle_status", "accepted")
+        .execute()
+        .data
+    )
+    claim_rows = [item for item in claim_rows if item.get("field_path") in SUPPORTED_METADATA_FIELDS]
+    if not claim_rows:
+        return rows
+
+    claim_ids = [str(item["claim_id"]) for item in claim_rows]
+    binding_rows = (
+        client.table("evidence_bindings")
+        .select("claim_id,source_id,relation")
+        .in_("claim_id", claim_ids)
+        .in_("relation", ["supports", "contradicts"])
+        .execute()
+        .data
+    )
+
+    relations_by_claim: dict[str, set[str]] = defaultdict(set)
+    supporting_sources_by_claim: dict[str, set[str]] = defaultdict(set)
+    for item in binding_rows:
+        claim_id = str(item["claim_id"])
+        relation = str(item["relation"])
+        relations_by_claim[claim_id].add(relation)
+        if relation == "supports":
+            supporting_sources_by_claim[claim_id].add(str(item["source_id"]))
+
+    eligible_claims: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    all_source_ids: set[str] = set()
+    for claim in claim_rows:
+        claim_id = str(claim["claim_id"])
+        relations = relations_by_claim[claim_id]
+        if "supports" not in relations or "contradicts" in relations:
+            continue
+        game_id = ruleset_to_game[str(claim["rule_set_id"])]
+        field_path = str(claim["field_path"])
+        sources = supporting_sources_by_claim[claim_id]
+        all_source_ids.update(sources)
+        eligible_claims[(game_id, field_path)].append(
+            {
+                "claim_id": claim_id,
+                "payload": claim.get("normalized_payload") or {},
+                "source_ids": sorted(sources),
+            }
+        )
+
+    source_urls: dict[str, str | None] = {}
+    if all_source_ids:
+        source_rows = (
+            client.table("evidence_sources")
+            .select("source_id,url")
+            .in_("source_id", sorted(all_source_ids))
+            .execute()
+            .data
+        )
+        source_urls = {str(item["source_id"]): item.get("url") for item in source_rows}
+
+    projected: list[dict[str, Any]] = []
+    for row in rows:
+        game_id = str(row.get("id") or "")
+        metadata_evidence: dict[str, Any] = {}
+        for field_path in sorted(SUPPORTED_METADATA_FIELDS):
+            candidates = eligible_claims.get((game_id, field_path), [])
+            if len(candidates) != 1:
+                continue
+            candidate = candidates[0]
+            source_ids = candidate["source_ids"]
+            metadata_evidence[field_path] = {
+                "status": "supported",
+                "claim_id": candidate["claim_id"],
+                "payload": candidate["payload"],
+                "sources": [
+                    {"source_id": source_id, "url": source_urls.get(source_id)}
+                    for source_id in source_ids
+                ],
+            }
+        projected.append({**row, "metadata_evidence": metadata_evidence})
+    return projected

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,6 +34,27 @@ function comparisonPlayTime(game) {
   return Number.isFinite(game.play_time) && game.play_time > 0 ? `${game.play_time}分` : '不明'
 }
 
+function comparisonFieldEvidence(game, fieldPath, currentValue) {
+  const evidence = game.metadata_evidence?.[fieldPath]
+  if (evidence?.status !== 'supported') return null
+  if (evidence.payload?.value !== currentValue) return null
+  return evidence
+}
+
+function comparisonPlayersEvidence(game) {
+  const minimum = comparisonFieldEvidence(game, 'min_players', game.min_players)
+  const maximum = comparisonFieldEvidence(game, 'max_players', game.max_players)
+  if (!minimum || !maximum) return null
+  return minimum
+}
+
+function ComparisonEvidence({ evidence, ariaLabel }) {
+  if (!evidence) return <div className="meta-item" aria-label={ariaLabel}>{UNVERIFIED_COMPARISON_EVIDENCE}</div>
+  const sourceUrl = evidence.sources?.find((source) => source.url)?.url
+  if (!sourceUrl) return <div className="meta-item" aria-label={ariaLabel}>根拠あり</div>
+  return <a className="meta-item" aria-label={ariaLabel} href={sourceUrl} target="_blank" rel="noreferrer">根拠あり</a>
+}
+
 function directoryTrustLabel(game) {
   if (game.identity_status !== 'verified') return '未検証'
   if (!['human_reviewed', 'publisher_reviewed'].includes(game.content_review_status)) return '内容要確認'
@@ -286,49 +307,56 @@ function App() {
         </div>
 
         <div className="battle-grid">
-          {compareList.map((game) => (
-            <div key={game.id} className="battle-col">
-              <div className="pro-card comparison-game-card">
-                <img src={gameImageUrl(game)} onError={handleGameImageError} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
-                <div className="pro-stat-value">{game.title_ja || game.title}</div>
-                {directoryTrustLabel(game) && <div className="meta-item">{directoryTrustLabel(game)}</div>}
-                {game.strategy_tier && <div className="tier-badge comparison-tier">戦略ティア {game.strategy_tier}</div>}
-              </div>
-
-              <div className="battle-attr">
-                <div className="battle-attr-label">概要</div>
-                <div className="comparison-summary">{game.summary || '概要はまだありません。'}</div>
-              </div>
-
-              <div className="battle-attr">
-                <div className="battle-attr-label">基本情報</div>
-                <div className="pro-stats-grid comparison-specs">
-                  <div className="pro-stat-card">
-                    <div className="pro-stat-label">人数</div>
-                    <div className="pro-stat-value comparison-stat">{comparisonPlayers(game)}</div>
-                    <div className="meta-item" aria-label="人数の根拠">{UNVERIFIED_COMPARISON_EVIDENCE}</div>
-                  </div>
-                  <div className="pro-stat-card">
-                    <div className="pro-stat-label">時間</div>
-                    <div className="pro-stat-value comparison-stat">{comparisonPlayTime(game)}</div>
-                    <div className="meta-item" aria-label="時間の根拠">{UNVERIFIED_COMPARISON_EVIDENCE}</div>
-                  </div>
+          {compareList.map((game) => {
+            const playersEvidence = comparisonPlayersEvidence(game)
+            const playTimeEvidence = comparisonFieldEvidence(game, 'play_time', game.play_time)
+            const mechanicsEvidence = game.metadata_evidence?.['structured_data.mechanics']?.status === 'supported'
+              ? game.metadata_evidence['structured_data.mechanics']
+              : null
+            return (
+              <div key={game.id} className="battle-col">
+                <div className="pro-card comparison-game-card">
+                  <img src={gameImageUrl(game)} onError={handleGameImageError} className="comparison-game-image" alt={game.title_ja || game.title || ''} />
+                  <div className="pro-stat-value">{game.title_ja || game.title}</div>
+                  {directoryTrustLabel(game) && <div className="meta-item">{directoryTrustLabel(game)}</div>}
+                  {game.strategy_tier && <div className="tier-badge comparison-tier">戦略ティア {game.strategy_tier}</div>}
                 </div>
-              </div>
 
-              {game.structured_data?.mechanics && (
                 <div className="battle-attr">
-                  <div className="battle-attr-label">メカニクス</div>
-                  <div className="meta-item" aria-label="メカニクスの根拠">{UNVERIFIED_COMPARISON_EVIDENCE}</div>
-                  <div className="tag-list">
-                    {game.structured_data.mechanics.slice(0, 5).map((mechanic) => <span key={mechanic} className="tag-item">{mechanic}</span>)}
+                  <div className="battle-attr-label">概要</div>
+                  <div className="comparison-summary">{game.summary || '概要はまだありません。'}</div>
+                </div>
+
+                <div className="battle-attr">
+                  <div className="battle-attr-label">基本情報</div>
+                  <div className="pro-stats-grid comparison-specs">
+                    <div className="pro-stat-card">
+                      <div className="pro-stat-label">人数</div>
+                      <div className="pro-stat-value comparison-stat">{comparisonPlayers(game)}</div>
+                      <ComparisonEvidence evidence={playersEvidence} ariaLabel="人数の根拠" />
+                    </div>
+                    <div className="pro-stat-card">
+                      <div className="pro-stat-label">時間</div>
+                      <div className="pro-stat-value comparison-stat">{comparisonPlayTime(game)}</div>
+                      <ComparisonEvidence evidence={playTimeEvidence} ariaLabel="時間の根拠" />
+                    </div>
                   </div>
                 </div>
-              )}
 
-              <Link to={`/games/${game.slug}`} className="filter-btn comparison-detail-link">詳しい情報を見る</Link>
-            </div>
-          ))}
+                {game.structured_data?.mechanics && (
+                  <div className="battle-attr">
+                    <div className="battle-attr-label">メカニクス</div>
+                    <ComparisonEvidence evidence={mechanicsEvidence} ariaLabel="メカニクスの根拠" />
+                    <div className="tag-list">
+                      {game.structured_data.mechanics.slice(0, 5).map((mechanic) => <span key={mechanic} className="tag-item">{mechanic}</span>)}
+                    </div>
+                  </div>
+                )}
+
+                <Link to={`/games/${game.slug}`} className="filter-btn comparison-detail-link">詳しい情報を見る</Link>
+              </div>
+            )
+          })}
         </div>
       </div>
     )

--- a/frontend/tests/directory-source-trust.spec.js
+++ b/frontend/tests/directory-source-trust.spec.js
@@ -14,6 +14,23 @@ const GAMES = [
     max_players: 4,
     play_time: 30,
     structured_data: { mechanics: ['Set Collection'] },
+    metadata_evidence: {
+      min_players: {
+        status: 'supported',
+        payload: { value: 2 },
+        sources: [{ source_id: 'official-product', url: 'https://example.com/rules' }],
+      },
+      max_players: {
+        status: 'supported',
+        payload: { value: 4 },
+        sources: [{ source_id: 'official-product', url: 'https://example.com/rules' }],
+      },
+      play_time: {
+        status: 'supported',
+        payload: { value: 30 },
+        sources: [{ source_id: 'official-product', url: 'https://example.com/rules' }],
+      },
+    },
   },
   {
     id: '22222222-2222-4222-8222-222222222222',
@@ -74,5 +91,7 @@ test('source provenance remains visible in directory and comparison', async ({ p
   await expect(page.getByLabel('人数の根拠')).toHaveCount(2)
   await expect(page.getByLabel('時間の根拠')).toHaveCount(2)
   await expect(page.getByLabel('メカニクスの根拠')).toHaveCount(1)
-  await expect(page.getByText('根拠未登録', { exact: true })).toHaveCount(5)
+  await expect(page.getByText('根拠あり', { exact: true })).toHaveCount(2)
+  await expect(page.getByText('根拠未登録', { exact: true })).toHaveCount(3)
+  await expect(page.getByRole('link', { name: '人数の根拠' })).toHaveAttribute('href', 'https://example.com/rules')
 })


### PR DESCRIPTION
## Player outcome

Comparison no longer treats all player-count/time metadata as permanently `根拠未登録`. A field becomes `根拠あり` only when the active source-bound RuleSet has exactly one accepted `game_metadata` claim with supporting evidence, no contradiction, and a payload value matching the displayed legacy field.

## Scope

- reuse existing Claim / EvidenceBinding / EvidenceSource contract; no new provenance store
- batch-project metadata evidence into Directory API results
- fail closed on multiple active RuleSets, multiple eligible claims, missing support, contradiction, or payload/value drift
- seed official product-page evidence for `ito` and `サイズ – 大鎌戦役 – 完全日本語版` player count and play time
- keep mechanics as `根拠未登録` until field-level evidence exists
- link `根拠あり` to the supporting source

## Official source boundaries

- ito: Arclight base product (2019), 2–10 players, about 30 minutes
- Scythe: Arclight `サイズ – 大鎌戦役 – 完全日本語版`, 1–5 players, 115 minutes
- expansions / other ito editions are not reused

## Success condition

On production comparison, ito and Scythe show linked `根拠あり` for 人数/時間 while unsupported metadata remains `根拠未登録`.
