### PR TITLE
Generate mechanics evidence from RuleOps manifests

### DIFF
--- a/backend/app/ruleops/source-manifest.schema.json
+++ b/backend/app/ruleops/source-manifest.schema.json
@@ -59,13 +59,13 @@
         "review_status": {"const": "reviewed"}
       }
     },
-    "metadata": {
+    "numeric_metadata": {
       "type": "object",
       "additionalProperties": false,
       "required": ["field", "value", "display", "unit", "source_id", "evidence_locator", "review_status"],
       "properties": {
         "field": {"enum": ["min_players", "max_players", "play_time", "published_year"]},
-        "value": {"type": "integer"},
+        "value": {"type": "integer", "minimum": 1},
         "display": {"type": "string", "minLength": 1},
         "unit": {"enum": ["players", "minutes", "year"]},
         "approximate": {"type": "boolean"},
@@ -73,6 +73,30 @@
         "evidence_locator": {"type": "string", "minLength": 1},
         "review_status": {"const": "reviewed"}
       }
+    },
+    "mechanics_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "value", "display", "source_id", "evidence_locator", "review_status"],
+      "properties": {
+        "field": {"const": "structured_data.mechanics"},
+        "value": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "display": {"type": "string", "minLength": 1},
+        "source_id": {"type": "string", "minLength": 1},
+        "evidence_locator": {"type": "string", "minLength": 1},
+        "review_status": {"const": "reviewed"}
+      }
+    },
+    "metadata": {
+      "oneOf": [
+        {"$ref": "#/$defs/numeric_metadata"},
+        {"$ref": "#/$defs/mechanics_metadata"}
+      ]
     },
     "game": {
       "type": "object",

--- a/backend/app/scripts/ruleops_generate_migration.py
+++ b/backend/app/scripts/ruleops_generate_migration.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from app.scripts.ruleops_manifest import validate_manifest
 
+MECHANICS_FIELD = "structured_data.mechanics"
+
 
 def sql_literal(value: str | None) -> str:
     if value is None:
@@ -125,15 +127,27 @@ def _metadata_payload(item: dict[str, Any]) -> dict[str, Any]:
     payload = {
         "value": item["value"],
         "display": item["display"],
-        "unit": item["unit"],
     }
+    if "unit" in item:
+        payload["unit"] = item["unit"]
     if "approximate" in item:
         payload["approximate"] = item["approximate"]
     return payload
 
 
 def _render_metadata_game_assignments(game: dict[str, Any]) -> str:
-    return "".join(f", {item['field']}={item['value']}" for item in game.get("metadata", []))
+    assignments = []
+    for item in game.get("metadata", []):
+        if item["field"] == MECHANICS_FIELD:
+            rendered = json.dumps(item["value"], ensure_ascii=False, separators=(",", ":"))
+            assignments.append(
+                ", structured_data=jsonb_set(COALESCE(structured_data,'{}'::jsonb), '{mechanics}', "
+                + sql_literal(rendered)
+                + "::jsonb, true)"
+            )
+        else:
+            assignments.append(f", {item['field']}={item['value']}")
+    return "".join(assignments)
 
 
 def _render_metadata_claim_rows(game: dict[str, Any], batch_id: str) -> str:
@@ -184,6 +198,19 @@ def _render_metadata_binding_rows(game: dict[str, Any], batch_id: str) -> str:
     return ",\n".join(rows)
 
 
+def _canonical_metadata_sql(field: str) -> str:
+    if field == MECHANICS_FIELD:
+        return "structured_data->'mechanics'"
+    return field
+
+
+def _expected_metadata_sql(item: dict[str, Any]) -> str:
+    if item["field"] == MECHANICS_FIELD:
+        rendered = json.dumps(item["value"], ensure_ascii=False, separators=(",", ":"))
+        return sql_literal(rendered) + "::jsonb"
+    return str(item["value"])
+
+
 def _render_metadata_sql(game: dict[str, Any], batch_id: str) -> str:
     metadata = game.get("metadata", [])
     if not metadata:
@@ -195,10 +222,11 @@ def _render_metadata_sql(game: dict[str, Any], batch_id: str) -> str:
     assertions = []
     for item in metadata:
         field = item["field"]
-        value = item["value"]
+        canonical_sql = _canonical_metadata_sql(field)
+        expected_sql = _expected_metadata_sql(item)
         assertions.append(
-            f"  IF (SELECT {field} FROM public.games WHERE id=v_game_id) IS DISTINCT FROM {value}\n"
-            f"    THEN RAISE EXCEPTION 'RuleOps {slug} canonical {field} must equal reviewed metadata value {value}'; END IF;"
+            f"  IF (SELECT {canonical_sql} FROM public.games WHERE id=v_game_id) IS DISTINCT FROM {expected_sql}\n"
+            f"    THEN RAISE EXCEPTION 'RuleOps {slug} canonical {field} must equal reviewed metadata value'; END IF;"
         )
         assertions.append(
             f"  IF (SELECT count(*) FROM public.claims WHERE claim_id={sql_literal(f'{slug}:metadata:{field}')} "
@@ -297,7 +325,7 @@ BEGIN
     source_url={sql_literal(first_source['url'])}, source_trust={sql_literal(trust)},
     content_review_status='review_required', is_official=true,
     edition_label={sql_literal(identity['edition'])}, language_code={sql_literal(identity['language'])},
-    source_revision={sql_literal(source_revision)}, updated_at=now(){metadata_assignments}{legacy_reset}
+    source_revision={sql_literal(source_revision)}, updated_at=now(){legacy_reset}{metadata_assignments}
   WHERE id=v_game_id;
 
   SELECT id INTO v_ruleset_id FROM public.rule_sets

--- a/backend/app/scripts/ruleops_manifest.py
+++ b/backend/app/scripts/ruleops_manifest.py
@@ -37,6 +37,8 @@ METADATA_UNITS = {
     "play_time": "minutes",
     "published_year": "year",
 }
+MECHANICS_FIELD = "structured_data.mechanics"
+SUPPORTED_METADATA_FIELDS = set(METADATA_UNITS) | {MECHANICS_FIELD}
 
 
 @dataclass(frozen=True)
@@ -160,13 +162,13 @@ def validate_game_manifest(game: dict[str, Any]) -> list[ValidationError]:
             continue
 
         field = item.get("field")
-        if field not in METADATA_UNITS:
+        if field not in SUPPORTED_METADATA_FIELDS:
             _error(
                 errors,
                 slug,
                 "invalid_metadata_field",
                 f"{path}.field",
-                f"metadata field must be one of {sorted(METADATA_UNITS)}",
+                f"metadata field must be one of {sorted(SUPPORTED_METADATA_FIELDS)}",
             )
             continue
         if field in metadata_fields:
@@ -174,32 +176,57 @@ def validate_game_manifest(game: dict[str, Any]) -> list[ValidationError]:
         metadata_fields.add(field)
 
         value = item.get("value")
-        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-            _error(errors, slug, "invalid_metadata_value", f"{path}.value", "metadata value must be a positive integer")
+        if field == MECHANICS_FIELD:
+            if (
+                not isinstance(value, list)
+                or not value
+                or any(not _nonempty(mechanic) for mechanic in value)
+                or len(set(value)) != len(value)
+            ):
+                _error(
+                    errors,
+                    slug,
+                    "invalid_mechanics_value",
+                    f"{path}.value",
+                    "mechanics value must be a non-empty list of unique non-empty strings",
+                )
+            if "unit" in item:
+                _error(errors, slug, "invalid_mechanics_unit", f"{path}.unit", "mechanics metadata must not define unit")
+            if "approximate" in item:
+                _error(
+                    errors,
+                    slug,
+                    "invalid_mechanics_approximation",
+                    f"{path}.approximate",
+                    "mechanics metadata must not define approximate",
+                )
         else:
-            metadata_values[field] = value
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                _error(errors, slug, "invalid_metadata_value", f"{path}.value", "metadata value must be a positive integer")
+            else:
+                metadata_values[str(field)] = value
+
+            expected_unit = METADATA_UNITS[str(field)]
+            if item.get("unit") != expected_unit:
+                _error(
+                    errors,
+                    slug,
+                    "metadata_unit_mismatch",
+                    f"{path}.unit",
+                    f"{field} unit must be {expected_unit}",
+                )
+
+            if item.get("approximate") and field != "play_time":
+                _error(
+                    errors,
+                    slug,
+                    "invalid_metadata_approximation",
+                    f"{path}.approximate",
+                    "approximate is only supported for play_time",
+                )
 
         if not _nonempty(item.get("display")):
             _error(errors, slug, "missing_metadata_display", f"{path}.display", "metadata display is required")
-
-        expected_unit = METADATA_UNITS[field]
-        if item.get("unit") != expected_unit:
-            _error(
-                errors,
-                slug,
-                "metadata_unit_mismatch",
-                f"{path}.unit",
-                f"{field} unit must be {expected_unit}",
-            )
-
-        if item.get("approximate") and field != "play_time":
-            _error(
-                errors,
-                slug,
-                "invalid_metadata_approximation",
-                f"{path}.approximate",
-                "approximate is only supported for play_time",
-            )
 
         if item.get("review_status") != REVIEWED:
             _error(errors, slug, "metadata_not_reviewed", f"{path}.review_status", "metadata must be reviewed")

--- a/backend/tests/test_ruleops_game_metadata.py
+++ b/backend/tests/test_ruleops_game_metadata.py
@@ -91,6 +91,17 @@ def game_with_metadata():
     }
 
 
+def mechanics_metadata():
+    return {
+        "field": "structured_data.mechanics",
+        "value": ["Hand Management", "Set Collection"],
+        "display": "Hand Management / Set Collection",
+        "source_id": "publisher:example:rulebook",
+        "evidence_locator": "p.2-p.4 Turn and scoring procedures",
+        "review_status": "reviewed",
+    }
+
+
 def manifest(game):
     return {"schema_version": "1.0", "batch_id": "metadata-pilot", "games": [game]}
 
@@ -142,8 +153,43 @@ def test_generator_updates_canonical_metadata_and_writes_matching_evidence():
     assert "'game_metadata_value'" in sql
     assert "'game_metadata'" in sql
     assert '"approximate":true' in sql
-    assert "canonical max_players must equal reviewed metadata value 10" in sql
+    assert "canonical max_players must equal reviewed metadata value" in sql
     assert "metadata evidence published_year must exist exactly once" in sql
+
+
+def test_mechanics_metadata_generates_canonical_array_claim_and_evidence():
+    game = game_with_metadata()
+    game["metadata"].append(mechanics_metadata())
+
+    sql, report = generate_migration(manifest(game), "076")
+
+    assert report["status"] == "generated"
+    assert "structured_data='{}'::jsonb, setup_summary=NULL" in sql
+    assert "structured_data=jsonb_set(COALESCE(structured_data,'{}'::jsonb), '{mechanics}'" in sql
+    assert sql.index("structured_data='{}'::jsonb") < sql.index("structured_data=jsonb_set")
+    assert '[\"Hand Management\",\"Set Collection\"]' in sql
+    assert "example-game:metadata:structured_data.mechanics" in sql
+    assert "example-game:binding:metadata:structured_data.mechanics" in sql
+    assert "structured_data->'mechanics'" in sql
+    assert "canonical structured_data.mechanics must equal reviewed metadata value" in sql
+
+
+def test_mechanics_metadata_blocks_empty_duplicate_or_unit_bearing_values():
+    for value, extra, expected_code in [
+        ([], {}, "invalid_mechanics_value"),
+        (["Drafting", "Drafting"], {}, "invalid_mechanics_value"),
+        (["Drafting"], {"unit": "players"}, "invalid_mechanics_unit"),
+    ]:
+        game = game_with_metadata()
+        item = mechanics_metadata()
+        item["value"] = value
+        item.update(extra)
+        game["metadata"].append(item)
+
+        report = validate_manifest(manifest(game))
+        codes = {error["code"] for error in report["games"][0]["errors"]}
+
+        assert expected_code in codes
 
 
 def test_manifest_without_metadata_keeps_existing_ruleops_behavior():


### PR DESCRIPTION
## Outcome

Extend the existing RuleOps `GAME_METADATA` path to support `structured_data.mechanics` without adding a comparison-specific truth store.

## Observable success condition

A reviewed manifest can generate canonical mechanics plus the matching accepted Claim/EvidenceBinding in one transaction, while invalid/ambiguous mechanics fail before SQL generation.

## Changes

- schema: add a dedicated mechanics metadata shape (`structured_data.mechanics` = non-empty unique string array)
- validator: reject empty/duplicate/unit-bearing/approximate mechanics and undeclared evidence sources
- generator: reset legacy structured data first, then re-apply reviewed mechanics; write the same array into the canonical row and normalized claim payload
- generator assertions: fail if the stored mechanics array differs from the reviewed manifest
- regression tests for generation, ordering, evidence IDs, and fail-closed validation

No game mechanics are invented or migrated in this PR; this only makes the existing evidence pipeline capable of carrying reviewed mechanics facts.