### PR TITLE
fix: LAMA本番migrationを実schemaに合わせる

### DIFF
--- a/backend/app/db/migrations/090_review_lama_2019.sql
+++ b/backend/app/db/migrations/090_review_lama_2019.sql
@@ -43,7 +43,7 @@ BEGIN
     trust_metadata=EXCLUDED.trust_metadata, updated_at=now();
 
   UPDATE public.evidence_bindings eb
-  SET source_id='publisher:amigo:lama:rules-v1.8-de', updated_at=now()
+  SET source_id='publisher:amigo:lama:rules-v1.8-de'
   FROM public.claims c
   WHERE c.claim_id=eb.claim_id AND c.rule_set_id=v_ruleset_id
     AND c.target_type='rule_node' AND c.lifecycle_status='accepted' AND eb.relation='supports';


### PR DESCRIPTION
## 目的
#507 の本番適用で、`evidence_bindings` に存在しない `updated_at` を更新していたためmigrationがトランザクションごと失敗しました。本番データは変更されていません。

## 修正
- `evidence_bindings.source_id` の更新だけに限定する
- ルール内容、版、9件の証拠条件、検索公開条件は変更しない

## 完了条件
exact-head CI成功後にmergeし、main read-back後、production migrationを再適用してLAMAが`human_reviewed`・Version 1.8根拠・検索公開になることを実確認する。
