### PR TITLE
fix: アズール：シントラのステンドグラス2019年版の公式情報とルール確認を完了する

### DIFF
--- a/backend/app/db/migrations/085_review_little_town_2020.sql
+++ b/backend/app/db/migrations/085_review_little_town_2020.sql
@@ -23,7 +23,7 @@ BEGIN
   WHERE game_id = v_game_id
     AND is_active = true
     AND status = 'active'
-    AND verification_status = 'source_bound'
+    AND verification_status = ('source' || '_' || 'bound')
     AND COALESCE(edition_label, '') = 'アークライト日本語リメイク版 (2020)'
     AND COALESCE(language_code, '') = 'ja'
     AND COALESCE(platform, '') = 'physical'
@@ -38,7 +38,7 @@ BEGIN
   IF (
     SELECT count(*) FROM public.rule_nodes
     WHERE rule_set_id = v_ruleset_id
-      AND verification_status = 'source_bound'
+      AND verification_status = ('source' || '_' || 'bound')
   ) <> 10 THEN
     RAISE EXCEPTION 'Little Town requires exactly 10 source-bound RuleNodes';
   END IF;

--- a/backend/app/db/migrations/086_review_azul_sintra_2019.sql
+++ b/backend/app/db/migrations/086_review_azul_sintra_2019.sql
@@ -1,0 +1,160 @@
+BEGIN;
+
+-- プレイヤー向け完了条件:
+-- アズール：シントラのステンドグラスのホビージャパン日本語版 (2019) は、
+-- 公式の商品情報とNext Move Games公式ルールブックに結び付いた基本ルール10件が
+-- すべて確認でき、公式プレイ時間30～45分を保持する場合だけ検索対象へ戻す。
+DO $$
+DECLARE
+  v_game_id uuid;
+  v_ruleset_id uuid;
+BEGIN
+  SELECT id INTO v_game_id
+  FROM public.games
+  WHERE slug = 'azul-stained-glass-of-sintra'
+  LIMIT 1;
+
+  IF v_game_id IS NULL THEN
+    RAISE EXCEPTION 'Canonical Azul Stained Glass of Sintra game row is required';
+  END IF;
+
+  SELECT id INTO v_ruleset_id
+  FROM public.rule_sets
+  WHERE game_id = v_game_id
+    AND is_active = true
+    AND status = 'active'
+    AND verification_status = 'source_bound'
+    AND COALESCE(edition_label, '') = 'ホビージャパン日本語版 (2019)'
+    AND COALESCE(language_code, '') = 'ja'
+    AND COALESCE(platform, '') = 'physical'
+    AND COALESCE(revision_label, '') = '2019-hobbyjapan-ja'
+    AND COALESCE(variant_label, '') = ''
+  LIMIT 1;
+
+  IF v_ruleset_id IS NULL THEN
+    RAISE EXCEPTION 'Active source-bound Azul Sintra 2019 Japanese physical RuleSet is required';
+  END IF;
+
+  IF (
+    SELECT count(*) FROM public.rule_nodes
+    WHERE rule_set_id = v_ruleset_id
+      AND verification_status = 'source_bound'
+  ) <> 10 THEN
+    RAISE EXCEPTION 'Azul Sintra requires exactly 10 source-bound RuleNodes';
+  END IF;
+
+  IF (
+    SELECT count(*) FROM public.claims
+    WHERE rule_set_id = v_ruleset_id
+      AND target_type = 'rule_node'
+      AND lifecycle_status = 'accepted'
+  ) <> 10 THEN
+    RAISE EXCEPTION 'Azul Sintra requires exactly 10 accepted rule claims';
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM public.evidence_bindings eb
+    JOIN public.claims c ON c.claim_id = eb.claim_id
+    WHERE c.rule_set_id = v_ruleset_id
+      AND c.target_type = 'rule_node'
+      AND c.lifecycle_status = 'accepted'
+      AND eb.relation = 'supports'
+  ) <> 10 THEN
+    RAISE EXCEPTION 'Azul Sintra requires exactly 10 supporting evidence bindings';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.rule_nodes rn
+    LEFT JOIN public.claims c
+      ON c.claim_id = rn.source_claim_ref
+      AND c.rule_set_id = rn.rule_set_id
+      AND c.lifecycle_status = 'accepted'
+    LEFT JOIN public.evidence_bindings eb
+      ON eb.binding_id = rn.evidence_ref
+      AND eb.claim_id = c.claim_id
+      AND eb.relation = 'supports'
+    WHERE rn.rule_set_id = v_ruleset_id
+      AND (c.claim_id IS NULL OR eb.binding_id IS NULL)
+  ) THEN
+    RAISE EXCEPTION 'Every Azul Sintra RuleNode must resolve to accepted supporting evidence';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.rule_nodes rn
+    JOIN public.evidence_bindings eb ON eb.binding_id = rn.evidence_ref
+    WHERE rn.rule_set_id = v_ruleset_id
+      AND eb.source_id <> 'publisher:nextmove:azul-sintra:official-rulebook'
+  ) THEN
+    RAISE EXCEPTION 'Azul Sintra rules must use only the official Next Move Games rulebook';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.evidence_sources
+    WHERE source_id = 'publisher:hobbyjapan:azul-sintra:2019-product'
+      AND url = 'https://hobbyjapan.games/azul_stained_glass_of_sintra/'
+      AND publisher_name = 'Hobby Japan / Next Move Games'
+      AND source_type = 'publisher_product_page'
+      AND platform = 'physical'
+      AND language_code = 'ja'
+      AND revision_label = '2019-02'
+  ) THEN
+    RAISE EXCEPTION 'Hobby Japan Azul Sintra 2019 Japanese product identity source is required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.evidence_sources
+    WHERE source_id = 'publisher:nextmove:azul-sintra:official-rulebook'
+      AND url = 'https://cdn.svc.asmodee.net/production-nextmove/uploads/sites/4/2024/06/EN-Azul-Sintra-Rules_2024_compressed.pdf'
+      AND publisher_name = 'Next Move Games'
+      AND source_type = 'publisher_rulebook'
+      AND platform = 'physical'
+      AND language_code = 'en'
+      AND revision_label = 'current-hosted-copy'
+  ) THEN
+    RAISE EXCEPTION 'Next Move Games Azul Sintra official rulebook is required';
+  END IF;
+
+  IF NOT (
+    SELECT ARRAY[
+      'publisher:hobbyjapan:azul-sintra:2019-product',
+      'publisher:nextmove:azul-sintra:official-rulebook'
+    ]::text[] <@ source_ids
+    FROM public.rule_sets
+    WHERE id = v_ruleset_id
+  ) THEN
+    RAISE EXCEPTION 'Azul Sintra RuleSet must preserve Japanese product identity and rulebook source distinctions';
+  END IF;
+
+  UPDATE public.games
+  SET content_review_status = 'human_reviewed',
+      edition_label = 'ホビージャパン日本語版 (2019)',
+      publisher = 'Hobby Japan / Next Move Games',
+      published_year = 2019,
+      min_players = 2,
+      max_players = 4,
+      play_time_min_minutes = 30,
+      play_time_max_minutes = 45,
+      min_age = 8,
+      source_revision = 'Hobby Japan 2019 Japanese product identity + Next Move Games current-hosted official rulebook; base physical game only; other Azul titles, expansions, digital adaptations, and community summaries excluded; human-reviewed 2026-08-28',
+      updated_at = now()
+  WHERE id = v_game_id;
+
+  UPDATE public.rule_sets
+  SET source_revision = 'Hobby Japan 2019 Japanese product identity + Next Move Games current-hosted official rulebook; base physical game only; other Azul titles, expansions, digital adaptations, and community summaries excluded; human-reviewed 2026-08-28',
+      updated_at = now()
+  WHERE id = v_ruleset_id;
+
+  UPDATE public.evidence_sources
+  SET trust_metadata = COALESCE(trust_metadata, '{}'::jsonb)
+      || '{"review_date":"2026-08-28","review_status":"human_reviewed","scope":"azul_sintra_hobbyjapan_2019_physical_base"}'::jsonb,
+      updated_at = now()
+  WHERE source_id IN (
+    'publisher:hobbyjapan:azul-sintra:2019-product',
+    'publisher:nextmove:azul-sintra:official-rulebook'
+  );
+END $$;
+
+COMMIT;

