### PR TITLE
fix: supersede inactive UNO ruleset consistently

### DIFF
--- a/backend/app/db/migrations/071_source_bound_uno_b7696_ja.sql
+++ b/backend/app/db/migrations/071_source_bound_uno_b7696_ja.sql
@@ -53,7 +53,7 @@ BEGIN
   WHERE id=v_game_id;
 
   UPDATE public.rule_sets
-  SET is_active=false,updated_at=now()
+  SET is_active=false,status='superseded',updated_at=now()
   WHERE game_id=v_game_id AND is_active=true
     AND NOT (COALESCE(edition_label,'')='ウノ B7696（日本語版・シャッフルワイルド）'
       AND COALESCE(revision_label,'')='B7696-ZZ70-G2_JJ2-2017');


### PR DESCRIPTION
Follow-up to #489. Production application of migration 071 rolled back because `rule_sets_status_activity_check` requires inactive superseded RuleSets to have `status='superseded'`; setting only `is_active=false` violates the database contract.

This changes no player-facing rule content. It repairs the migration before any production application so the existing #42003 RuleSet becomes historical/superseded and the B7696 Japanese RuleSet can become the sole active source-bound projection.