### PR TITLE
production検索公開状態を継続監査する

### DIFF
--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import xml.etree.ElementTree as ET
+from collections import Counter
 from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 MECHANICAL_DNA_PATH = "/api/games/skull-king/connections?limit=8"
 CATALOG_AUTH_PATH = "/api/games/splendor"
+PUBLIC_GAMES_PATH = "/api/games?limit=500&offset=0"
+SITEMAP_PATH = "/sitemap.xml"
+MISSING_GAME_PATH = "/games/this-game-does-not-exist"
+SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
 
 def validate_mechanical_dna_payload(payload: Any) -> int:
@@ -39,14 +45,67 @@ def validate_anonymous_catalog_patch_status(status_code: int) -> None:
         )
 
 
-def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0) -> int:
-    """Verify the production catalog mutation boundary without changing data.
+def indexability_reasons(game: dict[str, Any]) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if game.get("identity_status") != "verified":
+        reasons.append("identity_not_verified")
+    if game.get("content_review_status") != "human_reviewed":
+        reasons.append("content_not_human_reviewed")
+    return tuple(reasons)
 
-    The empty JSON object intentionally contains no update fields. Even if the
-    authorization dependency regressed, this request cannot change a game row;
-    the verification still fails unless production rejects the anonymous PATCH
-    before reaching the no-op update branch.
-    """
+
+def build_indexability_report(games: list[dict[str, Any]], sitemap_urls: set[str], base_url: str) -> dict[str, Any]:
+    expected_indexable: set[str] = set()
+    reasons = Counter()
+
+    for game in games:
+        slug = str(game.get("slug") or "").strip()
+        if not slug:
+            reasons["missing_slug"] += 1
+            continue
+        game_reasons = indexability_reasons(game)
+        if game_reasons:
+            reasons.update(game_reasons)
+            continue
+        expected_indexable.add(f"{base_url.rstrip('/')}/games/{slug}")
+
+    sitemap_game_urls = {url for url in sitemap_urls if "/games/" in url}
+    missing_from_sitemap = sorted(expected_indexable - sitemap_game_urls)
+    unexpected_in_sitemap = sorted(sitemap_game_urls - expected_indexable)
+    if missing_from_sitemap or unexpected_in_sitemap:
+        raise ValueError(
+            "production sitemap does not match the public indexability contract: "
+            f"missing={missing_from_sitemap}, unexpected={unexpected_in_sitemap}"
+        )
+
+    return {
+        "public_games": len(games),
+        "indexable": len(expected_indexable),
+        "non_indexable": len(games) - len(expected_indexable),
+        "reason_counts": dict(sorted(reasons.items())),
+        "sitemap_game_urls": len(sitemap_game_urls),
+        "missing_from_sitemap": missing_from_sitemap,
+        "unexpected_in_sitemap": unexpected_in_sitemap,
+    }
+
+
+def _request(base_url: str, path: str, timeout_seconds: float, accept: str) -> tuple[int, bytes]:
+    request = Request(
+        f"{base_url.rstrip('/')}{path}",
+        headers={
+            "Accept": accept,
+            "User-Agent": "rule-scribe-games-production-contract/1.0",
+        },
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+            return response.status, response.read()
+    except HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0) -> int:
+    """Verify the production catalog mutation boundary without changing data."""
 
     url = f"{base_url.rstrip('/')}{CATALOG_AUTH_PATH}"
     request = Request(
@@ -68,6 +127,45 @@ def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0)
 
     validate_anonymous_catalog_patch_status(status_code)
     return status_code
+
+
+def verify_search_indexability(base_url: str, timeout_seconds: float = 20.0) -> dict[str, Any]:
+    games_status, games_body = _request(base_url, PUBLIC_GAMES_PATH, timeout_seconds, "application/json")
+    if games_status != 200:
+        raise RuntimeError(f"public games endpoint returned HTTP {games_status}")
+    payload = json.loads(games_body)
+    games = payload.get("games")
+    if not isinstance(games, list):
+        raise ValueError("public games response must contain a games array")
+    if payload.get("total") != len(games):
+        raise ValueError(
+            "production indexability audit requires the full public catalog in one response; "
+            f"received total={payload.get('total')!r}, rows={len(games)}"
+        )
+
+    sitemap_status, sitemap_body = _request(base_url, SITEMAP_PATH, timeout_seconds, "application/xml")
+    if sitemap_status != 200:
+        raise RuntimeError(f"sitemap endpoint returned HTTP {sitemap_status}")
+    root = ET.fromstring(sitemap_body)
+    sitemap_urls = {loc.text for loc in root.findall("sm:url/sm:loc", SITEMAP_NS) if loc.text}
+
+    report = build_indexability_report(games, sitemap_urls, base_url)
+
+    non_indexable = next((game for game in games if indexability_reasons(game)), None)
+    if non_indexable is not None:
+        slug = str(non_indexable.get("slug") or "").strip()
+        page_status, page_body = _request(base_url, f"/games/{slug}", timeout_seconds, "text/html")
+        if page_status != 200 or b'content="noindex, follow"' not in page_body:
+            raise ValueError(
+                f"non-indexable production game must remain HTTP 200 with noindex, follow: slug={slug}, status={page_status}"
+            )
+        report["noindex_sample"] = slug
+
+    missing_status, _ = _request(base_url, MISSING_GAME_PATH, timeout_seconds, "text/html")
+    if missing_status != 404:
+        raise ValueError(f"missing game must return HTTP 404; received {missing_status}")
+    report["missing_game_status"] = missing_status
+    return report
 
 
 def verify_production(base_url: str, timeout_seconds: float = 20.0) -> int:
@@ -99,10 +197,12 @@ def main() -> None:
 
     connection_count = verify_production(args.base_url, args.timeout_seconds)
     auth_status = verify_anonymous_catalog_patch(args.base_url, args.timeout_seconds)
+    indexability = verify_search_indexability(args.base_url, args.timeout_seconds)
     print(
         "Production API contracts: OK "
         f"(mechanical_dna_connections={connection_count}, anonymous_catalog_patch={auth_status})"
     )
+    print(json.dumps({"search_indexability": indexability}, ensure_ascii=False, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -1,6 +1,8 @@
 import pytest
 
 from app.scripts.verify_production_contract import (
+    build_indexability_report,
+    indexability_reasons,
     validate_anonymous_catalog_patch_status,
     validate_mechanical_dna_payload,
 )
@@ -63,3 +65,66 @@ def test_anonymous_catalog_patch_accepts_auth_rejection(status_code):
 def test_anonymous_catalog_patch_rejects_other_statuses(status_code):
     with pytest.raises(ValueError, match="anonymous catalog PATCH must fail"):
         validate_anonymous_catalog_patch_status(status_code)
+
+
+def test_indexability_reasons_keep_unreviewed_games_out_of_search():
+    assert indexability_reasons(
+        {"identity_status": "verified", "content_review_status": "review_required"}
+    ) == ("content_not_human_reviewed",)
+    assert indexability_reasons(
+        {"identity_status": "unverified", "content_review_status": "human_reviewed"}
+    ) == ("identity_not_verified",)
+
+
+def test_build_indexability_report_matches_sitemap_and_counts_reasons():
+    base_url = "https://example.test"
+    games = [
+        {
+            "slug": "reviewed",
+            "identity_status": "verified",
+            "content_review_status": "human_reviewed",
+        },
+        {
+            "slug": "needs-review",
+            "identity_status": "verified",
+            "content_review_status": "review_required",
+        },
+        {
+            "slug": "unverified",
+            "identity_status": "unverified",
+            "content_review_status": "unknown",
+        },
+    ]
+    sitemap_urls = {
+        f"{base_url}/",
+        f"{base_url}/data",
+        f"{base_url}/games/reviewed",
+    }
+
+    report = build_indexability_report(games, sitemap_urls, base_url)
+
+    assert report == {
+        "public_games": 3,
+        "indexable": 1,
+        "non_indexable": 2,
+        "reason_counts": {
+            "content_not_human_reviewed": 2,
+            "identity_not_verified": 1,
+        },
+        "sitemap_game_urls": 1,
+        "missing_from_sitemap": [],
+        "unexpected_in_sitemap": [],
+    }
+
+
+def test_build_indexability_report_fails_on_sitemap_drift():
+    games = [
+        {
+            "slug": "reviewed",
+            "identity_status": "verified",
+            "content_review_status": "human_reviewed",
+        }
+    ]
+
+    with pytest.raises(ValueError, match="sitemap does not match"):
+        build_indexability_report(games, set(), "https://example.test")


### PR DESCRIPTION
## 目的

Issue #201 の残件である検索公開状態の実運用監査を、既存の production contract に統合します。

## 変更

- 公開ゲームAPIから現在の公開カタログを全件取得
- `identity_status=verified` かつ `content_review_status=human_reviewed` を検索公開候補として集計
- production sitemap のゲームURL集合と完全一致することを検証
- 未レビュー代表ページが HTTP 200 + `noindex, follow` であることを検証
- 存在しないゲームが HTTP 404 であることを検証
- 件数・理由をJSONとして同じproduction verification logへ出力
- 既存の `verify_production_contract.py` と既存CIだけを利用し、新しいworkflow/scriptは追加しない

## ユーザー向け成功条件

productionで、検索公開可能なゲームだけがsitemapへ入り、未レビューゲームは閲覧可能なままnoindex、存在しないゲームは404になる状態をreleaseごとに検証できること。

Closes #201