### PR TITLE
Generate canonical game metadata with field evidence in RuleOps

### DIFF
--- a/backend/app/ruleops/source-manifest.schema.json
+++ b/backend/app/ruleops/source-manifest.schema.json
@@ -86,6 +86,21 @@
         "review_status": {"const": "reviewed"}
       }
     },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "value", "display", "source_id", "evidence_locator", "review_status"],
+      "properties": {
+        "field": {"enum": ["min_players", "max_players", "play_time", "published_year"]},
+        "value": {"type": "integer"},
+        "display": {"type": "string", "minLength": 1},
+        "unit": {"enum": ["players", "minutes", "year"]},
+        "approximate": {"type": "boolean"},
+        "source_id": {"type": "string", "minLength": 1},
+        "evidence_locator": {"type": "string", "minLength": 1},
+        "review_status": {"const": "reviewed"}
+      }
+    },
     "game": {
       "type": "object",
       "additionalProperties": false,
@@ -113,6 +128,10 @@
           "type": "array",
           "minItems": 1,
           "items": {"$ref": "#/$defs/rule"}
+        },
+        "metadata": {
+          "type": "array",
+          "items": {"$ref": "#/$defs/metadata"}
         }
       }
     }

--- a/backend/app/ruleops/source-manifest.schema.json
+++ b/backend/app/ruleops/source-manifest.schema.json
@@ -8,11 +8,7 @@
   "properties": {
     "schema_version": {"const": "1.0"},
     "batch_id": {"type": "string", "minLength": 1},
-    "games": {
-      "type": "array",
-      "minItems": 1,
-      "items": {"$ref": "#/$defs/game"}
-    }
+    "games": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/game"}}
   },
   "$defs": {
     "identity": {
@@ -33,38 +29,17 @@
       "required": ["included_product", "excluded_products"],
       "properties": {
         "included_product": {"type": "string", "minLength": 1},
-        "excluded_products": {
-          "type": "array",
-          "items": {"type": "string", "minLength": 1}
-        }
+        "excluded_products": {"type": "array", "items": {"type": "string", "minLength": 1}}
       }
     },
     "source": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "source_id",
-        "url",
-        "source_type",
-        "review_status",
-        "applies_to_revision",
-        "applies_to_platform"
-      ],
+      "required": ["source_id", "url", "source_type", "review_status", "applies_to_revision", "applies_to_platform"],
       "properties": {
         "source_id": {"type": "string", "minLength": 1},
         "url": {"type": "string", "format": "uri"},
-        "source_type": {
-          "enum": [
-            "publisher_rulebook",
-            "publisher_rules_page",
-            "publisher_faq",
-            "publisher_errata",
-            "publisher_product_page",
-            "designer_rulebook",
-            "creator_rulebook",
-            "creator_listing"
-          ]
-        },
+        "source_type": {"enum": ["publisher_rulebook", "publisher_rules_page", "publisher_faq", "publisher_errata", "publisher_product_page", "designer_rulebook", "creator_rulebook", "creator_listing"]},
         "revision_label": {"type": ["string", "null"]},
         "review_status": {"const": "reviewed"},
         "applies_to_revision": {"type": "string", "minLength": 1},
@@ -77,9 +52,7 @@
       "required": ["rule_id", "node_type", "claim", "source_id", "evidence_locator", "review_status"],
       "properties": {
         "rule_id": {"type": "string", "minLength": 1},
-        "node_type": {
-          "enum": ["setup", "turn", "action", "condition", "effect", "scoring", "round_end", "victory"]
-        },
+        "node_type": {"enum": ["setup", "turn", "action", "condition", "effect", "scoring", "round_end", "victory"]},
         "claim": {"type": "string", "minLength": 1},
         "source_id": {"type": "string", "minLength": 1},
         "evidence_locator": {"type": "string", "minLength": 1},
@@ -89,7 +62,7 @@
     "metadata": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["field", "value", "display", "source_id", "evidence_locator", "review_status"],
+      "required": ["field", "value", "display", "unit", "source_id", "evidence_locator", "review_status"],
       "properties": {
         "field": {"enum": ["min_players", "max_players", "play_time", "published_year"]},
         "value": {"type": "integer"},
@@ -104,35 +77,16 @@
     "game": {
       "type": "object",
       "additionalProperties": false,
-      "required": [
-        "slug",
-        "identity",
-        "scope",
-        "review_status",
-        "remove_legacy_authority",
-        "sources",
-        "rules"
-      ],
+      "required": ["slug", "identity", "scope", "review_status", "remove_legacy_authority", "sources", "rules"],
       "properties": {
         "slug": {"type": "string", "minLength": 1},
         "identity": {"$ref": "#/$defs/identity"},
         "scope": {"$ref": "#/$defs/scope"},
         "review_status": {"const": "reviewed"},
         "remove_legacy_authority": {"type": "boolean"},
-        "sources": {
-          "type": "array",
-          "minItems": 1,
-          "items": {"$ref": "#/$defs/source"}
-        },
-        "rules": {
-          "type": "array",
-          "minItems": 1,
-          "items": {"$ref": "#/$defs/rule"}
-        },
-        "metadata": {
-          "type": "array",
-          "items": {"$ref": "#/$defs/metadata"}
-        }
+        "sources": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/source"}},
+        "rules": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/rule"}},
+        "metadata": {"type": "array", "items": {"$ref": "#/$defs/metadata"}}
       }
     }
   }

--- a/backend/app/scripts/ruleops_generate_migration.py
+++ b/backend/app/scripts/ruleops_generate_migration.py
@@ -79,6 +79,18 @@ def _render_locator_rows(game: dict[str, Any]) -> str:
                 ]
             ) + ")"
         )
