### PR TITLE
本番ゲーム監査の一覧取得を復旧する

### DIFF
--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -140,6 +140,9 @@ class GameService:
         rows = await supabase.search(query)
         return [row for row in rows if not should_hide_game_from_search(str(row.get("slug") or ""))]
 
+    async def list_recent_games(self, limit: int = 100, offset: int = 0) -> dict[str, Any]:
+        return await supabase.list_recent(limit=limit, offset=offset)
+
     async def get_game_by_slug(self, slug: str) -> dict[str, Any] | None:
         return await supabase.get_by_slug(slug)
 


### PR DESCRIPTION
## 変更前
定期のVRChat readiness production auditが `GameService.list_recent_games` を呼ぶ一方、current `GameService` から同methodが削除されており、`AttributeError` で全件監査が失敗していました。

## 変更後
既存の正準DB provider `app.core.supabase.list_recent` へ委譲する `GameService.list_recent_games` を復旧します。新しいデータ取得経路・fallback・retryは追加しません。

## 成功条件
mainと同じproduction環境で、全canonical gameのread-only auditが `AttributeError` なしで最後まで完了し、machine-readable artifactを出力できること。

## 検証
- exact-head CI
- VRChat readiness audit contract tests
- merge後main read-back
- 次回production read-only auditの実行結果を確認