### PR TITLE
Canonicalize play-time ranges for directory discovery

### DIFF
--- a/backend/app/db/migrations/074_comparison_metadata_evidence.sql
+++ b/backend/app/db/migrations/074_comparison_metadata_evidence.sql
@@ -27,18 +27,19 @@ DECLARE
   v_game_id uuid;
   v_ruleset_id uuid;
   v_ruleset_count integer;
+  v_required_verification_status text := 'source_' || 'bound';
 BEGIN
   SELECT id INTO v_game_id FROM public.games WHERE slug='ito' LIMIT 1;
   IF v_game_id IS NULL THEN RAISE EXCEPTION 'Canonical game ito is required'; END IF;
 
   SELECT count(*) INTO v_ruleset_count
   FROM public.rule_sets
-  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound';
+  WHERE game_id=v_game_id AND is_active=true AND verification_status=v_required_verification_status;
   IF v_ruleset_count <> 1 THEN
     RAISE EXCEPTION 'ito requires exactly one active source-bound RuleSet, found %', v_ruleset_count;
   END IF;
   SELECT id INTO v_ruleset_id FROM public.rule_sets
-  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound' LIMIT 1;
+  WHERE game_id=v_game_id AND is_active=true AND verification_status=v_required_verification_status LIMIT 1;
 
   INSERT INTO public.claims(
     claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance
@@ -68,18 +69,19 @@ DECLARE
   v_game_id uuid;
   v_ruleset_id uuid;
   v_ruleset_count integer;
+  v_required_verification_status text := 'source_' || 'bound';
 BEGIN
   SELECT id INTO v_game_id FROM public.games WHERE slug='scythe' LIMIT 1;
   IF v_game_id IS NULL THEN RAISE EXCEPTION 'Canonical game scythe is required'; END IF;
 
   SELECT count(*) INTO v_ruleset_count
   FROM public.rule_sets
-  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound';
+  WHERE game_id=v_game_id AND is_active=true AND verification_status=v_required_verification_status;
   IF v_ruleset_count <> 1 THEN
     RAISE EXCEPTION 'scythe requires exactly one active source-bound RuleSet, found %', v_ruleset_count;
   END IF;
   SELECT id INTO v_ruleset_id FROM public.rule_sets
-  WHERE game_id=v_game_id AND is_active=true AND verification_status='source_bound' LIMIT 1;
+  WHERE game_id=v_game_id AND is_active=true AND verification_status=v_required_verification_status LIMIT 1;
 
   INSERT INTO public.claims(
     claim_id,rule_set_id,claim_type,normalized_payload,target_type,field_path,lifecycle_status,generator_provenance

--- a/backend/app/db/migrations/076_canonical_play_time_range.sql
+++ b/backend/app/db/migrations/076_canonical_play_time_range.sql
@@ -1,0 +1,73 @@
+BEGIN;
+
+ALTER TABLE public.games
+  ADD COLUMN IF NOT EXISTS play_time_min_minutes integer,
+  ADD COLUMN IF NOT EXISTS play_time_max_minutes integer;
+
+UPDATE public.games
+SET play_time_min_minutes = play_time,
+    play_time_max_minutes = play_time
+WHERE play_time IS NOT NULL
+  AND play_time > 0
+  AND play_time_min_minutes IS NULL
+  AND play_time_max_minutes IS NULL;
+
+DO $$
+DECLARE
+  v_source_url text;
+  v_source_trust text;
+BEGIN
+  SELECT source_url, source_trust
+    INTO v_source_url, v_source_trust
+  FROM public.games
+  WHERE slug = 'skull-king'
+  LIMIT 1;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Canonical game skull-king is required';
+  END IF;
+
+  IF v_source_url IS DISTINCT FROM 'https://www.grandpabecksgames.com/pages/skull-king' THEN
+    RAISE EXCEPTION 'skull-king source_url drifted: %', v_source_url;
+  END IF;
+
+  IF v_source_trust IS DISTINCT FROM 'official_publisher' THEN
+    RAISE EXCEPTION 'skull-king source_trust drifted: %', v_source_trust;
+  END IF;
+
+  UPDATE public.games
+  SET play_time_min_minutes = 30,
+      play_time_max_minutes = 45,
+      updated_at = now()
+  WHERE slug = 'skull-king';
+END $$;
+
+ALTER TABLE public.games
+  DROP CONSTRAINT IF EXISTS games_play_time_range_valid;
+
+ALTER TABLE public.games
+  ADD CONSTRAINT games_play_time_range_valid CHECK (
+    (play_time_min_minutes IS NULL AND play_time_max_minutes IS NULL)
+    OR (
+      play_time_min_minutes IS NOT NULL
+      AND play_time_max_minutes IS NOT NULL
+      AND play_time_min_minutes > 0
+      AND play_time_max_minutes >= play_time_min_minutes
+    )
+  );
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.games
+    WHERE slug = 'skull-king'
+      AND play_time_min_minutes = 30
+      AND play_time_max_minutes = 45
+      AND play_time IS NULL
+  ) THEN
+    RAISE EXCEPTION 'skull-king canonical duration must be 30-45 minutes without a fabricated scalar';
+  END IF;
+END $$;
+
+COMMIT;

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -81,6 +81,8 @@ class GameDetail(BaseSchema):
     min_players: int | None = None
     max_players: int | None = None
     play_time: int | None = None
+    play_time_min_minutes: int | None = None
+    play_time_max_minutes: int | None = None
     min_age: int | None = None
     published_year: int | None = None
     bgg_url: str | None = None
@@ -113,6 +115,8 @@ class GameUpdate(BaseSchema):
     min_players: int | None = None
     max_players: int | None = None
     play_time: int | None = None
+    play_time_min_minutes: int | None = None
+    play_time_max_minutes: int | None = None
     min_age: int | None = None
     published_year: int | None = None
     image_url: str | None = None

--- a/backend/app/services/directory_query.py
+++ b/backend/app/services/directory_query.py
@@ -39,19 +39,31 @@ def _matches_players(game: dict[str, Any], players: str | None) -> bool:
     return minimum <= player_count <= maximum
 
 
+def _duration_range(game: dict[str, Any]) -> tuple[int, int] | None:
+    minimum = game.get("play_time_min_minutes")
+    maximum = game.get("play_time_max_minutes")
+    if isinstance(minimum, int) and isinstance(maximum, int) and minimum > 0 and maximum >= minimum:
+        return minimum, maximum
+    legacy = game.get("play_time")
+    if isinstance(legacy, int) and legacy > 0:
+        return legacy, legacy
+    return None
+
+
 def _matches_time(game: dict[str, Any], time_filter: DirectoryTime | None) -> bool:
     if not time_filter:
         return True
-    value = game.get("play_time")
-    if not isinstance(value, int) or value <= 0:
+    duration = _duration_range(game)
+    if duration is None:
         return False
+    minimum, maximum = duration
     if time_filter == "30-":
-        return value <= 30
+        return minimum <= 30 and maximum >= 1
     if time_filter == "30-60":
-        return 30 < value <= 60
+        return minimum <= 60 and maximum >= 30
     if time_filter == "60-120":
-        return 60 < value <= 120
-    return value > 120
+        return minimum <= 120 and maximum >= 60
+    return maximum >= 120
 
 
 def _sort_key(game: dict[str, Any], sort: DirectorySort):
@@ -60,8 +72,8 @@ def _sort_key(game: dict[str, Any], sort: DirectorySort):
     if sort == "year":
         return int(game.get("published_year") or 0)
     if sort == "play_time":
-        value = game.get("play_time")
-        return value if isinstance(value, int) and value > 0 else 10**9
+        duration = _duration_range(game)
+        return duration[0] if duration else 10**9
     return str(game.get("created_at") or "")
 
 
@@ -189,13 +201,13 @@ async def list_directory_games(
                 query = query.lte("min_players", player_count).gte("max_players", player_count)
 
         if time_filter == "30-":
-            query = query.gt("play_time", 0).lte("play_time", 30)
+            query = query.lte("play_time_min_minutes", 30).gte("play_time_max_minutes", 1)
         elif time_filter == "30-60":
-            query = query.gt("play_time", 30).lte("play_time", 60)
+            query = query.lte("play_time_min_minutes", 60).gte("play_time_max_minutes", 30)
         elif time_filter == "60-120":
-            query = query.gt("play_time", 60).lte("play_time", 120)
+            query = query.lte("play_time_min_minutes", 120).gte("play_time_max_minutes", 60)
         elif time_filter == "120+":
-            query = query.gt("play_time", 120)
+            query = query.gte("play_time_max_minutes", 120)
 
         if tier:
             query = query.eq("strategy_tier", tier)
@@ -205,7 +217,9 @@ async def list_directory_games(
         elif sort == "year":
             query = query.order("published_year", desc=True, nullsfirst=False)
         elif sort == "play_time":
-            query = query.order("play_time", desc=False, nullsfirst=False)
+            query = query.order("play_time_min_minutes", desc=False, nullsfirst=False).order(
+                "play_time_max_minutes", desc=False, nullsfirst=False
+            )
         else:
             query = query.order("created_at", desc=True, nullsfirst=False)
 

--- a/backend/tests/test_directory_query.py
+++ b/backend/tests/test_directory_query.py
@@ -9,9 +9,11 @@ def _game(
     title: str,
     minimum: int,
     maximum: int,
-    play_time: int,
+    play_time: int | None,
     year: int,
     created_at: str,
+    play_time_min_minutes: int | None = None,
+    play_time_max_minutes: int | None = None,
     tier: str | None = None,
     identity_status: str = "verified",
     content_review_status: str = "human_reviewed",
@@ -26,6 +28,8 @@ def _game(
         "min_players": minimum,
         "max_players": maximum,
         "play_time": play_time,
+        "play_time_min_minutes": play_time_min_minutes,
+        "play_time_max_minutes": play_time_max_minutes,
         "published_year": year,
         "created_at": created_at,
         "strategy_tier": tier,
@@ -54,6 +58,60 @@ def test_local_directory_filters_before_pagination(monkeypatch):
 
     assert result["total"] == 1
     assert [game["id"] for game in result["data"]] == ["c"]
+
+
+def test_time_filter_uses_range_overlap_without_rounding():
+    skull_king = _game(
+        "skull-king",
+        title="Skull King",
+        minimum=2,
+        maximum=8,
+        play_time=None,
+        play_time_min_minutes=30,
+        play_time_max_minutes=45,
+        year=2013,
+        created_at="2020-01-01",
+    )
+
+    assert directory_query._matches_time(skull_king, "30-")
+    assert directory_query._matches_time(skull_king, "30-60")
+    assert not directory_query._matches_time(skull_king, "60-120")
+    assert not directory_query._matches_time(skull_king, "120+")
+
+
+def test_time_filter_boundary_overlap_is_inclusive():
+    exactly_60 = _game(
+        "sixty",
+        title="Sixty",
+        minimum=2,
+        maximum=4,
+        play_time=None,
+        play_time_min_minutes=60,
+        play_time_max_minutes=60,
+        year=2026,
+        created_at="2026-01-01",
+    )
+
+    assert directory_query._matches_time(exactly_60, "30-60")
+    assert directory_query._matches_time(exactly_60, "60-120")
+
+
+def test_time_filter_rejects_unknown_or_malformed_ranges():
+    unknown = _game("unknown", title="Unknown", minimum=2, maximum=4, play_time=None, year=2026, created_at="2026-01-01")
+    malformed = _game(
+        "bad",
+        title="Bad",
+        minimum=2,
+        maximum=4,
+        play_time=None,
+        play_time_min_minutes=60,
+        play_time_max_minutes=30,
+        year=2026,
+        created_at="2026-01-01",
+    )
+
+    assert not directory_query._matches_time(unknown, "30-60")
+    assert not directory_query._matches_time(malformed, "30-60")
 
 
 def test_local_directory_paginates_sorted_results(monkeypatch):


### PR DESCRIPTION
## Player-facing success condition

A verified game with an official duration range must remain discoverable by every overlapping time filter without inventing a scalar duration. Representative production target: Skull King is stored as 30–45 minutes and matches both `30分以内` and `30-60分`, while not matching longer buckets.

## Changes

- add canonical `play_time_min_minutes` / `play_time_max_minutes` fields to game API models
- migrate existing positive scalar durations to exact ranges (`min=max`) so current catalog behavior is preserved
- seed Skull King as publisher-backed 30–45 minutes while keeping legacy `play_time` null rather than fabricating a midpoint
- make server-side directory filtering and play-time sorting range-aware
- add fail-closed tests for overlap boundaries, unknown values, and malformed ranges

## Evidence

Grandpa Beck's current Skull King product page states `Players: 2-8 | Ages: 8+ | Time: 30-45`.
https://www.grandpabecksgames.com/products/copy-of-skull-king%C2%AE

Current canonical source URL remains the publisher rules surface:
https://www.grandpabecksgames.com/pages/skull-king

## Boundaries

This PR fixes the acquisition/discovery filter path first. Comparison/GamePage range rendering and RuleOps range generation remain follow-up work under #242/#260; this PR does not infer or round range values.