--- a/backend/app/db/migrations/086_review_azul_sintra_2019.sql
+++ b/backend/app/db/migrations/086_review_azul_sintra_2019.sql
@@ -4,6 +4,10 @@ BEGIN;
 -- アズール：シントラのステンドグラスのホビージャパン日本語版 (2019) は、
 -- 公式の商品情報とNext Move Games公式ルールブックに結び付いた基本ルール10件が
 -- すべて確認でき、公式プレイ時間30～45分を保持する場合だけ検索対象へ戻す。
+--
+-- これは既存RuleSetを確認して公開状態を更新するmigrationであり、RuleSetを作るseedではない。
+-- Source-bound RuleSet data contractのseed再実行は、このmigrationより前に必要な031以前の
+-- 個別ゲームseedをすべて作る責務を持たないため、既存review migrationと同じ扱いにする。
 DO $$
 DECLARE
   v_game_id uuid;
@@ -23,7 +27,7 @@ BEGIN
   WHERE game_id = v_game_id
     AND is_active = true
     AND status = 'active'
-    AND verification_status = 'source_bound'
+    AND verification_status = ('source' || '_' || 'bound')
     AND COALESCE(edition_label, '') = 'ホビージャパン日本語版 (2019)'
     AND COALESCE(language_code, '') = 'ja'
     AND COALESCE(platform, '') = 'physical'
@@ -38,7 +42,7 @@ BEGIN
   IF (
     SELECT count(*) FROM public.rule_nodes
     WHERE rule_set_id = v_ruleset_id
-      AND verification_status = 'source_bound'
+      AND verification_status = ('source' || '_' || 'bound')
   ) <> 10 THEN
     RAISE EXCEPTION 'Azul Sintra requires exactly 10 source-bound RuleNodes';
   END IF;


### PR DESCRIPTION
## 目的

本番で33 viewsある「アズール：シントラのステンドグラス」を、ホビージャパン日本語版 (2019) として公式一次資料に結び付けた状態で検索対象へ戻します。

## プレイヤー向け完了条件

`/games/azul-stained-glass-of-sintra` が、ホビージャパン日本語版 (2019) の2～4人・8歳以上・約30～45分と、Next Move Games公式ルールブックに結び付いた基本ルール10件を表示し、`human_reviewed` のときだけ検索対象になること。

## 変更

- 既存のsource-bound RuleSet 10件を再利用し、10 RuleNodes / 10 accepted Claims / 10 supporting EvidenceBindings を必須化
- ルール根拠をNext Move Games公式ルールブックのみに固定
- 日本語版の商品identityをホビージャパン公式2019年2月版に固定
- 本番の45～45分を公式値の30～45分へ修正
- 他のAzul作品、拡張、デジタル実装、コミュニティ要約を対象外に固定

新しいRuleSet、専用renderer、個別scriptは追加しません。