### PR TITLE
検索公開状態の前回production差分をrelease検証に残す

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: vercel-${{ github.workflow }}-${{ github.ref }}
@@ -136,14 +137,61 @@ jobs:
         run: |
           echo "Production still does not match the exact main SHA after verification/fallback." >> "$GITHUB_STEP_SUMMARY"
           exit 1
+      - name: Download previous production indexability state
+        id: previous_indexability
+        if: >-
+          steps.budget.outputs.state == 'current' ||
+          steps.git_verification.outcome == 'success' ||
+          steps.push_fallback.outputs.deployed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/previous-indexability
+          artifact_id="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.name == "production-indexability" and (.expired | not)) | [.created_at, (.id | tostring)] | @tsv' | sort -r | head -n 1 | cut -f 2)"
+          if [ -z "$artifact_id" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No previous verified production indexability artifact; this release establishes the baseline and reports the comparison as UNVERIFIED." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > /tmp/previous-indexability.zip
+          unzip -q /tmp/previous-indexability.zip -d /tmp/previous-indexability
+          test -f /tmp/previous-indexability/indexability.json
+          echo "found=true" >> "$GITHUB_OUTPUT"
       - name: Verify Mechanical DNA production contract
         if: >-
           steps.budget.outputs.state == 'current' ||
           steps.git_verification.outcome == 'success' ||
           steps.push_fallback.outputs.deployed == 'true'
-        run: >-
-          python backend/app/scripts/verify_production_contract.py
-          --base-url https://bodoge-no-mikata.vercel.app
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            --base-url https://bodoge-no-mikata.vercel.app
+            --indexability-state-output /tmp/current-indexability/indexability.json
+          )
+          if [ "${{ steps.previous_indexability.outputs.found }}" = "true" ]; then
+            args+=(--previous-indexability-state /tmp/previous-indexability/indexability.json)
+          fi
+          python backend/app/scripts/verify_production_contract.py "${args[@]}" | tee /tmp/production-contract.txt
+          {
+            echo "### Production search indexability"
+            echo '```text'
+            cat /tmp/production-contract.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Save verified production indexability state
+        if: >-
+          steps.budget.outputs.state == 'current' ||
+          steps.git_verification.outcome == 'success' ||
+          steps.push_fallback.outputs.deployed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-indexability
+          path: /tmp/current-indexability/indexability.json
+          if-no-files-found: error
+          retention-days: 90
       - name: Notify IndexNow after verified production release
         if: >-
           steps.budget.outputs.state == 'current' ||
@@ -220,8 +268,49 @@ jobs:
           --team-id "${VERCEL_ORG_ID}"
           --timeout-seconds 180
           --poll-seconds 5
+      - name: Download previous production indexability state
+        id: previous_indexability
+        if: steps.budget.outputs.state == 'current' || steps.catchup.outputs.deployed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/previous-indexability
+          artifact_id="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" --jq '.artifacts[] | select(.name == "production-indexability" and (.expired | not)) | [.created_at, (.id | tostring)] | @tsv' | sort -r | head -n 1 | cut -f 2)"
+          if [ -z "$artifact_id" ]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "No previous verified production indexability artifact; this run establishes the baseline and reports the comparison as UNVERIFIED." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > /tmp/previous-indexability.zip
+          unzip -q /tmp/previous-indexability.zip -d /tmp/previous-indexability
+          test -f /tmp/previous-indexability/indexability.json
+          echo "found=true" >> "$GITHUB_OUTPUT"
       - name: Verify Mechanical DNA production contract
         if: steps.budget.outputs.state == 'current' || steps.catchup.outputs.deployed == 'true'