+    for item in game.get("metadata", []):
+        locator_id = f"{slug}:locator:metadata:{item['field']}"
+        rows.append(
+            "(" + ",".join(
+                [
+                    sql_literal(locator_id),
+                    sql_literal(item["source_id"]),
+                    sql_literal(item["evidence_locator"]),
+                    sql_literal(item["display"]),
+                ]
+            ) + ")"
+        )
     return ",\n".join(rows)
 
 
@@ -107,6 +119,119 @@ def _render_rule_rows(game: dict[str, Any]) -> str:
             ) + ")"
         )
     return ",\n".join(rows)
+
+
+def _metadata_payload(item: dict[str, Any]) -> dict[str, Any]:
+    payload = {
+        "value": item["value"],
+        "display": item["display"],
+        "unit": item["unit"],
+    }
+    if "approximate" in item:
+        payload["approximate"] = item["approximate"]
+    return payload
+
+
+def _render_metadata_game_assignments(game: dict[str, Any]) -> str:
+    return "".join(f", {item['field']}={item['value']}" for item in game.get("metadata", []))
+
+
+def _render_metadata_claim_rows(game: dict[str, Any], batch_id: str) -> str:
+    slug = game["slug"]
+    rows = []
+    provenance = json.dumps(
+        {"method": "ruleops_reviewed_manifest", "batch_id": batch_id},
+        separators=(",", ":"),
+    )
+    for item in game.get("metadata", []):
+        payload = json.dumps(_metadata_payload(item), ensure_ascii=False, separators=(",", ":"))
+        rows.append(
+            "(" + ",".join(
+                [
+                    sql_literal(f"{slug}:metadata:{item['field']}"),
+                    "v_ruleset_id",
+                    sql_literal("game_metadata_value"),
+                    sql_literal(payload) + "::jsonb",
+                    sql_literal("game_metadata"),
+                    sql_literal(item["field"]),
+                    sql_literal("accepted"),
+                    sql_literal(provenance) + "::jsonb",
+                ]
+            ) + ")"
+        )
+    return ",\n".join(rows)
+
+
+def _render_metadata_binding_rows(game: dict[str, Any], batch_id: str) -> str:
+    slug = game["slug"]
+    rows = []
+    generator = json.dumps({"batch_id": batch_id}, separators=(",", ":"))
+    for item in game.get("metadata", []):
+        rows.append(
+            "(" + ",".join(
+                [
+                    sql_literal(f"{slug}:binding:metadata:{item['field']}"),
+                    sql_literal(f"{slug}:metadata:{item['field']}"),
+                    sql_literal(item["source_id"]),
+                    sql_literal(f"{slug}:locator:metadata:{item['field']}"),
+                    sql_literal("supports"),
+                    sql_literal('{"review":"ruleops_reviewed_manifest"}') + "::jsonb",
+                    sql_literal(generator) + "::jsonb",
+                    "now()",
+                ]
+            ) + ")"
+        )
+    return ",\n".join(rows)
+
+
+def _render_metadata_sql(game: dict[str, Any], batch_id: str) -> str:
+    metadata = game.get("metadata", [])
+    if not metadata:
+        return ""
+
+    slug = game["slug"]
+    claim_rows = _render_metadata_claim_rows(game, batch_id)
+    binding_rows = _render_metadata_binding_rows(game, batch_id)
+    assertions = []
+    for item in metadata:
+        field = item["field"]
+        value = item["value"]
+        assertions.append(
+            f"  IF (SELECT {field} FROM public.games WHERE id=v_game_id) IS DISTINCT FROM {value}\n"
+            f"    THEN RAISE EXCEPTION 'RuleOps {slug} canonical {field} must equal reviewed metadata value {value}'; END IF;"
+        )
+        assertions.append(
+            f"  IF (SELECT count(*) FROM public.claims WHERE claim_id={sql_literal(f'{slug}:metadata:{field}')} "
+            "AND rule_set_id=v_ruleset_id AND target_type='game_metadata' AND lifecycle_status='accepted') <> 1\n"
+            f"    THEN RAISE EXCEPTION 'RuleOps {slug} metadata claim {field} must exist exactly once'; END IF;"
+        )
+        assertions.append(
+            "  IF (SELECT count(*) FROM public.evidence_bindings eb "
+            f"WHERE eb.claim_id={sql_literal(f'{slug}:metadata:{field}')} AND eb.relation='supports') <> 1\n"
+            f"    THEN RAISE EXCEPTION 'RuleOps {slug} metadata evidence {field} must exist exactly once'; END IF;"
+        )
+
+    return f"""
+  INSERT INTO public.claims(
+    claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance
+  ) VALUES
+{claim_rows}
+  ON CONFLICT(claim_id) DO UPDATE SET
+    rule_set_id=EXCLUDED.rule_set_id,claim_type=EXCLUDED.claim_type,normalized_payload=EXCLUDED.normalized_payload,
+    target_type=EXCLUDED.target_type,field_path=EXCLUDED.field_path,lifecycle_status=EXCLUDED.lifecycle_status,
+    generator_provenance=EXCLUDED.generator_provenance,updated_at=now();
+
+  INSERT INTO public.evidence_bindings(
+    binding_id,claim_id,source_id,locator_id,relation,reviewer_provenance,generator_provenance,verified_at
+  ) VALUES
+{binding_rows}
+  ON CONFLICT(binding_id) DO UPDATE SET
+    claim_id=EXCLUDED.claim_id,source_id=EXCLUDED.source_id,locator_id=EXCLUDED.locator_id,
+    relation=EXCLUDED.relation,reviewer_provenance=EXCLUDED.reviewer_provenance,
+    generator_provenance=EXCLUDED.generator_provenance,verified_at=EXCLUDED.verified_at;
+
+{chr(10).join(assertions)}
+""".rstrip()
 
 
 def render_game_sql(game: dict[str, Any], batch_id: str) -> str:
