### PR TITLE
短いコンテキストでもcurrent stateから再開できる運用へ簡素化する

### DIFF
--- a/.claude/skills/board-game-product/SKILL.md
+++ b/.claude/skills/board-game-product/SKILL.md
@@ -1,89 +1,49 @@
 ---
 name: board-game-product
-description: Improve ボドゲのミカタ as a trustworthy, useful, revenue-producing board-game product. Use for game rules, discovery/search, setup/play clarity, monetization flows, repository changes, CI, release, and production verification.
+description: ボドゲのミカタを、正しいルール・使いやすさ・検索流入・購入導線・production reliabilityの観点で改善する。
 ---
 
 # Board Game Product
 
-## Goal
+共通の実行手順は `AGENTS.md` を正本とする。このSkillではボードゲーム固有の判断だけを追加する。
 
-Maximize durable player value and revenue while reducing repeated manual work, duplicated code, dependencies, and operational complexity.
+## 優先順位
 
-## Before changing anything
+次の期待効果が大きいplayer-facing問題を優先する。
 
-Follow `AGENTS.md` as the repository-wide authority. Inspect the current `main`, related Issues/PRs, relevant code/data/workflows, CI, deployment, production state, usage/conversion evidence, and official game sources needed for the active workline.
+1. acquisition / discovery / search
+2. rule correctness / trust
+3. setup / play clarity
+4. retention
+5. 既存affiliate等のmonetizable flow
+6. production reliability / operating cost
 
-Define one observable player-facing success condition before implementation.
+同じ問題を扱うcurrent Issue/PRが有効なら続ける。過去の作業履歴を再構築するために大量のコメントを読む必要はない。current main、production、一次資料から状態を確認する。
 
-## Product priority
+## ルールと版の扱い
 
-Choose work by expected impact on:
+- publisher / designer等の公式一次資料を優先する。
+- product、edition、language、platform、revision、expansion、FAQ、errataを明示的に分ける。
+- 公式ルールと要約・翻訳・解釈を別物として保持する。
+- 公式根拠が不足する項目は埋めない。model memoryやcommunity summaryで再構築しない。
+- living rulesはrevisionを上書きせず、どのrevisionを表示しているか保持する。
 
-1. acquisition and discovery/search;
-2. rule correctness and trust;
-3. setup and play clarity;
-4. retention and repeat use;
-5. monetizable flows such as existing affiliate paths;
-6. production reliability and operating cost.
+## 捏造を通さない実装制約
 
-Continue the canonical Issue/PR when it remains valuable. Do not create parallel worklines for the same player problem.
+- networking pathを増やさず、repositoryの既存正準経路を使う。
+- broad `try-except`、silent fallback、default substitutionでmissing/invalid evidenceを成功へ変換しない。
+- unknown、source mismatch、edition ambiguity、invalid production stateは明示的なfailureまたはblocked stateにする。
+- authoritative schema/runtimeで検証できる値にmanual shadow mappingを作らない。
+- resilienceは、確認済みのproduction要件を満たし、失敗を隠さない場合だけ許可する。
 
-## Rule authority
+## ゲームデータ変更
 
-For externally verifiable game facts:
+既存のstructured model、RuleSet、RuleNode、Claim、EvidenceBinding、metadata evidence、RuleOps等を再利用する。複数ゲームを同じgeneric pipelineで扱えるならbatch化し、個別ゲーム専用script/test/workflowを残さない。
 
-- prefer current publisher or designer sources;
-- preserve product, edition, language, platform, revision, expansion, FAQ, and errata boundaries;
-- inspect relevant PDF pages when the source is a PDF;
-- store source URL plus version/revision evidence in the existing structured model;
-- keep official rules separate from summaries, translations, interpretations, recommendations, and generated text;
-- never reconstruct missing official rules from model memory when a suitable primary source is required;
-- do not silently mix base games, expansions, sequels, editions, or regional variants.
+既存のaffiliate/purchase pathは意図した変更でない限り保持する。売上やconversionの改善は実測なしに主張しない。
 
-If primary authority is insufficient, mark the item blocked rather than filling gaps with guesses.
+## 完了判定
 
-## Anti-fabrication implementation constraints
+`AGENTS.md` の検証経路に従い、最後にplayer-facing成功条件をproductionで確認する。確認できなければ `UNVERIFIED` とする。
 
