### PR TITLE
seo: gate indexability on reviewed canonical games

### DIFF
--- a/backend/app/services/search_visibility.py
+++ b/backend/app/services/search_visibility.py
@@ -35,5 +35,30 @@ def should_return_gone(slug: str) -> bool:
     return slug in GONE_GAME_SLUGS
 
 
-def should_hide_game_from_search(slug: str) -> bool:
-    return has_known_identity_conflict(slug)
+def game_indexability(game: dict) -> tuple[bool, tuple[str, ...]]:
+    """Return one fail-closed indexability decision shared by SSR and sitemap.
+
+    A catalog row is not search-release-ready merely because it exists. Keep
+    review-required, AI-draft, unknown-review and unverified identities publicly
+    readable when appropriate, but out of search indexing until reviewed.
+    """
+    reasons: list[str] = []
+    slug = str(game.get("slug") or "").strip()
+    if not slug:
+        reasons.append("missing_slug")
+    elif has_known_identity_conflict(slug):
+        reasons.append("identity_conflict")
+
+    if game.get("identity_status") != "verified":
+        reasons.append("identity_not_verified")
+    if game.get("content_review_status") != "human_reviewed":
+        reasons.append("content_not_human_reviewed")
+
+    return not reasons, tuple(reasons)
+
+
+def should_hide_game_from_search(game_or_slug: dict | str) -> bool:
+    if isinstance(game_or_slug, dict):
+        indexable, _ = game_indexability(game_or_slug)
+        return not indexable
+    return has_known_identity_conflict(game_or_slug)

--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -143,7 +143,7 @@ async def generate_seo_html(slug: str) -> str | None:
     game_url = f"{BASE_URL}/games/{slug}"
     page_title = _page_title(game, title)
     seo_description = description or f"「{title}」の登録済みルール要約と出典情報を確認できます。"
