### PR TITLE
RuleSetがないゲームでcurated guideを表示しない

### DIFF
--- a/.github/workflows/test-catalog-integrity.yml
+++ b/.github/workflows/test-catalog-integrity.yml
@@ -7,6 +7,7 @@ on:
       - "backend/app/models/**"
       - "backend/app/routers/auth.py"
       - "backend/app/routers/games.py"
+      - "backend/app/scripts/curated_game_fast_path_v2.py"
       - "backend/app/scripts/verify_production_contract.py"
       - "backend/app/services/catalog_access.py"
       - "backend/app/services/game_service.py"
@@ -16,6 +17,7 @@ on:
       - "backend/app/db/migrations/**"
       - "backend/tests/test_auth.py"
       - "backend/tests/test_catalog_trust_contract.py"
+      - "backend/tests/test_curated_game_publish_contract.py"
       - "backend/tests/test_game_identity_conflict_guard.py"
       - "backend/tests/test_games_router.py"
       - "backend/tests/test_identity_duplicate_audit.py"
@@ -38,6 +40,7 @@ on:
       - "backend/app/models/**"
       - "backend/app/routers/auth.py"
       - "backend/app/routers/games.py"
+      - "backend/app/scripts/curated_game_fast_path_v2.py"
       - "backend/app/scripts/verify_production_contract.py"
       - "backend/app/services/catalog_access.py"
       - "backend/app/services/game_service.py"
@@ -47,6 +50,7 @@ on:
       - "backend/app/db/migrations/**"
       - "backend/tests/test_auth.py"
       - "backend/tests/test_catalog_trust_contract.py"
+      - "backend/tests/test_curated_game_publish_contract.py"
       - "backend/tests/test_game_identity_conflict_guard.py"
       - "backend/tests/test_games_router.py"
       - "backend/tests/test_identity_duplicate_audit.py"
@@ -104,6 +108,7 @@ jobs:
           uv run pytest -q
           backend/tests/test_auth.py
           backend/tests/test_catalog_trust_contract.py
+          backend/tests/test_curated_game_publish_contract.py
           backend/tests/test_game_identity_conflict_guard.py
           backend/tests/test_games_router.py
           backend/tests/test_identity_duplicate_audit.py

--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -109,6 +109,7 @@ jobs:
           tests/rule_ask.spec.js
           tests/pili_pili_ruleset_context.spec.js
           tests/directory-source-trust.spec.js
