### PR TITLE
本番ゲーム監査の依存APIをCIで固定する

### DIFF
--- a/.github/workflows/test-vrchat-readiness.yml
+++ b/.github/workflows/test-vrchat-readiness.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "backend/app/models/vrchat_readiness.py"
+      - "backend/app/services/game_service.py"
       - "backend/app/services/vrchat_readiness_audit.py"
       - "backend/app/services/vrchat_readiness_policy.py"
       - "backend/tests/test_vrchat_readiness.py"
@@ -17,6 +18,7 @@ on:
       - main
     paths:
       - "backend/app/models/vrchat_readiness.py"
+      - "backend/app/services/game_service.py"
       - "backend/app/services/vrchat_readiness_audit.py"
       - "backend/app/services/vrchat_readiness_policy.py"
       - "backend/tests/test_vrchat_readiness.py"
@@ -44,6 +46,17 @@ jobs:
 
       - name: Install Python dependencies
         run: uv sync --frozen --dev
+
+      - name: Verify production game catalog interface
+        env:
+          PYTHONPATH: backend
+        run: |
+          uv run python - <<'PY'
+          from app.services.game_service import GameService
+
+          if not callable(getattr(GameService, "list_recent_games", None)):
+              raise SystemExit("VRChat readiness audit requires GameService.list_recent_games")
+          PY
 
       - name: Compile readiness modules
         run: >-


### PR DESCRIPTION
## 変更前
本番の全ゲーム監査は `GameService.list_recent_games` に依存していましたが、`game_service.py` の変更ではこのworkflowが起動せず、methodが削除されても通常の契約testで検知できませんでした。

## 変更後
既存の `VRChat readiness audit` だけを更新します。

- `backend/app/services/game_service.py` の変更で同workflowを起動する
- contract test段階で `GameService.list_recent_games` が利用可能か明示的に検証する

新しいworkflowや別の監査経路は追加しません。

## 成功条件
`GameService.list_recent_games` が将来削除・改名された場合、production定期監査まで待たずPRのCIで失敗すること。

## 検証
exact-head CI → merge → main pushで同workflow起動 → production read-only auditまで確認します。