### PR TITLE
production検索公開監査をAPI上限内で全件取得する

### DIFF
--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -10,7 +10,7 @@ from urllib.request import Request, urlopen
 
 MECHANICAL_DNA_PATH = "/api/games/skull-king/connections?limit=8"
 CATALOG_AUTH_PATH = "/api/games/splendor"
-PUBLIC_GAMES_PATH = "/api/games?limit=500&offset=0"
+PUBLIC_GAMES_PAGE_SIZE = 100
 SITEMAP_PATH = "/sitemap.xml"
 MISSING_GAME_PATH = "/games/this-game-does-not-exist"
 SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
@@ -104,6 +104,48 @@ def _request(base_url: str, path: str, timeout_seconds: float, accept: str) -> t
         return exc.code, exc.read()
 
 
+def fetch_public_games(base_url: str, timeout_seconds: float = 20.0) -> list[dict[str, Any]]:
+    games: list[dict[str, Any]] = []
+    expected_total: int | None = None
+    offset = 0
+
+    while expected_total is None or offset < expected_total:
+        path = f"/api/games?limit={PUBLIC_GAMES_PAGE_SIZE}&offset={offset}"
+        status, body = _request(base_url, path, timeout_seconds, "application/json")
+        if status != 200:
+            raise RuntimeError(f"public games endpoint returned HTTP {status} at offset={offset}")
+
+        payload = json.loads(body)
+        page = payload.get("games")
+        total = payload.get("total")
+        if not isinstance(page, list):
+            raise ValueError("public games response must contain a games array")
+        if not isinstance(total, int) or total < 0:
+            raise ValueError(f"public games response must contain a non-negative integer total; received {total!r}")
+        if expected_total is None:
+            expected_total = total
+        elif total != expected_total:
+            raise ValueError(
+                "public games total changed while paginating: "
+                f"expected={expected_total}, received={total}, offset={offset}"
+            )
+        if not page and offset < expected_total:
+            raise ValueError(
+                "public games pagination ended before total rows were collected: "
+                f"expected={expected_total}, collected={len(games)}, offset={offset}"
+            )
+
+        games.extend(page)
+        offset += len(page)
+
+    if expected_total is None or len(games) != expected_total:
+        raise ValueError(
+            "production indexability audit requires the full public catalog: "
+            f"expected={expected_total!r}, collected={len(games)}"
+        )
+    return games
+
+
 def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0) -> int:
     """Verify the production catalog mutation boundary without changing data."""
 
@@ -130,18 +172,7 @@ def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0)
 
 
 def verify_search_indexability(base_url: str, timeout_seconds: float = 20.0) -> dict[str, Any]:
-    games_status, games_body = _request(base_url, PUBLIC_GAMES_PATH, timeout_seconds, "application/json")
-    if games_status != 200:
-        raise RuntimeError(f"public games endpoint returned HTTP {games_status}")
-    payload = json.loads(games_body)
-    games = payload.get("games")
-    if not isinstance(games, list):
-        raise ValueError("public games response must contain a games array")
-    if payload.get("total") != len(games):
-        raise ValueError(
-            "production indexability audit requires the full public catalog in one response; "
-            f"received total={payload.get('total')!r}, rows={len(games)}"
-        )
+    games = fetch_public_games(base_url, timeout_seconds)
 
     sitemap_status, sitemap_body = _request(base_url, SITEMAP_PATH, timeout_seconds, "application/xml")
     if sitemap_status != 200:

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -1,7 +1,11 @@
+import json
+
 import pytest
 
+import app.scripts.verify_production_contract as production_contract
 from app.scripts.verify_production_contract import (
     build_indexability_report,
+    fetch_public_games,
     indexability_reasons,
     validate_anonymous_catalog_patch_status,
     validate_mechanical_dna_payload,
@@ -65,6 +69,41 @@ def test_anonymous_catalog_patch_accepts_auth_rejection(status_code):
 def test_anonymous_catalog_patch_rejects_other_statuses(status_code):
     with pytest.raises(ValueError, match="anonymous catalog PATCH must fail"):
         validate_anonymous_catalog_patch_status(status_code)
+
+
+def test_fetch_public_games_paginates_within_api_limit(monkeypatch):
+    requested_paths = []
+
+    def fake_request(base_url, path, timeout_seconds, accept):
+        requested_paths.append(path)
+        offset = int(path.split("offset=")[1])
+        total = 185
+        size = min(100, total - offset)
+        body = json.dumps({"total": total, "games": [{"slug": f"game-{i}"} for i in range(offset, offset + size)]}).encode()
+        return 200, body
+
+    monkeypatch.setattr(production_contract, "_request", fake_request)
+
+    games = fetch_public_games("https://example.test")
+
+    assert len(games) == 185
+    assert requested_paths == [
+        "/api/games?limit=100&offset=0",
+        "/api/games?limit=100&offset=100",
+    ]
+
+
+def test_fetch_public_games_fails_if_pagination_ends_early(monkeypatch):
+    def fake_request(base_url, path, timeout_seconds, accept):
+        offset = int(path.split("offset=")[1])
+        if offset == 0:
+            return 200, json.dumps({"total": 185, "games": [{"slug": f"game-{i}"} for i in range(100)]}).encode()
+        return 200, json.dumps({"total": 185, "games": []}).encode()
+
+    monkeypatch.setattr(production_contract, "_request", fake_request)
+
+    with pytest.raises(ValueError, match="ended before total rows"):
+        fetch_public_games("https://example.test")
 
 
 def test_indexability_reasons_keep_unreviewed_games_out_of_search():


### PR DESCRIPTION
Issue #201 のproduction確認で、公開ゲームAPIへ `limit=500` を送ってHTTP 422になり、exact-mainの `Production-Build-And-Verify` が失敗していました。

変更内容:
- 公開ゲームAPIを100件ずつページングして全件取得します。
- `total` が途中で変わる、途中で空ページになる、最終件数が一致しない場合は明示的に失敗します。
- 185件を100件+85件で取得する回帰テストと、途中欠損を拒否するテストを追加します。

完了条件:
- exact-head CIが成功すること。
- merge後のmainをread-backすること。
- exact-mainのproduction deploymentがREADYになること。
- canonical productionでproduction contractが成功し、sitemapと検索公開対象の一致を確認できること。

Closes #201 は付けません。#201には前回の検証済み状態との promoted / demoted 差分追跡が残っています。