-        run: >-
-          python backend/app/scripts/verify_production_contract.py
-          --base-url https://bodoge-no-mikata.vercel.app
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            --base-url https://bodoge-no-mikata.vercel.app
+            --indexability-state-output /tmp/current-indexability/indexability.json
+          )
+          if [ "${{ steps.previous_indexability.outputs.found }}" = "true" ]; then
+            args+=(--previous-indexability-state /tmp/previous-indexability/indexability.json)
+          fi
+          python backend/app/scripts/verify_production_contract.py "${args[@]}" | tee /tmp/production-contract.txt
+          {
+            echo "### Production search indexability"
+            echo '```text'
+            cat /tmp/production-contract.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Save verified production indexability state
+        if: steps.budget.outputs.state == 'current' || steps.catchup.outputs.deployed == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-indexability
+          path: /tmp/current-indexability/indexability.json
+          if-no-files-found: error
+          retention-days: 90

--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import xml.etree.ElementTree as ET
 from collections import Counter
+from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -14,6 +15,7 @@ PUBLIC_GAMES_PAGE_SIZE = 100
 SITEMAP_PATH = "/sitemap.xml"
 MISSING_GAME_PATH = "/games/this-game-does-not-exist"
 SITEMAP_NS = {"sm": "http://www.sitemaps.org/schemas/sitemap/0.9"}
+INDEXABILITY_STATE_VERSION = 1
 
 
 def validate_mechanical_dna_payload(payload: Any) -> int:
@@ -52,6 +54,58 @@ def indexability_reasons(game: dict[str, Any]) -> tuple[str, ...]:
     if game.get("content_review_status") != "human_reviewed":
         reasons.append("content_not_human_reviewed")
     return tuple(reasons)
+
+
+def indexable_slugs(games: list[dict[str, Any]]) -> list[str]:
+    slugs: list[str] = []
+    for game in games:
+        slug = str(game.get("slug") or "").strip()
+        if slug and not indexability_reasons(game):
+            slugs.append(slug)
+    return sorted(set(slugs))
+
+
+def load_indexability_state(path: Path) -> set[str]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("indexability state must be a JSON object")
+    if set(payload) != {"version", "indexable_slugs"}:
+        raise ValueError("indexability state must contain only version and indexable_slugs")
+    if payload.get("version") != INDEXABILITY_STATE_VERSION:
+        raise ValueError(
+            "unsupported indexability state version: "
+            f"{payload.get('version')!r}; expected {INDEXABILITY_STATE_VERSION}"
+        )
+    slugs = payload.get("indexable_slugs")
+    if not isinstance(slugs, list) or not all(isinstance(slug, str) and slug.strip() for slug in slugs):
+        raise ValueError("indexability state indexable_slugs must be a non-empty-string JSON array")
+    if len(slugs) != len(set(slugs)):
+        raise ValueError("indexability state indexable_slugs must not contain duplicates")
+    return set(slugs)
+
+
+def write_indexability_state(path: Path, slugs: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"version": INDEXABILITY_STATE_VERSION, "indexable_slugs": sorted(slugs)}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def compare_indexability_state(current_slugs: list[str], previous_path: Path | None) -> dict[str, Any]:
+    if previous_path is None:
+        return {
+            "comparison_status": "UNVERIFIED",
+            "newly_promoted": None,
+            "newly_demoted": None,
+        }
+    if not previous_path.is_file():
+        raise ValueError(f"previous indexability state does not exist: {previous_path}")
+    previous_slugs = load_indexability_state(previous_path)
+    current = set(current_slugs)
+    return {
+        "comparison_status": "verified",
+        "newly_promoted": sorted(current - previous_slugs),
+        "newly_demoted": sorted(previous_slugs - current),
+    }
 
 
 def build_indexability_report(games: list[dict[str, Any]], sitemap_urls: set[str], base_url: str) -> dict[str, Any]:
@@ -171,7 +225,7 @@ def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0)
     return status_code
 
 
-def verify_search_indexability(base_url: str, timeout_seconds: float = 20.0) -> dict[str, Any]:
+def verify_search_indexability(base_url: str, timeout_seconds: float = 20.0) -> tuple[dict[str, Any], list[str]]:
     games = fetch_public_games(base_url, timeout_seconds)
 
     sitemap_status, sitemap_body = _request(base_url, SITEMAP_PATH, timeout_seconds, "application/xml")
@@ -196,7 +250,7 @@ def verify_search_indexability(base_url: str, timeout_seconds: float = 20.0) -> 
     if missing_status != 404:
         raise ValueError(f"missing game must return HTTP 404; received {missing_status}")
     report["missing_game_status"] = missing_status
-    return report
+    return report, indexable_slugs(games)
 
 
 def verify_production(base_url: str, timeout_seconds: float = 20.0) -> int:
@@ -224,11 +278,18 @@ def main() -> None:
         help="Canonical production origin",
     )
     parser.add_argument("--timeout-seconds", type=float, default=20.0)
+    parser.add_argument("--previous-indexability-state", type=Path)
+    parser.add_argument("--indexability-state-output", type=Path)
     args = parser.parse_args()
 
     connection_count = verify_production(args.base_url, args.timeout_seconds)
     auth_status = verify_anonymous_catalog_patch(args.base_url, args.timeout_seconds)
-    indexability = verify_search_indexability(args.base_url, args.timeout_seconds)
+    indexability, current_slugs = verify_search_indexability(args.base_url, args.timeout_seconds)
+    indexability.update(compare_indexability_state(current_slugs, args.previous_indexability_state))
+
+    if args.indexability_state_output is not None:
+        write_indexability_state(args.indexability_state_output, current_slugs)
+
     print(
         "Production API contracts: OK "
         f"(mechanical_dna_connections={connection_count}, anonymous_catalog_patch={auth_status})"


### PR DESCRIPTION
Issue #201 の残件を完了します。

Before:
- production の検索公開件数と sitemap 一致は検証できるが、直前に検証済みの production と比べて、どのゲームが新しく検索公開されたか／外れたかを判定できない。
- Issue #201 がこの残件を満たさないまま closed になっていたため reopen 済み。

After:
- 既存 `verify_production_contract.py` が検索公開 slug 集合をJSONで保存する。
- 直前の検証済みproduction artifactがある場合だけ `newly_promoted` / `newly_demoted` を算出する。
- 過去状態がない初回は `UNVERIFIED` と明示し、空集合を過去状態として捏造しない。
- 既存 `Vercel Deployment` workflowだけを使い、GitHub Actions artifactから直前状態を取得する。新workflow・DB・独自サービスは追加しない。
- production contract成功後だけ現在状態をartifactとして保存する。

成功条件:
1. exact-head CIが成功する。
2. merge後のproduction releaseでbaseline artifactを保存する。
3. 同じproductionを次回検証したとき `newly_promoted=[]` / `newly_demoted=[]` を実測する。
4. canonical productionのsitemapと公開可能ゲーム集合の一致を維持する。

Closes #201