### PR TITLE
perf: batch presentation evidence reads

### DIFF
--- a/backend/app/services/presentation_projection.py
+++ b/backend/app/services/presentation_projection.py
@@ -246,16 +246,29 @@ class PresentationProjectionService:
             .execute()
             .data
         )
+        if not claims:
+            return {}
+
+        claim_ids = [claim["claim_id"] for claim in claims]
+        binding_rows = (
+            client.table("evidence_bindings")
+            .select("claim_id,source_id,relation")
+            .in_("claim_id", claim_ids)
+            .execute()
+            .data
+        )
+        bindings_by_claim: dict[str, list[dict]] = defaultdict(list)
+        for binding in binding_rows:
+            claim_id = binding.get("claim_id")
+            if claim_id:
+                bindings_by_claim[str(claim_id)].append(binding)
+
         eligible: dict[str, list[dict]] = defaultdict(list)
         for claim in claims:
-            bindings = (
-                client.table("evidence_bindings")
-                .select("source_id,relation")
-                .eq("claim_id", claim["claim_id"])
-                .execute()
-                .data
+            evidence = accepted_supported_claim(
+                claim,
+                bindings_by_claim.get(str(claim["claim_id"]), []),
             )
-            evidence = accepted_supported_claim(claim, bindings)
             rule_id = claim.get("rule_id")
             if evidence is not None and rule_id:
                 eligible[rule_id].append(evidence)

--- a/backend/tests/test_presentation_projection_batching.py
+++ b/backend/tests/test_presentation_projection_batching.py
@@ -1,0 +1,71 @@
+from app.services.presentation_projection import PresentationProjectionService
+
+
+class Result:
+    def __init__(self, data):
+        self.data = data
+
+
+class Query:
+    def __init__(self, client, table):
+        self.client = client
+        self.table = table
+
+    def select(self, *_args, **_kwargs):
+        return self
+
+    def eq(self, *_args, **_kwargs):
+        return self
+
+    def order(self, *_args, **_kwargs):
+        return self
+
+    def in_(self, column, values):
+        assert self.table == "evidence_bindings"
+        assert column == "claim_id"
+        self.client.requested_claim_ids = list(values)
+        return self
+
+    def execute(self):
+        self.client.execute_counts[self.table] = self.client.execute_counts.get(self.table, 0) + 1
+        return Result(self.client.rows[self.table])
+
+
+class Client:
+    def __init__(self):
+        self.execute_counts = {}
+        self.requested_claim_ids = []
+        self.rows = {
+            "claims": [
+                {
+                    "claim_id": "claim.setup",
+                    "rule_id": "rule.setup",
+                    "normalized_payload": {"statement": "Set up the board."},
+                    "lifecycle_status": "accepted",
+                },
+                {
+                    "claim_id": "claim.end",
+                    "rule_id": "rule.end",
+                    "normalized_payload": {"statement": "End after the final round."},
+                    "lifecycle_status": "accepted",
+                },
+            ],
+            "evidence_bindings": [
+                {"claim_id": "claim.setup", "source_id": "source.rules", "relation": "supports"},
+                {"claim_id": "claim.end", "source_id": "source.rules", "relation": "supports"},
+            ],
+        }
+
+    def table(self, table):
+        return Query(self, table)
+
+
+def test_projection_batches_evidence_bindings_for_all_claims():
+    client = Client()
+
+    eligible = PresentationProjectionService._load_eligible_rule_claims(client, "ruleset-1")
+
+    assert client.execute_counts == {"claims": 1, "evidence_bindings": 1}
+    assert client.requested_claim_ids == ["claim.setup", "claim.end"]
+    assert eligible["rule.setup"][0]["source_ids"] == ["source.rules"]
+    assert eligible["rule.end"][0]["source_ids"] == ["source.rules"]


### PR DESCRIPTION
Production reliability follow-up from #493 verification.

Player-facing success condition: source-bound GamePages such as HacKClaD keep the same accepted/supporting-evidence projection while reducing evidence binding reads from one HTTP request per claim to one batched request per RuleSet, reducing transient Supabase/httpx failures that can turn the SSR route into HTTP 500.

Observed production evidence before change: `/games/hack-clad` returned one HTTP 500 during read-back; runtime logs show the failure occurred while repeatedly reading `evidence_bindings` claim-by-claim. An immediate retry returned HTTP 200 with the expected source-backed projection.

Changes:
- batch `evidence_bindings` with PostgREST `in_(claim_id, ...)`
- preserve accepted/supports/contradicts semantics unchanged
- add regression proving two claims use one evidence query

No rule facts, source identity, edition, or review status is changed.