@@ -141,6 +266,8 @@ def render_game_sql(game: dict[str, Any], batch_id: str) -> str:
 
     source_revision = identity["revision"]
     trust = source_trust(first_source["source_type"])
+    metadata_assignments = _render_metadata_game_assignments(game)
+    metadata_sql = _render_metadata_sql(game, batch_id)
     return f"""
 -- RuleOps game: {slug} / {identity['edition']} / {identity['revision']}
 INSERT INTO public.evidence_sources (
@@ -170,7 +297,7 @@ BEGIN
     source_url={sql_literal(first_source['url'])}, source_trust={sql_literal(trust)},
     content_review_status='review_required', is_official=true,
     edition_label={sql_literal(identity['edition'])}, language_code={sql_literal(identity['language'])},
-    source_revision={sql_literal(source_revision)}, updated_at=now(){legacy_reset}
+    source_revision={sql_literal(source_revision)}, updated_at=now(){metadata_assignments}{legacy_reset}
   WHERE id=v_game_id;
 
   SELECT id INTO v_ruleset_id FROM public.rule_sets
@@ -228,11 +355,13 @@ BEGIN
     relation=EXCLUDED.relation,reviewer_provenance=EXCLUDED.reviewer_provenance,
     generator_provenance=EXCLUDED.generator_provenance,verified_at=EXCLUDED.verified_at;
 
+{metadata_sql}
+
   IF (SELECT count(*) FROM public.rule_nodes WHERE rule_set_id=v_ruleset_id AND verification_status='source_bound') <> {count}
     THEN RAISE EXCEPTION 'RuleOps {slug} RuleNode count must be {count}'; END IF;
   IF (SELECT count(*) FROM public.claims WHERE rule_set_id=v_ruleset_id AND target_type='rule_node' AND lifecycle_status='accepted') <> {count}
     THEN RAISE EXCEPTION 'RuleOps {slug} Claim count must be {count}'; END IF;
-  IF (SELECT count(*) FROM public.evidence_bindings eb JOIN public.claims c ON c.claim_id=eb.claim_id WHERE c.rule_set_id=v_ruleset_id AND eb.relation='supports') <> {count}
+  IF (SELECT count(*) FROM public.evidence_bindings eb JOIN public.claims c ON c.claim_id=eb.claim_id WHERE c.rule_set_id=v_ruleset_id AND eb.relation='supports' AND c.target_type='rule_node') <> {count}
     THEN RAISE EXCEPTION 'RuleOps {slug} EvidenceBinding count must be {count}'; END IF;
 END $$;
 """.strip()

