### PR TITLE
docs: README冒頭に本番URLを固定する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,8 @@ Before changing anything:
 - inspect relevant CI, data, and production state;
 - continue existing work when it already covers the same task.
 
+If the repository has a public production site, keep its canonical production URL as a complete plain-text `https://...` URL at the very beginning of `README.md`, before headings, badges, images, or alternate deployment URLs.
+
 Use existing repository commands and structures before adding code, configuration, dependencies, or documentation. `Taskfile.yml` is the preferred command interface when it already provides the required operation.
 
 For externally verifiable game facts:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+https://bodoge-no-mikata.vercel.app/
+
 # RuleScribe Games
 
 [![Vercel Deployment](https://github.com/KAFKA2306/rule-scribe-games/actions/workflows/deploy.yml/badge.svg)](https://github.com/KAFKA2306/rule-scribe-games/actions/workflows/deploy.yml)


### PR DESCRIPTION
README冒頭にcanonical production URLを完全な平文URLで置き、同じ逸脱を繰り返さないよう既存AGENTS.mdへ規則を統合します。

変更はREADMEと既存運用規約だけで、application runtimeやproduction dataは変更しません。