### PR TITLE
growth: measure affiliate outbound conversion intent

### DIFF
--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -11,11 +11,34 @@ const isValidUrl = (url) => {
   }
 }
 
+const hasAmazonAffiliateTag = (url) => {
+  if (!isValidUrl(url)) return false
+
+  try {
+    const parsed = new URL(url)
+    return parsed.hostname.toLowerCase().includes('amazon.') && Boolean(parsed.searchParams.get('tag'))
+  } catch {
+    return false
+  }
+}
+
 const sourceLabel = (sourceTrust) => {
   if (sourceTrust === 'official_publisher') return '出版社のページ'
   if (sourceTrust === 'authorized_partner') return '認定パートナーのページ'
   if (sourceTrust === 'third_party') return '第三者の出典'
   return '登録済み出典（未検証）'
+}
+
+const trackAffiliateOutbound = (gameSlug, provider) => {
+  if (typeof window === 'undefined' || typeof window.va !== 'function') return
+
+  window.va('event', {
+    name: 'Affiliate Outbound',
+    data: {
+      gameSlug,
+      provider,
+    },
+  })
 }
 
 export const ExternalLinks = ({ game }) => {
@@ -28,7 +51,12 @@ export const ExternalLinks = ({ game }) => {
     ? { url: source_url, label: sourceLabel(source_trust), class: 'source', sponsored: false }
     : null
   const links = [
-    { url: amazon, label: 'Amazon', class: 'amazon', sponsored: Boolean(affiliateAmazon) },
+    {
+      url: amazon,
+      label: 'Amazon',
+      class: 'amazon',
+      sponsored: Boolean(affiliateAmazon) || hasAmazonAffiliateTag(amazon_url),
+    },
     { url: rakuten, label: '楽天で見る', class: 'rakuten', sponsored: true },
     { url: yahoo, label: 'Yahoo!で見る', class: 'yahoo', sponsored: true },
     { url: bgg_url, label: 'BoardGameGeek', class: 'bgg', sponsored: false },
@@ -66,6 +94,7 @@ export const ExternalLinks = ({ game }) => {
                 target="_blank"
                 rel={link.sponsored ? 'noopener noreferrer sponsored' : 'noopener noreferrer'}
                 className={`link-button ${link.class}`}
+                onClick={link.sponsored ? () => trackAffiliateOutbound(game.slug, link.class) : undefined}
               >
                 {link.label}
               </a>

--- a/frontend/tests/affiliate-analytics.spec.js
+++ b/frontend/tests/affiliate-analytics.spec.js
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test'
+
+const affiliateGame = {
+  id: 9001,
+  slug: 'affiliate-fixture',
+  title: 'Affiliate Fixture',
+  title_ja: 'アフィリエイト検証ゲーム',
+  summary: '収益リンク計測の検証用ゲーム。',
+  rules_content: '# Rules',
+  structured_data: {},
+  identity_status: 'verified',
+  source_trust: 'official_publisher',
+  content_review_status: 'human_reviewed',
+  source_url: 'https://publisher.example/game',
+  affiliate_urls: {
+    amazon: 'https://www.amazon.co.jp/dp/example?tag=bodogemikata-22',
+    rakuten: 'https://example.rakuten.co.jp/item/game',
+  },
+}
+
+async function mockGame(page, game = affiliateGame) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${game.slug}`) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ game }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('affiliate click emits one aggregate-safe Web Analytics event and keeps sponsored relation', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__analyticsCalls = []
+    window.va = (...args) => window.__analyticsCalls.push(args)
+  })
+  await mockGame(page)
+  await page.goto('/games/affiliate-fixture')
+
+  const amazon = page.getByRole('link', { name: 'Amazon', exact: true })
+  await expect(amazon).toHaveAttribute('rel', 'noopener noreferrer sponsored')
+  await amazon.evaluate(element => element.addEventListener('click', event => event.preventDefault(), { once: true }))
+  await amazon.click()
+
+  expect(await page.evaluate(() => window.__analyticsCalls)).toEqual([
+    [
+      'event',
+      {
+        name: 'Affiliate Outbound',
+        data: { gameSlug: 'affiliate-fixture', provider: 'amazon' },
+      },
+    ],
+  ])
+})
+
+test('legacy Amazon URL with an Associates tag is treated as sponsored and measured', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__analyticsCalls = []
+    window.va = (...args) => window.__analyticsCalls.push(args)
+  })
+  const legacyTaggedAmazon = {
+    ...affiliateGame,
+    slug: 'legacy-amazon-fixture',
+    affiliate_urls: null,
+    amazon_url: 'https://www.amazon.co.jp/s?k=game&tag=bodogemikata-22',
+  }
+  await mockGame(page, legacyTaggedAmazon)
+  await page.goto('/games/legacy-amazon-fixture')
+
+  const amazon = page.getByRole('link', { name: 'Amazon', exact: true })
+  await expect(amazon).toHaveAttribute('rel', 'noopener noreferrer sponsored')
+  await amazon.evaluate(element => element.addEventListener('click', event => event.preventDefault(), { once: true }))
+  await amazon.click()
+
+  expect(await page.evaluate(() => window.__analyticsCalls)).toEqual([
+    [
+      'event',
+      {
+        name: 'Affiliate Outbound',
+        data: { gameSlug: 'legacy-amazon-fixture', provider: 'amazon' },
+      },
+    ],
+  ])
+})
+
+test('non-monetized outbound links do not emit affiliate events', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__analyticsCalls = []
+    window.va = (...args) => window.__analyticsCalls.push(args)
+  })
+  const communityOnly = {
+    ...affiliateGame,
+    slug: 'community-fixture',
+    affiliate_urls: null,
+    amazon_url: null,
+    bgg_url: 'https://boardgamegeek.com/boardgame/1/example',
+  }
+  await mockGame(page, communityOnly)
+  await page.goto('/games/community-fixture')
+
+  const bgg = page.getByRole('link', { name: 'BoardGameGeek', exact: true })
+  await expect(bgg).toHaveAttribute('rel', 'noopener noreferrer')
+  await bgg.evaluate(element => element.addEventListener('click', event => event.preventDefault(), { once: true }))
+  await bgg.click()
+
+  expect(await page.evaluate(() => window.__analyticsCalls)).toEqual([])
+})


### PR DESCRIPTION
Advances #208.

Observable player-facing success condition: clicking a monetized GamePage outbound link keeps the destination behavior intact, remains marked `rel=sponsored`, and emits exactly one Vercel Web Analytics custom event containing only the game slug and provider so affiliate intent can be aggregated without storing user identity or free-text search data.

Changes:
- emit `Affiliate Outbound` through the already-canonical `window.va` Web Analytics path for sponsored Amazon/Rakuten/Yahoo links only;
- keep non-monetized BGG/BGA/source links outside this revenue event;
- treat legacy Amazon URLs containing an Associates `tag` parameter as sponsored instead of silently exposing them as ordinary links;
- add Playwright coverage for affiliate, legacy tagged-Amazon, and non-monetized link behavior.

Primary source: Vercel Web Analytics custom events / aggregate API documentation. No second analytics SDK, custom database, or user identifier is added.

Production verification after merge: exact deployed SHA, rendered `rel=sponsored` on a real tagged Amazon game, no new runtime errors, then subsequent real traffic can be read from the Vercel custom-event aggregate endpoint.