-These constraints are mandatory because hidden recovery and multiple equivalent network paths allow false assumptions, stale behavior, and fabricated outputs to survive verification.
-
-- **One networking path**: do not add `httpx`, `requests`, `aiohttp`, `curl_cffi`, or another parallel HTTP client. Use the repository's established Playwright networking path unless current repository code has an explicitly approved replacement.
-- **Fail loudly**: do not add broad `try-except`, silent fallback, default substitution, or defensive branches whose effect is to turn missing/invalid evidence into plausible-looking success.
-- **No invented defaults**: absence, parsing failure, source mismatch, edition ambiguity, and invalid production state must remain observable failures or explicit blocked states.
-- **No manual shadow mappings** when the authoritative schema/runtime can validate the value directly. Duplicate mappings create a second truth that can drift.
-- Error handling is allowed only when it preserves the failure as an explicit typed/domain state, adds actionable context, or performs required cleanup; it must not convert an unknown into an accepted fact.
-
-The objective is not minimal code for its own sake. The objective is to make unsupported claims unable to pass through the pipeline as valid player-facing content.
-
-## Implementation
-
-Use existing repository structures and `Taskfile.yml` before adding helpers, workflows, schemas, dependencies, or documents.
-
-Prefer generic structured data and shared validation over game-specific scripts or tests. For repeated migrations or publication work, batch multiple reviewed games through the existing shared pipeline when edition/source review remains independently verifiable.
-
-Do not mandate a specific AI provider or external content-generation tool. Such tools are replaceable; evidence boundaries and fail-loud behavior are not.
-
-## Verification loop
-
-For code or data changes:
-
-1. run the narrowest meaningful local/repository validation;
-2. run the affected shared CI without weakening checks;
-3. verify the exact PR head before merge;
-4. treat merge and release as separate states;
-5. after merge, verify exact-main deployment/release state;
-6. read back the public API/page and relevant production data/runtime state;
-7. verify that the observable player-facing success condition actually holds.
-
-A green PR is not proof of production success. A merged but unverified release is `UNRELEASED/UNVERIFIED`.
-
-## Revenue and efficiency
-
-Use real usage/conversion evidence where available. Prefer high-demand, monetizable, source-verifiable games over low-impact maintenance.
-
-Preserve existing affiliate or purchase flows unless the task intentionally changes them. Do not claim revenue lift without observed conversion or revenue evidence.
-
-Reduce repeated agent work by consolidating shared candidate selection, source manifests, validation, generation, CI, and production readback. Keep human/agent review focused on product identity, edition boundaries, official sources, claims, and evidence.
-
-## Completion report
-
-Report only what was directly verified: player/revenue Before→After, trusted evidence, monetization path when grounded, PR/CI/merge/release/production state, removed duplication/manual work, and the next highest-value games problem.
+報告は、Before→After、trusted evidence、根拠のあるmonetization path、PR/CI/merge/production、削除した重複・手作業、残るUNVERIFIED、次の最大価値問題だけに絞る。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,48 @@
 # AGENTS.md
 
-Improve **ボドゲのミカタ** with small, evidence-backed changes that preserve production behavior unless the task requires a product change.
+このrepositoryでは、過去チャットや長いIssue履歴を前提にしない。短いコンテキストでも、current stateから安全に再開できることを優先する。
 
-Before changing anything:
+## 最初に確認する順序
 
-- fetch the current `main` branch;
-- read open Issues and pull requests related to the task;
-- inspect relevant CI, data, and production state;
-- continue existing work when it already covers the same task.
+1. current `main` のSHAとopen PRを確認する。
+2. 同じ問題を扱うopen Issue/PRがあれば本文だけ先に読む。全コメント履歴は、現在状態を確定できない場合だけ読む。
+3. ユーザーが実際に見るcanonical productionとreal dataを確認する。
+4. ゲームの事実が必要ならpublisher/designer等の公式一次資料を確認する。PDFは必要なページを実際に読む。
+5. 変更対象のcode/data/workflowだけを読む。
+6. 変更前に、観測可能なユーザー向け成功条件を1つ書く。
 
-If the repository has a public production site, keep its canonical production URL as a complete plain-text `https://...` URL at the very beginning of `README.md`, before headings, badges, images, or alternate deployment URLs.
+状態の正本は用途ごとに分ける。
 
-Use existing repository commands and structures before adding code, configuration, dependencies, or documentation. `Taskfile.yml` is the preferred command interface when it already provides the required operation.
+- code/schema/workflow: current `main`
+- 実ユーザー向け状態・利用実績: canonical production / real data
+- ゲームのルール・版・商品情報: 公式一次資料
+- 作業の調整: current open Issue/PR
 
-For externally verifiable game facts:
+過去チャット、closed Issue、古いPR、古いコメントは正本ではない。上記と矛盾する場合は現在状態を優先する。
 
