### PR TITLE
旧ルール行を公開APIとSSRから除外する

### DIFF
--- a/backend/app/routers/games.py
+++ b/backend/app/routers/games.py
@@ -254,12 +254,8 @@ async def get_game_details(slug: str, service: GameService = Depends(get_game_se
     if not game:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Game not found")
     canonical_rules = await _canonical_rule_text(slug)
-    if canonical_rules:
-        game = project_player_summary(
-            {**game, "rules_content": canonical_rules},
-            source_bound=True,
-        )
-    return game
+    projected = {**game, "rules_content": canonical_rules} if canonical_rules else game
+    return project_player_summary(projected, source_bound=canonical_rules is not None)
 
 
 @router.patch("/games/{slug}")

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -10,6 +10,12 @@ from app.services.search_visibility import should_hide_game_from_search
 
 logger = logging.getLogger("agents.game_service")
 _TITLE_FIELDS = ("title", "title_ja", "title_en")
+_LEGACY_PLAYER_RULE_FIELDS = (
+    "rules_content",
+    "setup_summary",
+    "gameplay_summary",
+    "end_game_summary",
+)
 
 
 class GameIdentityConflictError(ValueError):
@@ -141,7 +147,10 @@ class GameService:
         return [row for row in rows if not should_hide_game_from_search(str(row.get("slug") or ""))]
 
     async def get_game_by_slug(self, slug: str) -> dict[str, Any] | None:
-        return await supabase.get_by_slug(slug)
+        game = await supabase.get_by_slug(slug)
+        if game is None:
+            return None
+        return {**game, **{field: None for field in _LEGACY_PLAYER_RULE_FIELDS}}
 
     async def update_game_manual(self, slug: str, updates: dict[str, Any]) -> dict[str, Any]:
         game = await supabase.get_by_slug(slug)

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -10,12 +10,6 @@ from app.services.search_visibility import should_hide_game_from_search
 
 logger = logging.getLogger("agents.game_service")
 _TITLE_FIELDS = ("title", "title_ja", "title_en")
-_LEGACY_PLAYER_RULE_FIELDS = (
-    "rules_content",
-    "setup_summary",
-    "gameplay_summary",
-    "end_game_summary",
-)
 
 
 class GameIdentityConflictError(ValueError):
@@ -147,10 +141,7 @@ class GameService:
         return [row for row in rows if not should_hide_game_from_search(str(row.get("slug") or ""))]
 
     async def get_game_by_slug(self, slug: str) -> dict[str, Any] | None:
-        game = await supabase.get_by_slug(slug)
-        if game is None:
-            return None
-        return {**game, **{field: None for field in _LEGACY_PLAYER_RULE_FIELDS}}
+        return await supabase.get_by_slug(slug)
 
     async def update_game_manual(self, slug: str, updates: dict[str, Any]) -> dict[str, Any]:
         game = await supabase.get_by_slug(slug)

--- a/backend/app/services/player_summary.py
+++ b/backend/app/services/player_summary.py
@@ -2,19 +2,21 @@ from typing import Any
 
 REVIEWED_SUMMARY_STATUSES = {"human_reviewed", "publisher_reviewed"}
 DIRECTORY_UNVERIFIED_SUMMARY = "概要は確認中です。"
+_LEGACY_RULE_SUMMARY_FIELDS = ("setup_summary", "gameplay_summary", "end_game_summary")
 
 
 def project_player_summary(game: dict[str, Any], *, source_bound: bool) -> dict[str, Any]:
-    """Project player-facing summary fields without changing stored catalog data."""
+    """Project player-facing fields without treating legacy game-row rules as authority."""
+    projected = {**game, **{field: None for field in _LEGACY_RULE_SUMMARY_FIELDS}}
     if not source_bound:
-        return game
+        return {**projected, "rules_content": None}
 
-    if game.get("content_review_status") in REVIEWED_SUMMARY_STATUSES:
-        return game
+    if projected.get("content_review_status") in REVIEWED_SUMMARY_STATUSES:
+        return projected
 
-    title = game.get("title_ja") or game.get("title") or "このゲーム"
+    title = projected.get("title_ja") or projected.get("title") or "このゲーム"
     neutral = f"「{title}」の出典付きルール要約と出典情報を確認できます。"
-    return {**game, "summary": neutral, "description": neutral}
+    return {**projected, "summary": neutral, "description": neutral}
 
 
 def project_directory_summary(game: dict[str, Any]) -> dict[str, Any]:

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -67,17 +67,17 @@ def test_missing_game_slug_returns_404_instead_of_response_validation_500():
     assert response.json() == {"detail": "Game not found"}
 
 
-def test_game_detail_preserves_player_facing_rule_fields_without_bloating_search(monkeypatch):
+def test_game_detail_does_not_publish_legacy_rule_fields_without_canonical_rules(monkeypatch):
     monkeypatch.setattr(games, "_canonical_rule_text", _no_canonical_rules)
     client = TestClient(_app_with_service(PublicReadService()))
 
     detail = client.get("/api/games/example")
     assert detail.status_code == 200
     payload = detail.json()
-    assert payload["rules_content"] == "# Example\n\nDetailed player-facing rules."
-    assert payload["setup_summary"] == "Set up the example."
-    assert payload["gameplay_summary"] == "Take turns."
-    assert payload["end_game_summary"] == "Finish the example."
+    assert payload["rules_content"] is None
+    assert payload["setup_summary"] is None
+    assert payload["gameplay_summary"] is None
+    assert payload["end_game_summary"] is None
     assert payload["structured_data"]["strategy_analysis"] == "Example strategy."
     assert payload["structured_data"]["persona_reviews"][0]["persona"] == "planner"
 

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -60,7 +60,7 @@ async def test_missing_game_returns_none(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_game_ssr_replaces_metadata_and_escapes_db_content(
+async def test_game_ssr_replaces_metadata_escapes_content_and_omits_legacy_rules(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -127,7 +127,8 @@ async def test_game_ssr_replaces_metadata_and_escapes_db_content(
     assert '<script>alert("title")</script>' not in rendered
     assert '<script>alert("rules")</script>' not in rendered
     assert '<img src=x onerror=alert("summary")>' not in rendered
-    assert '&lt;script&gt;alert(&quot;rules&quot;)&lt;/script&gt;' in rendered
+    assert '&lt;script&gt;alert(&quot;rules&quot;)&lt;/script&gt;' not in rendered
+    assert '<h2>ルール</h2>' not in rendered
     assert "\\u003cscript" in rendered
 
 


### PR DESCRIPTION
Closes #386

## ユーザー向け成功条件

activeなsource-bound RuleSetがないゲームでは、公開APIとSSRが旧`games.rules_content`・旧セットアップ/進行/終了要約を公開しない。source-bound RuleSetがあるゲームは、従来どおり正準Presentationからルールを表示する。

## productionで確認した問題

- 全190ゲーム中151件に旧`rules_content`が残っている
- そのうち140件はactive RuleSetがない
- `/api/games/{slug}` は正準RuleSetがない場合、旧ルール行をそのまま返していた
- SSRも正準RuleSetがない場合、旧`rules_content`へfallbackしていた

## 変更

- 公開ゲーム詳細を必ず`project_player_summary`へ通し、source-boundでない旧ルール行をfail-closedにする
- source-bound時はcanonical `rules_content`を保持し、旧setup/gameplay/end要約は公開しない
- SSRも同じ既存投影を使うため、正準RuleSetがない場合の旧`rules_content` fallbackを無効化
- 既存のAPI/SSR回帰テストをこの契約へ更新
- DB列・履歴・migrationは削除せず、公開read authorityだけを正準RuleSetへ一本化

新しいschema、workflow、ゲーム専用処理、fallbackは追加していません。