### PR TITLE
productionで匿名カタログ更新拒否を継続検証する

### DIFF
--- a/.github/workflows/test-catalog-integrity.yml
+++ b/.github/workflows/test-catalog-integrity.yml
@@ -7,6 +7,7 @@ on:
       - "backend/app/models/**"
       - "backend/app/routers/auth.py"
       - "backend/app/routers/games.py"
+      - "backend/app/scripts/verify_production_contract.py"
       - "backend/app/services/catalog_access.py"
       - "backend/app/services/game_service.py"
       - "backend/app/services/identity_coherence.py"
@@ -18,6 +19,7 @@ on:
       - "backend/tests/test_game_identity_conflict_guard.py"
       - "backend/tests/test_games_router.py"
       - "backend/tests/test_identity_duplicate_audit.py"
+      - "backend/tests/test_production_contract.py"
       - "backend/tests/test_seo_renderer.py"
       - "backend/tests/test_sitemap.py"
       - "frontend/src/components/game/ExternalLinks.jsx"
@@ -36,6 +38,7 @@ on:
       - "backend/app/models/**"
       - "backend/app/routers/auth.py"
       - "backend/app/routers/games.py"
+      - "backend/app/scripts/verify_production_contract.py"
       - "backend/app/services/catalog_access.py"
       - "backend/app/services/game_service.py"
       - "backend/app/services/identity_coherence.py"
@@ -47,6 +50,7 @@ on:
       - "backend/tests/test_game_identity_conflict_guard.py"
       - "backend/tests/test_games_router.py"
       - "backend/tests/test_identity_duplicate_audit.py"
+      - "backend/tests/test_production_contract.py"
       - "backend/tests/test_seo_renderer.py"
       - "backend/tests/test_sitemap.py"
       - "frontend/src/components/game/ExternalLinks.jsx"
@@ -103,6 +107,7 @@ jobs:
           backend/tests/test_game_identity_conflict_guard.py
           backend/tests/test_games_router.py
           backend/tests/test_identity_duplicate_audit.py
+          backend/tests/test_production_contract.py
           backend/tests/test_seo_renderer.py
           backend/tests/test_sitemap.py
 

--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 from typing import Any
+from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 MECHANICAL_DNA_PATH = "/api/games/skull-king/connections?limit=8"
+CATALOG_AUTH_PATH = "/api/games/splendor"
 
 
 def validate_mechanical_dna_payload(payload: Any) -> int:
@@ -27,6 +29,45 @@ def validate_mechanical_dna_payload(payload: Any) -> int:
         raise ValueError("connections must be a JSON array")
 
     return len(connections)
+
+
+def validate_anonymous_catalog_patch_status(status_code: int) -> None:
+    if status_code not in {401, 403}:
+        raise ValueError(
+            "anonymous catalog PATCH must fail with HTTP 401 or 403; "
+            f"received {status_code}"
+        )
+
+
+def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0) -> int:
+    """Verify the production catalog mutation boundary without changing data.
+
+    The empty JSON object intentionally contains no update fields. Even if the
+    authorization dependency regressed, this request cannot change a game row;
+    the verification still fails unless production rejects the anonymous PATCH
+    before reaching the no-op update branch.
+    """
+
+    url = f"{base_url.rstrip('/')}{CATALOG_AUTH_PATH}"
+    request = Request(
+        url,
+        data=b"{}",
+        method="PATCH",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": "rule-scribe-games-production-contract/1.0",
+        },
+    )
+
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+            status_code = response.status
+    except HTTPError as exc:
+        status_code = exc.code
+
+    validate_anonymous_catalog_patch_status(status_code)
+    return status_code
 
 
 def verify_production(base_url: str, timeout_seconds: float = 20.0) -> int:
@@ -57,9 +98,10 @@ def main() -> None:
     args = parser.parse_args()
 
     connection_count = verify_production(args.base_url, args.timeout_seconds)
+    auth_status = verify_anonymous_catalog_patch(args.base_url, args.timeout_seconds)
     print(
-        "Mechanical DNA production contract: OK "
-        f"(algorithm=mechanical-dna-concept-v1, status=available, connections={connection_count})"
+        "Production API contracts: OK "
+        f"(mechanical_dna_connections={connection_count}, anonymous_catalog_patch={auth_status})"
     )
 
 

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -1,6 +1,9 @@
 import pytest
 
-from app.scripts.verify_production_contract import validate_mechanical_dna_payload
+from app.scripts.verify_production_contract import (
+    validate_anonymous_catalog_patch_status,
+    validate_mechanical_dna_payload,
+)
 
 
 def test_validate_mechanical_dna_payload_accepts_canonical_contract():
@@ -49,3 +52,14 @@ def test_validate_mechanical_dna_payload_fails_closed(field, value):
 
     with pytest.raises(ValueError):
         validate_mechanical_dna_payload(payload)
+
+
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_anonymous_catalog_patch_accepts_auth_rejection(status_code):
+    validate_anonymous_catalog_patch_status(status_code)
+
+
+@pytest.mark.parametrize("status_code", [200, 204, 400, 404, 422, 500])
+def test_anonymous_catalog_patch_rejects_other_statuses(status_code):
+    with pytest.raises(ValueError, match="anonymous catalog PATCH must fail"):
+        validate_anonymous_catalog_patch_status(status_code)


### PR DESCRIPTION
## 目的

Issue #134 の残課題だったproductionでの匿名PATCH拒否を、毎回手作業で確認せず既存のproduction contractで継続検証します。

## 成功条件

production `PATCH /api/games/splendor` を認証なし・空JSON `{}` で実行したとき、HTTP 401 または 403 で拒否されること。

空JSONは更新項目を含まないため、仮に認証guardが壊れていてもゲームデータは変更されません。その場合は既存APIのno-op分岐が200を返すため、このproduction contractが失敗します。

## 変更

- 既存 `verify_production_contract.py` に匿名PATCHの非破壊smoke testを追加
- 401/403以外を失敗とする回帰テストを既存 `test_production_contract.py` へ追加
- 既存 `Test catalog integrity` の対象にproduction contract script/testを追加

新しいworkflow、API、認証方式は追加しません。既存のexact-main production verificationに統合します。

Closes #134 は行いません。authorized editorによるproductionの安全な更新確認が別途必要なため、今回のproduction実測後も未検証ならIssueを残します。