### PR TITLE
fix: clear unbound Heart of Crown player count

### DIFF
--- a/backend/app/db/migrations/078_clear_unbound_heart_of_crown_players.sql
+++ b/backend/app/db/migrations/078_clear_unbound_heart_of_crown_players.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+-- The physical Second Edition identity is verified, but the current first-party
+-- physical rules/product material available to this pipeline has not yet bound
+-- the player-count claim. Fail closed rather than retaining a legacy value.
+UPDATE public.games
+SET
+  min_players = NULL,
+  max_players = NULL,
+  updated_at = now()
+WHERE slug = 'heart-of-crown-2nd-edition';
+
+COMMIT;


### PR DESCRIPTION
Follow-up to #491.

The canonical physical Second Edition identity is verified, but the remaining 2–4 player count still lacks an exact first-party physical Second Edition binding in the current evidence path. Clear it rather than allowing a legacy value to survive the fail-closed correction.

Player-facing success condition remains: no edition-sensitive metadata is shown as settled fact without exact source binding.