### PR TITLE
Skull King旧RuleSetをDB制約に沿って履歴化する

### DIFF
--- a/backend/app/db/migrations/121_deactivate_superseded_skull_king_ruleset.sql
+++ b/backend/app/db/migrations/121_deactivate_superseded_skull_king_ruleset.sql
@@ -38,6 +38,7 @@ BEGIN
   UPDATE public.rule_sets
   SET
     is_active = false,
+    status = 'superseded',
     updated_at = now()
   WHERE game_id = v_game_id
     AND id <> v_current_ruleset_id
@@ -50,6 +51,7 @@ BEGIN
   UPDATE public.rule_sets
   SET
     is_active = true,
+    status = 'active',
     updated_at = now()
   WHERE id = v_current_ruleset_id;
 
@@ -58,6 +60,7 @@ BEGIN
   FROM public.rule_sets
   WHERE game_id = v_game_id
     AND is_active
+    AND status = 'active'
     AND language_code = 'en'
     AND edition_label = 'Grandpa Beck''s Games current edition'
     AND platform = 'physical'


### PR DESCRIPTION
## 変更前
#567 の migration は旧RuleSetの `is_active` だけを false にするため、production の `rule_sets_status_activity_check` に違反して適用できませんでした。transaction は rollback され、production は active RuleSet 2件のままです。

## 変更後
旧RuleSetを `status='superseded'` と `is_active=false` に同時更新し、現行RuleSetを `status='active'` と `is_active=true` に固定します。既存schemaの状態整合性を維持します。

## 成功条件
Skull Kingの現行英語版・physical・通常RuleSetがproductionで1件だけactiveになり、旧RuleSetは履歴として残ること。

## 検証
exact-head CI → merge → main read-back → repositoryの同一migrationをproductionへ適用 → production DB直接read-back → 全ゲームread-only auditで `multiple_active_rulesets` が消えることを確認します。