### PR TITLE
fix: ブラスの公式プレイ時間60～120分を保持する

### DIFF
--- a/backend/app/db/migrations/092_fix_brass_birmingham_play_time.sql
+++ b/backend/app/db/migrations/092_fix_brass_birmingham_play_time.sql
@@ -1,0 +1,55 @@
+BEGIN;
+
+-- プレイヤー向け完了条件:
+-- ブラス：バーミンガム 完全日本語版の公式プレイ時間「60～120分」を、
+-- 本番データと公開ページで単一値120分へ潰さず保持する。
+DO $$
+DECLARE
+  v_game_id uuid;
+BEGIN
+  SELECT id INTO v_game_id
+  FROM public.games
+  WHERE slug = 'brass-birmingham'
+  LIMIT 1;
+
+  IF v_game_id IS NULL THEN
+    RAISE EXCEPTION 'Canonical Brass: Birmingham game row is required';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.evidence_sources
+    WHERE source_id = 'localizer:arclight:brass-birmingham:product'
+      AND publisher_name = 'アークライト'
+  ) THEN
+    RAISE EXCEPTION 'Official Arclight Brass: Birmingham product source is required';
+  END IF;
+
+  IF (
+    SELECT content_review_status
+    FROM public.games
+    WHERE id = v_game_id
+  ) <> 'human_reviewed' THEN
+    RAISE EXCEPTION 'Brass: Birmingham must remain human reviewed before metadata correction';
+  END IF;
+
+  UPDATE public.games
+  SET play_time = 120,
+      play_time_min_minutes = 60,
+      play_time_max_minutes = 120,
+      updated_at = now()
+  WHERE id = v_game_id;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.games
+    WHERE id = v_game_id
+      AND play_time = 120
+      AND play_time_min_minutes = 60
+      AND play_time_max_minutes = 120
+  ) THEN
+    RAISE EXCEPTION 'Brass: Birmingham official 60-120 minute range was not preserved';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## 目的

ブラス：バーミンガム 完全日本語版の公式プレイ時間「60～120分」が、本番で「120分」に潰れている状態を修正します。

## プレイヤー向け完了条件

`/games/brass-birmingham` が公式値の60～120分を表示し、本番データでも最小60分・最大120分を保持すること。

## 変更

- 既存のプレイ時間範囲用カラムを使用し、最小60分・最大120分へ修正
- 後方互換の `play_time` は最大値120分を維持
- アークライト公式の商品情報が存在し、既に確認済みのゲームである場合だけ更新
- 更新後に60～120分を保持できなければmigrationを失敗させる

新しいschema、専用renderer、個別script、独自workflowは追加しません。