### PR TITLE
fix: remove duplicate analytics integration

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.86.2",
-        "@vercel/analytics": "^2.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^2.0.5",
@@ -1972,48 +1971,6 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
-      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "nuxt": ">= 3",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "nuxt": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitejs/plugin-react-swc": {
       "version": "4.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.86.2",
-    "@vercel/analytics": "^2.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^2.0.5",

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,7 +2,6 @@ import { StrictMode, Suspense, lazy } from 'react'
 import { createRoot } from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
-import { inject } from '@vercel/analytics'
 import App from './App.jsx'
 import './index.css'
 import './layout.css'
@@ -21,7 +20,6 @@ import LoadingFallback from './components/LoadingFallback.jsx'
 import { installMobileFilterFocus } from './lib/mobileFilterFocus.js'
 
 installMobileFilterFocus()
-inject()
 
 const router = createBrowserRouter([
   {


### PR DESCRIPTION
Production already has the existing privacy-safe Vercel Web Analytics integration in frontend/index.html. Remove the second @vercel/analytics/inject path added by #481 so analytics has one canonical integration. Existing Web Analytics script and exporter remain unchanged.