### PR TITLE
READMEの公開URLをcanonical productionへ統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://bodoge-no-mikata.vercel.app/
   ### **The Infinite Intelligence for Board Gamers**
   **「世界中のボードゲームのルールを、瞬時に、正確に、その手に」。**
 
-  [![Vercel](https://img.shields.io/badge/Vercel-Deployed-000000?style=for-the-badge&logo=vercel&logoColor=white)](https://rule-scribe-games.vercel.app)
+  [![Vercel](https://img.shields.io/badge/Vercel-Deployed-000000?style=for-the-badge&logo=vercel&logoColor=white)](https://bodoge-no-mikata.vercel.app/)
   [![License: MIT](https://img.shields.io/badge/License-MIT-005CB9?style=for-the-badge&logo=github)](https://opensource.org/licenses/MIT)
   [![Python](https://img.shields.io/badge/Python-3.11-3776AB?style=for-the-badge&logo=python&logoColor=white)](https://www.python.org/)
   [![React](https://img.shields.io/badge/React-18.x-61DAFB?style=for-the-badge&logo=react&logoColor=black)](https://reactjs.org/)


### PR DESCRIPTION
## 変更
README内のVercel badgeのリンク先を `https://bodoge-no-mikata.vercel.app/` へ統一します。

## 理由
README冒頭のcanonical production URLと同じ公開入口だけを案内し、同一deploymentへの別aliasを人間向け導線として残さないためです。

## 変更範囲
- README.md のリンク1件のみ
- runtime / deployment設定 / API / data は変更しません

Closes #565