### PR TITLE
旧ルール行への新規PATCHを拒否する

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal
 from urllib.parse import urlparse
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 IdentityStatus = Literal["unverified", "verified", "needs_review"]
 SourceTrust = Literal["unknown", "official_publisher", "authorized_partner", "third_party"]
@@ -128,6 +128,19 @@ class GameUpdate(BaseSchema):
     amazon_url: str | None = None
 
     _validate_bga_url = field_validator("bga_url")(validate_bga_url)
+
+    @model_validator(mode="before")
+    @classmethod
+    def reject_legacy_rule_row_fields(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            deprecated = {"rules_content", "setup_summary", "gameplay_summary", "end_game_summary"}
+            supplied = sorted(deprecated.intersection(value))
+            if supplied:
+                raise ValueError(
+                    "Deprecated game-row rule fields are read-only history; use source-bound RuleSet data: "
+                    + ", ".join(supplied)
+                )
+        return value
 
 
 SEARCH_RESULT = GameDetail

--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -241,16 +241,11 @@ async def generate_seo_html(slug: str) -> str | None:
 
     safe_title = html.escape(title)
     safe_summary = html.escape(str(game.get("summary") or ""))
-    if canonical_rules:
-        safe_rules = html.escape(canonical_rules)
-        rules_heading = "出典付きルール要約"
-    else:
-        safe_rules = html.escape(str(game.get("rules_content") or "")[:2000])
-        rules_heading = "ルール"
+    safe_rules = html.escape(canonical_rules) if canonical_rules else ""
     rules_section = ""
     if safe_rules:
         rules_section = f"""    <section>
-      <h2>{rules_heading}</h2>
+      <h2>出典付きルール要約</h2>
       <pre itemprop="text">{safe_rules}</pre>
     </section>
 """

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -97,6 +97,21 @@ def test_catalog_patch_requires_authentication_before_mutation():
     assert service.updated is False
 
 
+def test_catalog_patch_rejects_deprecated_rule_row_fields_before_mutation():
+    service = MutableGameService()
+    app = _app_with_service(service)
+    app.dependency_overrides[games.require_catalog_editor] = lambda: {
+        "id": "editor-1",
+        "catalog_role": "editor",
+    }
+    client = TestClient(app)
+
+    response = client.patch("/api/games/example", json={"rules_content": "unverified legacy rule"})
+
+    assert response.status_code == 422
+    assert service.updated is False
+
+
 def test_read_only_search_remains_and_legacy_post_search_is_removed():
     client = TestClient(_app_with_service(PublicReadService()))
 


### PR DESCRIPTION
Closes #386

## ユーザー向け成功条件

旧`games.rules_content`・`setup_summary`・`gameplay_summary`・`end_game_summary`を公開PATCHへ送った場合、黙って無視せず422で失敗し、catalog mutationを実行しない。SSRはsource-bound RuleSet以外のルール本文を読む分岐自体を持たない。

## 変更

- 既存`GameUpdate`に入力時validatorを追加し、deprecated rule-row fieldを明示拒否
- 既存route testで422とmutation未実行を固定
- SSRに残っていた到達不能な旧`rules_content` fallback分岐を削除
- identity field等、既存の未知field無視契約は変更しない

PR #547で公開read側を正準RuleSetへ一本化済み。このPRで残るwrite/fallback branchを閉じる。新しいschema、workflow、DB列は追加しない。