### PR TITLE
fix: preserve play-time ranges in SSR SEO output

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -63,6 +63,26 @@ def _player_count_projection(game: dict) -> tuple[dict[str, object] | None, str]
     return quantitative_value, label
 
 
+def _play_time_projection(game: dict) -> tuple[str | None, str]:
+    min_minutes = game.get("play_time_min_minutes")
+    max_minutes = game.get("play_time_max_minutes")
+    legacy_minutes = game.get("play_time")
+
+    if min_minutes is None and max_minutes is None and legacy_minutes is not None:
+        min_minutes = legacy_minutes
+        max_minutes = legacy_minutes
+
+    if min_minutes is not None and max_minutes is not None:
+        if min_minutes == max_minutes:
+            return f"PT{min_minutes}M", f"{min_minutes}分"
+        return None, f"{min_minutes}-{max_minutes}分"
+    if min_minutes is not None:
+        return None, f"{min_minutes}分以上"
+    if max_minutes is not None:
+        return None, f"最大{max_minutes}分"
+    return None, ""
+
+
 def _render_projection_rules(projection) -> str | None:
     sections = (
         ("セットアップ", projection.setup),
@@ -141,8 +161,9 @@ async def generate_seo_html(slug: str) -> str | None:
             "@type": "PeopleAudience",
             "suggestedMinAge": game.get("min_age"),
         }
-    if game.get("play_time"):
-        structured_data["timeRequired"] = f"PT{game.get('play_time')}M"
+    time_required, play_time_label = _play_time_projection(game)
+    if time_required:
+        structured_data["timeRequired"] = time_required
 
     breadcrumb_data = {
         "@context": "https://schema.org",
@@ -230,8 +251,8 @@ async def generate_seo_html(slug: str) -> str | None:
     if player_count_label:
         players_info = f"<p><strong>プレイ人数:</strong> {html.escape(player_count_label)}</p>"
     time_info = ""
-    if game.get("play_time"):
-        time_info = f"<p><strong>プレイ時間:</strong> {html.escape(str(game.get('play_time')))}分</p>"
+    if play_time_label:
+        time_info = f"<p><strong>プレイ時間:</strong> {html.escape(play_time_label)}</p>"
 
     ssr_content = f"""<div id="root">
   <article itemscope itemtype="https://schema.org/Game" data-ssr-game="true">

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -24,6 +24,31 @@ def test_open_ended_player_count_does_not_invent_maximum() -> None:
     assert label == "3人以上"
 
 
+def test_play_time_range_is_preserved_without_inventing_schema_duration() -> None:
+    duration, label = seo_renderer._play_time_projection(
+        {"play_time_min_minutes": 90, "play_time_max_minutes": 120, "play_time": None}
+    )
+
+    assert duration is None
+    assert label == "90-120分"
+
+
+def test_exact_play_time_keeps_schema_duration() -> None:
+    duration, label = seo_renderer._play_time_projection(
+        {"play_time_min_minutes": 30, "play_time_max_minutes": 30, "play_time": None}
+    )
+
+    assert duration == "PT30M"
+    assert label == "30分"
+
+
+def test_legacy_play_time_remains_supported_as_exact_value() -> None:
+    duration, label = seo_renderer._play_time_projection({"play_time": 45})
+
+    assert duration == "PT45M"
+    assert label == "45分"
+
+
 @pytest.mark.asyncio
 async def test_missing_game_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
     async def missing(_slug: str):
@@ -48,7 +73,9 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
             "rules_content": '</pre><script>alert("rules")</script>',
             "min_players": 2,
             "max_players": 4,
-            "play_time": 30,
+            "play_time": None,
+            "play_time_min_minutes": 90,
+            "play_time_max_minutes": 120,
             "image_url": "/images/game.webp",
         }
 
@@ -95,6 +122,8 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert '<nav aria-label="パンくずリスト">' in rendered
     assert '<a href="/">ゲーム一覧</a>' in rendered
     assert 'aria-current="page"' in rendered
+    assert '<strong>プレイ時間:</strong> 90-120分' in rendered
+    assert '"timeRequired"' not in rendered
     assert '<script>alert("title")</script>' not in rendered
     assert '<script>alert("rules")</script>' not in rendered
     assert '<img src=x onerror=alert("summary")>' not in rendered


### PR DESCRIPTION
Player-facing success condition: raw production HTML for `/games/hack-clad` shows the canonical `90-120分` play-time range in the SSR basic-information section, while JSON-LD does not invent a single `timeRequired` duration for a range.

Changes:
- project canonical `play_time_min_minutes` / `play_time_max_minutes` into SSR
- retain legacy scalar `play_time` only as an exact fallback
- emit Schema.org `timeRequired` only when the duration is exact
- cover range, exact, legacy, and rendered SSR behavior in backend tests

Why: current main only reads scalar `play_time`, so source-backed ranges disappear from raw HTML. Schema.org currently defines `timeRequired` as a single `Duration`, so collapsing a range to one endpoint would lose source meaning.

Related: #242, #388