### PR TITLE
Correct ito metadata to official product values

### DIFF
--- a/backend/app/db/migrations/075_correct_ito_official_metadata.sql
+++ b/backend/app/db/migrations/075_correct_ito_official_metadata.sql
@@ -1,0 +1,42 @@
+BEGIN;
+
+DO $$
+DECLARE
+  v_game_id uuid;
+  v_source_url text;
+BEGIN
+  SELECT id, source_url
+    INTO v_game_id, v_source_url
+  FROM public.games
+  WHERE slug = 'ito'
+  LIMIT 1;
+
+  IF v_game_id IS NULL THEN
+    RAISE EXCEPTION 'Canonical game ito is required';
+  END IF;
+
+  IF v_source_url IS DISTINCT FROM 'https://arclightgames.jp/product/ito/' THEN
+    RAISE EXCEPTION 'ito source_url drifted: %', v_source_url;
+  END IF;
+
+  UPDATE public.games
+  SET max_players = 10,
+      published_year = 2019,
+      updated_at = now()
+  WHERE id = v_game_id;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.games
+    WHERE id = v_game_id
+      AND min_players = 2
+      AND max_players = 10
+      AND play_time = 30
+      AND min_age = 8
+      AND published_year = 2019
+  ) THEN
+    RAISE EXCEPTION 'ito metadata does not match official product facts after correction';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Player outcome

Production currently exposes `ito` as 2–8 players even though the bound official Arclight product page states 2–10 players. The comparison evidence claim already records the official 2–10 range, so the canonical row and evidence disagree.

## Change

- correct `ito.max_players` from 8 to 10
- correct `ito.published_year` from 2021 to the official 2019 release year
- keep existing 2-player minimum, ~30 minute play time, age 8+, source URL and source-bound RuleSet unchanged
- fail closed if the canonical source URL has drifted
- assert all official product metadata after the update

## Observable success condition

After production release, Directory/Comparison returns `ito` as 2–10 players and the existing `ito:metadata:max_players` evidence payload (value 10) matches the displayed canonical value.

Official source: https://arclightgames.jp/product/ito/