-- prefer current publisher or designer sources;
-- record the source URL and revision or version evidence in structured data;
-- inspect relevant PDF pages when the source is a PDF;
-- do not infer missing facts or substitute community summaries when suitable primary sources exist;
-- keep generated summaries, translations, interpretations, and recommendations distinct from verified facts.
+## 必須ルール
 
-For curated game data:
+- public Web siteがある場合、`README.md` の先頭行にcanonical production URLを完全な `https://...` の平文で置く。
+- 公式ルールと、要約・翻訳・解釈・推薦・生成文を分離する。
+- product / edition / language / platform / revision / expansion / FAQ / errataを混ぜない。不明なら推測せず `UNVERIFIED` またはblockedにする。
+- fixture/synthetic dataはtest専用。本番の問題数、品質、利用実績の代用にしない。
+- 既存実装と標準機能を優先し、`DELETE > MERGE > REPLACE > ADD`。重複helper/workflow/docs、個別ゲーム専用one-off script、生成可能な成果物を増やさない。
+- networking pathを増やさない。既存の正準経路を使う。
+- broad `try-except`、silent fallback、根拠のないdefault、壊れたデータを成功扱いするretryを追加しない。失敗は明示する。
+- 同じ意味のshadow mappingや第二のtruth storeを作らない。
 
-- store game-specific source data in `data/curated-games/<slug>.json` when the existing schema supports it;
-- use `task game:add GAME=<slug>` and the existing validation commands;
-- keep the filename, `GAME`, and canonical slug consistent;
-- put game-specific regression facts in the structured `assertions` data instead of adding a game-specific importer or test when the generic schema can express them;
-- do not hand-edit or commit generated curated-game output;
-- do not write production data from a pull request.
+## 実装と検証
 
-Prefer the smallest coherent change. Do not redesign unrelated schemas or UI, create duplicate helpers or workflows, commit reproducible generated output, or silently delete production data because a source file is absent.
+`Taskfile.yml` と既存schema/validator/generatorを優先する。ゲーム固有の事実は既存schemaで表現できる限りstructured dataへ入れ、専用処理を作らない。
 
-Run the narrowest meaningful tests first, then the broader checks required by the affected code or repository CI. Do not weaken or skip checks to make a change pass.
+変更は可能な範囲で次まで完了する。
 
-Treat **PR merge** and **product release** as separate decisions. Merge checks run on the pull request and must not require production credentials, production writes, or production deployment. Release checks run only after the change reaches `main` and cover production publication, deployment, exact-main-SHA verification, and production read-back. A release failure means the merged change is not yet released; do not retroactively redefine a passed PR merge check as failed.
+`validation/test → PR → exact-head CI → merge → main read-back → production release → public read-back`
 
-When safe, complete work through implementation, tests, pull request, exact-head merge checks, merge, post-merge release, cleanup, and production verification. Do not claim CI, deployment, production state, or cleanup unless directly verified. If release is blocked after merge, report the product as **UNRELEASED/UNVERIFIED** and preserve the successful merge evidence separately.
+PRのCI成功とproduction成功は別物。merge後にproductionを直接確認できなければ `UNRELEASED/UNVERIFIED` とする。CIを弱めたりskipして通さない。
 
-After merge, remove temporary files and superseded work when the available GitHub operations allow it. Report the repository, Issue or PR, commit, measurable change, merge-check evidence, release evidence, files and lines changed, dependency or configuration changes, production verification, and remaining unverified items.
+## コンテキスト節約
+
+最初からrepository全体、全Issue、全履歴を読まない。上の開始順序で必要最小限を取得し、未解決の曖昧さがある場合だけ範囲を広げる。
+
+同じ修正が繰り返される原因を見つけたら、その場のpatchではなく既存の `AGENTS.md`、CI、schema、test、canonical docsの最小authorityへ統合する。新しい管理層は作らない。


### PR DESCRIPTION
Closes #535

## ユーザー向け成功条件

過去会話を持たないエージェントでも、`AGENTS.md` と単一の `board-game-product` Skillを読んだ後、current main / current open work / canonical production / 必要な公式一次資料だけから、安全に同じ作業を再開できること。

## 変更

- `AGENTS.md` をrepository-wideの唯一の実行手順として整理
- current main / production / 一次資料 / open workの用途別authorityを明示
- 過去チャット・closed Issue・全コメント履歴を開始条件から除外
- 必要最小限の情報から読み、不明点だけ追加取得する手順へ変更
- `board-game-product` Skillから共通CI/release手順の重複を削除
- fail loudly、単一networking path、silent fallback禁止、版分離は維持
- 新しいrunbook・状態ファイル・管理層は追加しない

## 差分

2 files: +62 / -95。説明量を純減しながら、短いコンテキスト向けの開始順序を追加した。