### PR TITLE
Fail closed when metadata evidence drifts from displayed values

### DIFF
--- a/.github/workflows/test-games-router.yml
+++ b/.github/workflows/test-games-router.yml
@@ -7,11 +7,13 @@ on:
       - "backend/app/routers/games.py"
       - "backend/app/services/directory_query.py"
       - "backend/app/services/game_service.py"
+      - "backend/app/services/metadata_evidence_projection.py"
       - "backend/app/services/player_summary.py"
       - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
       - "backend/tests/test_directory_query.py"
       - "backend/tests/test_games_router.py"
+      - "backend/tests/test_metadata_evidence_projection.py"
       - "backend/tests/test_seo_renderer.py"
       - "backend/tests/test_seo_renderer_canonical_rules.py"
       - "backend/tests/test_web_not_found.py"
@@ -27,11 +29,13 @@ on:
       - "backend/app/routers/games.py"
       - "backend/app/services/directory_query.py"
       - "backend/app/services/game_service.py"
+      - "backend/app/services/metadata_evidence_projection.py"
       - "backend/app/services/player_summary.py"
       - "backend/app/services/seo_renderer.py"
       - "backend/app/core/supabase.py"
       - "backend/tests/test_directory_query.py"
       - "backend/tests/test_games_router.py"
+      - "backend/tests/test_metadata_evidence_projection.py"
       - "backend/tests/test_seo_renderer.py"
       - "backend/tests/test_seo_renderer_canonical_rules.py"
       - "backend/tests/test_web_not_found.py"
@@ -53,6 +57,6 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - run: uv sync --frozen --dev
       - name: Run game route and SSR regression tests
-        run: uv run pytest -q backend/tests/test_directory_query.py backend/tests/test_games_router.py backend/tests/test_seo_renderer.py backend/tests/test_seo_renderer_canonical_rules.py backend/tests/test_web_not_found.py
+        run: uv run pytest -q backend/tests/test_directory_query.py backend/tests/test_games_router.py backend/tests/test_metadata_evidence_projection.py backend/tests/test_seo_renderer.py backend/tests/test_seo_renderer_canonical_rules.py backend/tests/test_web_not_found.py
         env:
           PYTHONPATH: backend

--- a/backend/app/services/metadata_evidence_projection.py
+++ b/backend/app/services/metadata_evidence_projection.py
@@ -6,6 +6,29 @@ from app.core import supabase
 SUPPORTED_METADATA_FIELDS = {"min_players", "max_players", "play_time", "structured_data.mechanics"}
 
 
+def _current_metadata_value(row: dict[str, Any], field_path: str) -> Any:
+    if field_path == "structured_data.mechanics":
+        structured_data = row.get("structured_data")
+        if not isinstance(structured_data, dict):
+            return None
+        return structured_data.get("mechanics")
+    return row.get(field_path)
+
+
+def _payload_matches_current_value(row: dict[str, Any], field_path: str, payload: Any) -> bool:
+    if not isinstance(payload, dict) or "value" not in payload:
+        return False
+    current_value = _current_metadata_value(row, field_path)
+    claimed_value = payload["value"]
+    if field_path == "structured_data.mechanics":
+        return (
+            isinstance(current_value, list)
+            and isinstance(claimed_value, list)
+            and current_value == claimed_value
+        )
+    return current_value is not None and current_value == claimed_value
+
+
 def project_metadata_evidence(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Attach field-level metadata evidence without inferring trust from game-level state."""
     if not rows or supabase.is_local():
@@ -109,6 +132,8 @@ def project_metadata_evidence(rows: list[dict[str, Any]]) -> list[dict[str, Any]
             if len(candidates) != 1:
                 continue
             candidate = candidates[0]
+            if not _payload_matches_current_value(row, field_path, candidate["payload"]):
+                continue
             source_ids = candidate["source_ids"]
             metadata_evidence[field_path] = {
                 "status": "supported",

--- a/backend/tests/test_metadata_evidence_projection.py
+++ b/backend/tests/test_metadata_evidence_projection.py
@@ -1,0 +1,66 @@
+from app.services.metadata_evidence_projection import _payload_matches_current_value
+
+
+def test_scalar_metadata_requires_exact_current_value() -> None:
+    game = {"min_players": 2, "play_time": 30}
+
+    assert _payload_matches_current_value(game, "min_players", {"value": 2}) is True
+    assert _payload_matches_current_value(game, "min_players", {"value": 3}) is False
+    assert _payload_matches_current_value(game, "play_time", {"value": 30}) is True
+    assert _payload_matches_current_value(game, "play_time", {}) is False
+
+
+def test_mechanics_evidence_requires_exact_array_match() -> None:
+    game = {"structured_data": {"mechanics": ["Deck Building", "Hand Management"]}}
+
+    assert (
+        _payload_matches_current_value(
+            game,
+            "structured_data.mechanics",
+            {"value": ["Deck Building", "Hand Management"]},
+        )
+        is True
+    )
+    assert (
+        _payload_matches_current_value(
+            game,
+            "structured_data.mechanics",
+            {"value": ["Deck Building"]},
+        )
+        is False
+    )
+    assert (
+        _payload_matches_current_value(
+            game,
+            "structured_data.mechanics",
+            {"value": ["Hand Management", "Deck Building"]},
+        )
+        is False
+    )
+
+
+def test_mechanics_evidence_fails_closed_on_missing_or_wrong_types() -> None:
+    assert (
+        _payload_matches_current_value(
+            {"structured_data": {}},
+            "structured_data.mechanics",
+            {"value": []},
+        )
+        is False
+    )
+    assert (
+        _payload_matches_current_value(
+            {"structured_data": {"mechanics": ["Drafting"]}},
+            "structured_data.mechanics",
+            {"value": "Drafting"},
+        )
+        is False
+    )
+    assert (
+        _payload_matches_current_value(
+            {"structured_data": "not-an-object"},
+            "structured_data.mechanics",
+            {"value": ["Drafting"]},
+        )
+        is False
+    )


### PR DESCRIPTION
## Player outcome

Comparison metadata must only show `根拠あり` when the accepted supporting claim exactly matches the value currently displayed to the player.

## Observable success condition

For `structured_data.mechanics`, evidence is projected only when the claim payload is an array exactly equal to the displayed mechanics array. Partial, reordered, missing, or wrong-type payloads remain unverified.

## Changes

- validate projected metadata evidence against the current game row before exposing it
- apply the same fail-closed check to scalar metadata fields
- require exact array equality for mechanics
- add regression tests for exact match, drift, reorder, missing data, and type mismatch
- add the metadata projection service/tests to the existing `Test game routes` CI gate

No game facts, rules, edition data, affiliate URLs, or production records are modified.