--- a/backend/app/scripts/ruleops_manifest.py
+++ b/backend/app/scripts/ruleops_manifest.py
@@ -31,6 +31,12 @@ CANONICAL_NODE_TYPES = {
     "victory",
 }
 PLATFORMS = {"physical", "digital", "vrchat"}
+METADATA_UNITS = {
+    "min_players": "players",
+    "max_players": "players",
+    "play_time": "minutes",
+    "published_year": "year",
+}
 
 
 @dataclass(frozen=True)
@@ -139,6 +145,84 @@ def validate_game_manifest(game: dict[str, Any]) -> list[ValidationError]:
                 f"{path}.applies_to_platform",
                 "source platform binding must exactly match identity.platform",
             )
+
+    metadata = game.get("metadata", [])
+    if not isinstance(metadata, list):
+        _error(errors, slug, "invalid_metadata", "metadata", "metadata must be a list")
+        metadata = []
+
+    metadata_fields: set[str] = set()
+    metadata_values: dict[str, int] = {}
+    for index, item in enumerate(metadata):
+        path = f"metadata[{index}]"
+        if not isinstance(item, dict):
+            _error(errors, slug, "invalid_metadata_item", path, "metadata item must be an object")
+            continue
+
+        field = item.get("field")
+        if field not in METADATA_UNITS:
+            _error(
+                errors,
+                slug,
+                "invalid_metadata_field",
+                f"{path}.field",
+                f"metadata field must be one of {sorted(METADATA_UNITS)}",
+            )
+            continue
+        if field in metadata_fields:
+            _error(errors, slug, "duplicate_metadata_field", f"{path}.field", f"duplicate metadata field {field}")
+        metadata_fields.add(field)
+
+        value = item.get("value")
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            _error(errors, slug, "invalid_metadata_value", f"{path}.value", "metadata value must be a positive integer")
+        else:
+            metadata_values[field] = value
+
+        if not _nonempty(item.get("display")):
+            _error(errors, slug, "missing_metadata_display", f"{path}.display", "metadata display is required")
+
+        expected_unit = METADATA_UNITS[field]
+        if item.get("unit") != expected_unit:
+            _error(
+                errors,
+                slug,
+                "metadata_unit_mismatch",
+                f"{path}.unit",
+                f"{field} unit must be {expected_unit}",
+            )
+
+        if item.get("approximate") and field != "play_time":
+            _error(
+                errors,
+                slug,
+                "invalid_metadata_approximation",
+                f"{path}.approximate",
+                "approximate is only supported for play_time",
+            )
+
+        if item.get("review_status") != REVIEWED:
+            _error(errors, slug, "metadata_not_reviewed", f"{path}.review_status", "metadata must be reviewed")
+
+        source_id = item.get("source_id")
+        if source_by_id.get(str(source_id)) is None:
+            _error(errors, slug, "missing_metadata_source", f"{path}.source_id", "metadata must reference a declared source")
+
+        if not _nonempty(item.get("evidence_locator")):
+            _error(errors, slug, "missing_metadata_locator", f"{path}.evidence_locator", "metadata evidence locator is required")
+
+    if (
+        "min_players" in metadata_values
+        and "max_players" in metadata_values
+        and metadata_values["min_players"] > metadata_values["max_players"]
+    ):
+        _error(
+            errors,
+            slug,
+            "invalid_player_range",
+            "metadata",
+            "min_players cannot exceed max_players",
+        )
 
     rules = game.get("rules")
     if not isinstance(rules, list) or not rules:

--- a/backend/tests/test_ruleops_game_metadata.py
+++ b/backend/tests/test_ruleops_game_metadata.py
@@ -1,0 +1,157 @@
+from app.scripts.ruleops_generate_migration import generate_migration
+from app.scripts.ruleops_manifest import validate_manifest
+
+
+def game_with_metadata():
+    revision = "publisher-2026-example"
+    return {
+        "slug": "example-game",
+        "identity": {
+            "title": "Example Game",
+            "edition": "Base Game 2026",
+            "language": "ja",
+            "platform": "physical",
+            "revision": revision,
+        },
+        "scope": {
+            "included_product": "Base Game 2026",
+            "excluded_products": ["Expansion"],
+        },
+        "review_status": "reviewed",
+        "remove_legacy_authority": True,
+        "sources": [
+            {
+                "source_id": "publisher:example:rulebook",
+                "url": "https://publisher.example/example/rules.pdf",
+                "source_type": "publisher_rulebook",
+                "revision_label": "2026 rules",
+                "review_status": "reviewed",
+                "applies_to_revision": revision,
+                "applies_to_platform": "physical",
+            },
+            {
+                "source_id": "publisher:example:product",
+                "url": "https://publisher.example/example",
+                "source_type": "publisher_product_page",
+                "revision_label": "2026 product page",
+                "review_status": "reviewed",
+                "applies_to_revision": revision,
+                "applies_to_platform": "physical",
+            },
+        ],
+        "rules": [
+            {
+                "rule_id": "turn.draw",
+                "node_type": "turn",
+                "claim": "手番ではカードを1枚引く。",
+                "source_id": "publisher:example:rulebook",
+                "evidence_locator": "p.2 Turn",
+                "review_status": "reviewed",
+            }
+        ],
+        "metadata": [
+            {
+                "field": "min_players",
+                "value": 2,
+                "display": "2～10人",
+                "unit": "players",
+                "source_id": "publisher:example:product",
+                "evidence_locator": "商品概要 / プレイ人数",
+                "review_status": "reviewed",
+            },
+            {
+                "field": "max_players",
+                "value": 10,
+                "display": "2～10人",
+                "unit": "players",
+                "source_id": "publisher:example:product",
+                "evidence_locator": "商品概要 / プレイ人数",
+                "review_status": "reviewed",
+            },
+            {
+                "field": "play_time",
+                "value": 30,
+                "display": "約30分",
+                "unit": "minutes",
+                "approximate": True,
+                "source_id": "publisher:example:product",
+                "evidence_locator": "商品概要 / プレイ時間",
+                "review_status": "reviewed",
+            },
+            {
+                "field": "published_year",
+                "value": 2026,
+                "display": "2026年",
+                "unit": "year",
+                "source_id": "publisher:example:product",
+                "evidence_locator": "商品概要 / 発売日",
+                "review_status": "reviewed",
+            },
+        ],
+    }
+
+
+def manifest(game):
+    return {"schema_version": "1.0", "batch_id": "metadata-pilot", "games": [game]}
+
+
+def test_reviewed_metadata_is_ready_and_product_page_can_support_it():
+    report = validate_manifest(manifest(game_with_metadata()))
+
+    assert report["status"] == "ready"
+    assert report["ready_games"] == 1
+
+
+def test_metadata_validation_blocks_range_unit_source_and_review_failures():
+    game = game_with_metadata()
+    game["metadata"][0]["value"] = 11
+    game["metadata"][1]["value"] = 10
+    game["metadata"][2]["unit"] = "players"
+    game["metadata"][2]["source_id"] = "publisher:missing"
+    game["metadata"][3]["review_status"] = "needs_review"
+
+    report = validate_manifest(manifest(game))
+    codes = {error["code"] for error in report["games"][0]["errors"]}
+
+    assert "invalid_player_range" in codes
+    assert "metadata_unit_mismatch" in codes
+    assert "missing_metadata_source" in codes
+    assert "metadata_not_reviewed" in codes
+
+
+def test_duplicate_metadata_field_is_blocked_before_generation():
+    game = game_with_metadata()
+    game["metadata"].append(dict(game["metadata"][0]))
+
+    report = validate_manifest(manifest(game))
+
+    assert any(error["code"] == "duplicate_metadata_field" for error in report["games"][0]["errors"])
+
+
+def test_generator_updates_canonical_metadata_and_writes_matching_evidence():
+    sql, report = generate_migration(manifest(game_with_metadata()), "076")
+
+    assert report["status"] == "generated"
+    assert "min_players=2" in sql
+    assert "max_players=10" in sql
+    assert "play_time=30" in sql
+    assert "published_year=2026" in sql
+    assert "example-game:metadata:min_players" in sql
+    assert "example-game:binding:metadata:max_players" in sql
+    assert "example-game:locator:metadata:play_time" in sql
+    assert "'game_metadata_value'" in sql
+    assert "'game_metadata'" in sql
+    assert '"approximate":true' in sql
+    assert "canonical max_players must equal reviewed metadata value 10" in sql
+    assert "metadata evidence published_year must exist exactly once" in sql
+
+
+def test_manifest_without_metadata_keeps_existing_ruleops_behavior():
+    game = game_with_metadata()
+    del game["metadata"]
+
+    sql, report = generate_migration(manifest(game), "076")
+
+    assert report["status"] == "generated"
+    assert ":metadata:" not in sql
+    assert "target_type='game_metadata'" not in sql


### PR DESCRIPTION
## Player-facing success condition
A reviewed RuleOps manifest can define official `min_players`, `max_players`, `play_time`, and `published_year` once, and the generated migration updates the canonical game row and matching `GAME_METADATA` Claim/EvidenceBinding in the same transaction. Invalid ranges, units, sources, review state, or duplicate fields are blocked before SQL generation.

## Why
The comparison evidence work required hand-written migration 074 for metadata claims and migration 075 for the canonical ito row correction. That split allowed official evidence (`max_players=10`) and the canonical row (`max_players=8`) to drift.

## Changes
- extend source manifest schema with optional reviewed game metadata
- validate supported fields, exact units, declared sources, review state, and player ranges
- generate canonical game-row updates, source locators, GAME_METADATA claims, supports bindings, and fail-loud assertions together
- preserve existing manifests without metadata unchanged
- add regression coverage for valid generation and blocked drift cases

No production game data is changed by this PR.