+          tests/ruleset-curated-guide.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/backend/app/scripts/curated_game_fast_path_v2.py
+++ b/backend/app/scripts/curated_game_fast_path_v2.py
@@ -25,6 +25,12 @@ from app.scripts.curated_game_workflow import (
 DEFAULT_BASE_URL = "https://bodoge-no-mikata.vercel.app"
 CURATED_GENERATOR_PATH = REPO_ROOT / "frontend" / "scripts" / "generate-curated-game-artifacts.mjs"
 DEPLOYMENT_MANIFEST_PATH = REPO_ROOT / "frontend" / "public" / "curated-guides-manifest.json"
+LEGACY_RULE_FIELDS = (
+    "rules_content",
+    "setup_summary",
+    "gameplay_summary",
+    "end_game_summary",
+)
 
 
 def resolve_spec_path(game: str) -> Path:
@@ -106,6 +112,14 @@ def preflight_catalog(spec: CuratedGameSpec) -> tuple[Any, IdentityPlan]:
     return client, plan
 
 
+def catalog_write_payload(spec: CuratedGameSpec, work_id: str | None) -> dict[str, Any]:
+    payload = dict(spec.game)
+    for field in LEGACY_RULE_FIELDS:
+        payload[field] = None
+    payload["work_id"] = work_id
+    return payload
+
+
 def write_catalog_with_plan(client: Any, spec: CuratedGameSpec, plan: IdentityPlan) -> dict[str, Any]:
     created_work_id: str | None = None
     work_id = plan.work_id
@@ -127,8 +141,7 @@ def write_catalog_with_plan(client: Any, spec: CuratedGameSpec, plan: IdentityPl
         created_work_id = str(rows[0]["id"])
         work_id = created_work_id
 
-    payload = dict(spec.game)
-    payload["work_id"] = work_id
+    payload = catalog_write_payload(spec, work_id)
 
     try:
         if plan.game_id:

--- a/backend/tests/test_curated_game_publish_contract.py
+++ b/backend/tests/test_curated_game_publish_contract.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from app.scripts.curated_game_fast_path_v2 import LEGACY_RULE_FIELDS, catalog_write_payload
+from app.scripts.curated_game_workflow import load_spec
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKULL_KING = REPO_ROOT / "data" / "curated-games" / "skull-king.json"
+
+
+def test_curated_release_does_not_publish_legacy_rule_fields():
+    spec = load_spec(SKULL_KING)
+
+    payload = catalog_write_payload(spec, "work-1")
+
+    assert payload["work_id"] == "work-1"
+    assert payload["slug"] == "skull-king"
+    assert payload["source_url"] == spec.source.url
+    for field in LEGACY_RULE_FIELDS:
+        assert payload[field] is None

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -122,7 +122,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const identityLabel = IDENTITY_LABELS[game.identity_status] || IDENTITY_LABELS.unverified
   const sourceTrustLabel = SOURCE_TRUST_LABELS[game.source_trust] || SOURCE_TRUST_LABELS.unknown
   const reviewLabel = REVIEW_LABELS[game.content_review_status] || REVIEW_LABELS.unknown
-  const ruleGuide = getCuratedRuleGuide(slug)
+  const ruleGuide = rules ? getCuratedRuleGuide(slug) : null
   const legacyInfographicsSourceUrl = game.infographics_source_url || coachSourceUrl
   const legacyInfographicsVerified = Boolean(
     game.infographics &&

--- a/frontend/tests/ruleset-curated-guide.spec.js
+++ b/frontend/tests/ruleset-curated-guide.spec.js
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+
+async function mockGameApi(page, game) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${game.slug}`) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ game }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('RuleSetが公開されていないゲームではcurated guideを表示しない', async ({ page }) => {
+  await mockGameApi(page, {
+    slug: 'minna-de-ponkotsu-paint',
+    title: 'みんなでぽんこつペイント',
+    title_ja: 'みんなでぽんこつペイント',
+    summary: '公式商品情報に基づくゲーム概要。',
+    rules_content: null,
+    setup_summary: null,
+    gameplay_summary: null,
+    end_game_summary: null,
+    min_players: 2,
+    max_players: 12,
+    play_time: 10,
+    min_age: 6,
+    published_year: 2018,
+    source_url: 'https://hobbyjapan.games/ponkotsu_paint/',
+    source_trust: 'official_publisher',
+    identity_status: 'verified',
+    content_review_status: 'review_required',
+    structured_data: {},
+  })
+
+  await page.goto('/games/minna-de-ponkotsu-paint')
+
+  await expect(page.getByRole('heading', { name: 'みんなでぽんこつペイント' })).toBeVisible()
+  await expect(page.getByText('「みんなでぽんこつペイント」のゲーム概要', { exact: true })).toBeVisible()
+  await expect(page.getByText('30秒でわかる「みんなでぽんこつペイント」', { exact: true })).toHaveCount(0)
+  await expect(page.locator('.quick-rules-panel')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '図で見る', exact: true })).toHaveCount(0)
+})
+
+test('公開RuleSetがあるゲームではcurated guideを維持する', async ({ page }) => {
+  await mockGameApi(page, {
+    slug: 'skull-king',
+    title: 'Skull King',
+    title_ja: 'スカルキング',
+    summary: 'トリックテイキングゲーム。',
+    rules_content: '# スカルキング\n\n公開RuleSetに基づくルール。',
+    setup_summary: null,
+    gameplay_summary: null,
+    end_game_summary: null,
+    min_players: 2,
+    max_players: 8,
+    play_time: 30,
+    min_age: 8,
+    source_url: 'https://www.grandpabecksgames.com/pages/skull-king',
+    source_trust: 'official_publisher',
+    identity_status: 'verified',
+    content_review_status: 'human_reviewed',
+    structured_data: {},
+  })
+
+  await page.goto('/games/skull-king')
+
+  await expect(page.getByText('30秒でわかる「スカルキング」', { exact: true })).toBeVisible()
+  await expect(page.locator('.quick-rules-panel')).toHaveCount(1)
+  await expect(page.getByRole('button', { name: '図で見る', exact: true })).toHaveCount(1)
+})


### PR DESCRIPTION
## ユーザー向け完了条件

一次資料へ結び付いた公開RuleSetがないゲームでは、ブラウザのhydration後もQuickRules・ルールフローを表示しない。一方、公開RuleSetがあるゲームの既存ガイドは維持する。

## 変更

- GamePageは公開APIの`rules_content`が存在する場合だけcurated guideを利用する。
- `minna-de-ponkotsu-paint`相当の`rules_content=null`を使ったPlaywright回帰テストを追加する。
- main releaseで使用するcurated publishは`rules_content`、`setup_summary`、`gameplay_summary`、`end_game_summary`をservice roleでproductionへ再投入せず、明示的に`null`へする。
- curated publishの書込みpayloadを回帰テストする。

## 根拠

ホビージャパン公式商品ページで確認できる範囲と、canonical productionのRuleSet公開可否を分離する。curated guideを第二の公開authorityとして使わない。

Related: #556