### PR TITLE
ピリピリmigrationを本番DB状態に合わせる

### DIFF
--- a/backend/app/db/migrations/119_remove_pili_pili_unbound_public_interpretation.sql
+++ b/backend/app/db/migrations/119_remove_pili_pili_unbound_public_interpretation.sql
@@ -23,6 +23,8 @@ BEGIN
     RAISE EXCEPTION 'Canonical Pili Pili game row is required';
   END IF;
 
+  -- 旧game rowのルール欄は移行履歴としてDBに残っているが、public projectionでは
+  -- #547/#548により利用されない。公開APIのnullをDB上のnullと誤認しない。
   IF NOT EXISTS (
     SELECT 1
     FROM public.games
@@ -32,13 +34,15 @@ BEGIN
       AND source_trust = 'authorized_partner'
       AND source_url = 'https://ja.boardgamearena.com/gamepanel?game=pilipili'
       AND content_review_status = 'review_required'
-      AND rules_content IS NULL
-      AND setup_summary IS NULL
-      AND gameplay_summary IS NULL
-      AND end_game_summary IS NULL
+      AND rules_content IS NOT NULL
+      AND btrim(rules_content) <> ''
+      AND setup_summary IS NOT NULL
+      AND gameplay_summary IS NOT NULL
+      AND end_game_summary IS NOT NULL
       AND summary = '取るトリック数を先にベットし、実際の獲得数をぴったり合わせる予想型トリックテイキング。BGA版では毎ラウンドのミッションで条件が変わり、ベットとの差だけピリを受け取ります。誰かが6ピリに達すると終了し、最少ピリが勝利です。'
+      AND COALESCE(structured_data, '{}'::jsonb) ?| ARRAY['keywords', 'pro_tips', 'rule_mistakes', 'strategy_analysis']
   ) THEN
-    RAISE EXCEPTION 'Pili Pili canonical public state changed; re-audit before migration';
+    RAISE EXCEPTION 'Pili Pili canonical stored state changed; re-audit before migration';
   END IF;
 
   SELECT count(*) INTO v_ruleset_count
@@ -89,7 +93,6 @@ BEGIN
     FROM public.games
     WHERE id = v_game_id
       AND content_review_status = 'review_required'
-      AND rules_content IS NULL
       AND summary = '物理版とBoard Game Arena版では構成物と一部ルールが異なります。版を混ぜず、利用するRuleSetの版・プラットフォームを確認して参照してください。'
       AND description = '取るトリック数を先に予想するトリックテイキングです。物理版とBoard Game Arena版は別のRuleSetとして管理しており、構成物と一部ルールの差を混在させません。'
       AND NOT (COALESCE(structured_data, '{}'::jsonb) ?| ARRAY['keywords', 'pro_tips', 'rule_mistakes', 'strategy_analysis'])


### PR DESCRIPTION
## 修正理由

PR #549 のproduction migration適用時、fail-closed guardが停止しました。

原因は、#547/#548で**公開APIからnullへ投影される旧ルール欄**を、production DB自体もnullだと扱ったことです。production DBを再取得すると、旧ルール欄は移行履歴として保持されていました。

## 変更

- 未適用のmigration 119自体を修正し、重複migrationを追加しない。
- production DBの実状態（旧rule-rowは保存、public projectionでは不使用）をguardへ反映。
- 物理版/BGA版の2本のsource-bound RuleSet境界は引き続き必須。
- 公開要約と未検証`structured_data`除去の目的は変更しない。

Related #202 / #549