-    hide_from_search = should_hide_game_from_search(slug)
+    hide_from_search = should_hide_game_from_search(game)
 
     structured_data: dict[str, object] = {
         "@context": "https://schema.org",

--- a/backend/app/services/sitemap.py
+++ b/backend/app/services/sitemap.py
@@ -2,7 +2,7 @@ import os
 import xml.etree.ElementTree as ET
 from datetime import datetime
 
-from app.core.supabase import list_for_sitemap
+from app.core.supabase import list_recent
 from app.services.search_visibility import should_hide_game_from_search
 
 NS_SITEMAP = "http://www.sitemaps.org/schemas/sitemap/0.9"
@@ -14,7 +14,7 @@ STATIC_LASTMOD = "2025-12-20"
 
 async def get_sitemap_xml() -> str:
     base_url = os.getenv("NEXT_PUBLIC_BASE_URL", "https://bodoge-no-mikata.vercel.app")
-    games = await list_for_sitemap()
+    games = (await list_recent(limit=50000))["data"]
     root = ET.Element(f"{{{NS_SITEMAP}}}urlset")
     static_pages = [
         {"loc": "/", "priority": "1.0", "changefreq": "daily"},
@@ -33,7 +33,7 @@ async def get_sitemap_xml() -> str:
 
     for game in games:
         slug = str(game.get("slug") or "").strip()
-        if not slug or should_hide_game_from_search(slug):
+        if not slug or should_hide_game_from_search(game):
             continue
 
         url_elem = ET.SubElement(root, f"{{{NS_SITEMAP}}}url")

--- a/backend/tests/test_sitemap.py
+++ b/backend/tests/test_sitemap.py
@@ -9,19 +9,28 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from app.services import sitemap  # noqa: E402
 
 
+def reviewed_game(slug: str, title: str, **overrides):
+    game = {
+        "slug": slug,
+        "title": title,
+        "updated_at": "2026-08-06T12:34:56Z",
+        "image_url": None,
+        "identity_status": "verified",
+        "content_review_status": "human_reviewed",
+    }
+    game.update(overrides)
+    return game
+
+
 @pytest.mark.asyncio
 async def test_image_entries_are_nested_under_their_game_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_list_for_sitemap() -> list[dict[str, str]]:
-        return [
-            {
-                "slug": "catan",
-                "title": "カタン",
-                "updated_at": "2026-08-06T12:34:56Z",
-                "image_url": "/assets/games/catan.webp",
-            }
-        ]
+    async def fake_list_recent(limit: int = 100, offset: int = 0):
+        return {
+            "data": [reviewed_game("catan", "カタン", image_url="/assets/games/catan.webp")],
+            "total": 1,
+        }
 
-    monkeypatch.setattr(sitemap, "list_for_sitemap", fake_list_for_sitemap)
+    monkeypatch.setattr(sitemap, "list_recent", fake_list_recent)
     monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
 
     xml_text = await sitemap.get_sitemap_xml()
@@ -47,14 +56,17 @@ async def test_image_entries_are_nested_under_their_game_url(monkeypatch: pytest
 
 @pytest.mark.asyncio
 async def test_invalid_game_slugs_are_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_list_for_sitemap() -> list[dict[str, str | None]]:
-        return [
-            {"slug": "valid-game", "title": "Valid", "updated_at": None, "image_url": None},
-            {"slug": None, "title": "Legacy null", "updated_at": None, "image_url": None},
-            {"slug": "  ", "title": "Legacy blank", "updated_at": None, "image_url": None},
-        ]
+    async def fake_list_recent(limit: int = 100, offset: int = 0):
+        return {
+            "data": [
+                reviewed_game("valid-game", "Valid", updated_at=None),
+                reviewed_game(None, "Legacy null", updated_at=None),
+                reviewed_game("  ", "Legacy blank", updated_at=None),
+            ],
+            "total": 3,
+        }
 
-    monkeypatch.setattr(sitemap, "list_for_sitemap", fake_list_for_sitemap)
+    monkeypatch.setattr(sitemap, "list_recent", fake_list_recent)
     monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
 
     xml_text = await sitemap.get_sitemap_xml()
@@ -66,14 +78,17 @@ async def test_invalid_game_slugs_are_not_emitted(monkeypatch: pytest.MonkeyPatc
 
 @pytest.mark.asyncio
 async def test_retired_mixed_game_record_is_not_emitted(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def fake_list_for_sitemap() -> list[dict[str, str | None]]:
-        return [
-            {"slug": "game", "title": "Mixed", "updated_at": None, "image_url": None},
-            {"slug": "hack-clad", "title": "HacKClaD", "updated_at": None, "image_url": None},
-            {"slug": "raise-your-goblets", "title": "Raise Your Goblets", "updated_at": None, "image_url": None},
-        ]
+    async def fake_list_recent(limit: int = 100, offset: int = 0):
+        return {
+            "data": [
+                reviewed_game("game", "Mixed"),
+                reviewed_game("hack-clad", "HacKClaD"),
+                reviewed_game("raise-your-goblets", "Raise Your Goblets"),
+            ],
+            "total": 3,
+        }
 
-    monkeypatch.setattr(sitemap, "list_for_sitemap", fake_list_for_sitemap)
+    monkeypatch.setattr(sitemap, "list_recent", fake_list_recent)
     monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
 
     xml_text = await sitemap.get_sitemap_xml()
@@ -81,3 +96,27 @@ async def test_retired_mixed_game_record_is_not_emitted(monkeypatch: pytest.Monk
     assert "https://example.test/games/game" not in xml_text
     assert "https://example.test/games/hack-clad" in xml_text
     assert "https://example.test/games/raise-your-goblets" in xml_text
+
+
+@pytest.mark.asyncio
+async def test_review_required_game_is_excluded_but_reviewed_game_remains(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_list_recent(limit: int = 100, offset: int = 0):
+        return {
+            "data": [
+                reviewed_game(
+                    "heart-of-crown-2nd-edition",
+                    "ハートオブクラウン 第二版",
+                    content_review_status="review_required",
+                ),
+                reviewed_game("uno", "ウノ"),
+            ],
+            "total": 2,
+        }
+
+    monkeypatch.setattr(sitemap, "list_recent", fake_list_recent)
+    monkeypatch.setenv("NEXT_PUBLIC_BASE_URL", "https://example.test")
+
+    xml_text = await sitemap.get_sitemap_xml()
+
+    assert "https://example.test/games/heart-of-crown-2nd-edition" not in xml_text
+    assert "https://example.test/games/uno" in xml_text


### PR DESCRIPTION
Closes part of #201.

Player-facing success condition:
- `heart-of-crown-2nd-edition` remains HTTP 200 but renders `noindex, follow` and is excluded from `/sitemap.xml` while it is `review_required`.
- reviewed canonical games such as `hack-clad` / `uno` remain indexable and sitemap-listed.

Changes:
- centralize indexability on canonical identity + `human_reviewed` content state
- make SSR robots meta use the game record rather than slug-only conflict checks
- make sitemap use the same decision instead of listing every non-conflicted DB row
- reuse `list_recent` so sitemap has the review/identity fields without adding another query contract

No rule content or edition identity is changed.