### PR TITLE
プレイ時間の正準範囲を一覧・比較に表示する

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,11 @@ function comparisonPlayers(game) {
 }
 
 function comparisonPlayTime(game) {
+  const minimum = game.play_time_min_minutes
+  const maximum = game.play_time_max_minutes
+  if (Number.isFinite(minimum) && minimum > 0 && Number.isFinite(maximum) && maximum >= minimum) {
+    return minimum === maximum ? `${minimum}分` : `${minimum}-${maximum}分`
+  }
   return Number.isFinite(game.play_time) && game.play_time > 0 ? `${game.play_time}分` : '不明'
 }
 
@@ -46,6 +51,13 @@ function comparisonPlayersEvidence(game) {
   const maximum = comparisonFieldEvidence(game, 'max_players', game.max_players)
   if (!minimum || !maximum) return null
   return minimum
+}
+
+function comparisonPlayTimeEvidence(game) {
+  const minimum = comparisonFieldEvidence(game, 'play_time_min_minutes', game.play_time_min_minutes)
+  const maximum = comparisonFieldEvidence(game, 'play_time_max_minutes', game.play_time_max_minutes)
+  if (minimum && maximum) return minimum
+  return comparisonFieldEvidence(game, 'play_time', game.play_time)
 }
 
 function ComparisonEvidence({ evidence, ariaLabel }) {
@@ -309,7 +321,7 @@ function App() {
         <div className="battle-grid">
           {compareList.map((game) => {
             const playersEvidence = comparisonPlayersEvidence(game)
-            const playTimeEvidence = comparisonFieldEvidence(game, 'play_time', game.play_time)
+            const playTimeEvidence = comparisonPlayTimeEvidence(game)
             const mechanicsEvidence = game.metadata_evidence?.['structured_data.mechanics']?.status === 'supported'
               ? game.metadata_evidence['structured_data.mechanics']
               : null
@@ -483,7 +495,7 @@ function App() {
                       <div className="asset-meta">
                         {trustLabel && <span className="meta-item">{trustLabel}</span>}
                         {game.min_players && <span className="meta-item">👥 {game.min_players}{game.max_players && game.max_players !== game.min_players ? `-${game.max_players}` : ''}</span>}
-                        {game.play_time && <span className="meta-item">⏳ {game.play_time}分</span>}
+                        <span className="meta-item">⏳ {comparisonPlayTime(game)}</span>
                         {game.published_year && <span className="meta-item">📅 {game.published_year}</span>}
                       </div>
                       <div className="asset-summary">{game.summary || game.description}</div>


### PR DESCRIPTION
Issue #242 の修正です。

## 変更
- `play_time_min_minutes` / `play_time_max_minutes` が両方有効な場合は、その範囲を表示します。
- 範囲が未登録の場合だけ既存の `play_time` を使います。
- どちらも無い場合は `不明` と表示し、推測値は使いません。
- 比較画面の根拠表示も、範囲の両端に対応する `metadata_evidence` が揃った場合だけ「根拠あり」とします。

## 利用者向け完了条件
Skull King が一覧・比較で公式の 30-45分として表示され、未登録ゲームは推測せず `不明` のままになること。

## 根拠
Grandpa Beck's Games公式商品ページ: https://www.grandpabecksgames.com/products/copy-of-skull-king%C2%AE

Closes #242