### PR TITLE
GamePageの表示位置をURL fragmentで共有できるようにする

### DIFF
--- a/.github/workflows/frontend-pr-build.yml
+++ b/.github/workflows/frontend-pr-build.yml
@@ -24,3 +24,9 @@ jobs:
       - name: Build without production secrets
         working-directory: frontend
         run: npm run build
+      - name: Install Chromium for GamePage section navigation
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+      - name: Verify GamePage section navigation
+        working-directory: frontend
+        run: npx playwright test tests/game_section_navigation.spec.js --project=chromium

--- a/.github/workflows/frontend-pr-build.yml
+++ b/.github/workflows/frontend-pr-build.yml
@@ -24,9 +24,3 @@ jobs:
       - name: Build without production secrets
         working-directory: frontend
         run: npm run build
-      - name: Install Chromium for GamePage section navigation
-        working-directory: frontend
-        run: npx playwright install --with-deps chromium
-      - name: Verify GamePage section navigation
-        working-directory: frontend
-        run: npx playwright test tests/game_section_navigation.spec.js --project=chromium

--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -101,6 +101,7 @@ jobs:
           tests/navigation.spec.js
           tests/performance.spec.js
           tests/game_layout.spec.js
+          tests/game_section_navigation.spec.js
           tests/mobile_game_scroll.spec.js
           tests/auth.spec.js
           tests/generated-game-images.spec.js

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -30,6 +30,19 @@ const REVIEW_LABELS = {
   unknown: 'REVIEW UNKNOWN',
 }
 
+const TAB_HASHES = {
+  rules: '#rules',
+  coach: '#setup',
+  strategy: '#strategy',
+  reviews: '#reviews',
+  graph: '#connections',
+  infographics: '#visual',
+}
+
+const HASH_TABS = Object.fromEntries(
+  Object.entries(TAB_HASHES).map(([tab, hash]) => [hash, tab]),
+)
+
 function formatPlayTime(game) {
   const min = game.play_time_min_minutes
   const max = game.play_time_max_minutes
@@ -37,6 +50,14 @@ function formatPlayTime(game) {
   if (min != null) return `${min}m+`
   if (max != null) return `≤${max}m`
   return game.play_time != null ? `${game.play_time}m` : 'N/A'
+}
+
+function isTabAvailable(tab, { hasCoachSummary, hasStrategy, hasReviews, hasInfographics }) {
+  if (tab === 'coach') return hasCoachSummary
+  if (tab === 'strategy') return hasStrategy
+  if (tab === 'reviews') return hasReviews
+  if (tab === 'infographics') return hasInfographics
+  return tab === 'rules' || tab === 'graph'
 }
 
 export default function GamePage({ slug: propSlug, initialGame }) {
@@ -52,6 +73,19 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const [connectionsError, setConnectionsError] = useState(false)
 
   const BASE_URL = 'https://bodoge-no-mikata.vercel.app'
+  const structuredData = game?.structured_data || {}
+  const infographicsSourceUrl = game?.infographics_source_url || game?.source_url || null
+  const hasInfographics = Boolean(
+    game?.infographics &&
+    game.infographics_reviewed === true &&
+    infographicsSourceUrl,
+  )
+  const hasCoachSummary = Boolean(
+    game?.setup_summary || game?.gameplay_summary || game?.end_game_summary,
+  )
+  const hasStrategy = Boolean(structuredData.strategy_analysis)
+  const hasReviews = Boolean(structuredData.persona_reviews?.length)
+  const tabAvailability = { hasCoachSummary, hasStrategy, hasReviews, hasInfographics }
 
   useEffect(() => {
     const fetchData = async () => {
@@ -72,6 +106,27 @@ export default function GamePage({ slug: propSlug, initialGame }) {
     }
     fetchData()
   }, [slug, initialGame])
+
+  useEffect(() => {
+    if (!game || typeof window === 'undefined') return undefined
+
+    const syncFromLocation = () => {
+      const requestedTab = HASH_TABS[window.location.hash]
+      if (requestedTab && isTabAvailable(requestedTab, tabAvailability)) {
+        setActiveTab(requestedTab)
+        return
+      }
+      setActiveTab('rules')
+    }
+
+    syncFromLocation()
+    window.addEventListener('popstate', syncFromLocation)
+    window.addEventListener('hashchange', syncFromLocation)
+    return () => {
+      window.removeEventListener('popstate', syncFromLocation)
+      window.removeEventListener('hashchange', syncFromLocation)
+    }
+  }, [game, hasCoachSummary, hasStrategy, hasReviews, hasInfographics])
 
   useEffect(() => {
     if (activeTab !== 'graph') return undefined
@@ -95,6 +150,16 @@ export default function GamePage({ slug: propSlug, initialGame }) {
 
     return () => { cancelled = true }
   }, [activeTab, slug])
+
+  const navigateToTab = (tab) => {
+    if (!isTabAvailable(tab, tabAvailability)) return
+    setActiveTab(tab)
+
+    if (typeof window === 'undefined') return
+    const hash = TAB_HASHES[tab]
+    if (!hash || window.location.hash === hash) return
+    window.history.pushState(null, '', `${window.location.pathname}${window.location.search}${hash}`)
+  }
 
   if (loading) {
     return <div className="page-state page-state--loading" role="status">ARCHIVE LOADING...</div>
@@ -123,10 +188,6 @@ export default function GamePage({ slug: propSlug, initialGame }) {
     game.infographics &&
     game.infographics_reviewed === true &&
     legacyInfographicsSourceUrl,
-  )
-  const hasInfographics = legacyInfographicsVerified
-  const hasCoachSummary = Boolean(
-    game.setup_summary || game.gameplay_summary || game.end_game_summary,
   )
 
   const pageTitle = `「${title}」のルール${sd.strategy_analysis ? '・戦略' : ''}・インスト要約 | ボドゲのミカタ`
@@ -192,25 +253,29 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
 
           <div className="rules-tabs" role="group" aria-label="ゲーム詳細表示">
-            <button type="button" aria-pressed={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => setActiveTab('rules')}>
+            <button type="button" aria-pressed={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => navigateToTab('rules')}>
               詳しいルール
             </button>
             {hasCoachSummary && (
-              <button type="button" aria-pressed={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => setActiveTab('coach')}>
+              <button type="button" aria-pressed={activeTab === 'coach'} className={activeTab === 'coach' ? 'active' : ''} onClick={() => navigateToTab('coach')}>
                 準備・流れ・終了
               </button>
             )}
-            <button type="button" aria-pressed={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => setActiveTab('strategy')}>
-              戦略
-            </button>
-            <button type="button" aria-pressed={activeTab === 'reviews'} className={activeTab === 'reviews' ? 'active' : ''} onClick={() => setActiveTab('reviews')}>
-              レビュー
-            </button>
-            <button type="button" aria-pressed={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => setActiveTab('graph')}>
+            {hasStrategy && (
+              <button type="button" aria-pressed={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => navigateToTab('strategy')}>
+                戦略
+              </button>
+            )}
+            {hasReviews && (
+              <button type="button" aria-pressed={activeTab === 'reviews'} className={activeTab === 'reviews' ? 'active' : ''} onClick={() => navigateToTab('reviews')}>
+                レビュー
+              </button>
+            )}
+            <button type="button" aria-pressed={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => navigateToTab('graph')}>
               関連ゲーム
             </button>
             {hasInfographics && (
-              <button type="button" aria-pressed={activeTab === 'infographics'} className={activeTab === 'infographics' ? 'active' : ''} onClick={() => setActiveTab('infographics')}>
+              <button type="button" aria-pressed={activeTab === 'infographics'} className={activeTab === 'infographics' ? 'active' : ''} onClick={() => navigateToTab('infographics')}>
                 図で見る
               </button>
             )}

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -188,7 +188,7 @@ test('preparation flow only appears when at least one game-specific summary exis
   await expect(page.getByText(bigShot.end_game_summary)).toBeVisible()
 })
 
-test('empty strategy and review states do not suggest unavailable regeneration actions', async ({ page }) => {
+test('empty strategy and review states are not exposed as detail destinations', async ({ page }) => {
   const withoutOptionalContent = {
     ...bigShot,
     slug: 'empty-optional-content',
@@ -202,12 +202,10 @@ test('empty strategy and review states do not suggest unavailable regeneration a
   await mockGameApi(page, withoutOptionalContent)
   await page.goto('/games/empty-optional-content')
 
-  await page.getByRole('button', { name: '戦略', exact: true }).click()
-  await expect(page.getByText('戦略解説はまだ登録されていません。', { exact: true })).toBeVisible()
-  await expect(page.getByText(/再生成してください/)).toHaveCount(0)
-
-  await page.getByRole('button', { name: 'レビュー', exact: true }).click()
-  await expect(page.getByText('レビューはまだ登録されていません。', { exact: true })).toBeVisible()
+  await expect(page.getByRole('button', { name: '戦略', exact: true })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'レビュー', exact: true })).toHaveCount(0)
+  await expect(page.getByText('戦略解説はまだ登録されていません。', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('レビューはまだ登録されていません。', { exact: true })).toHaveCount(0)
   await expect(page.getByText(/再生成してください/)).toHaveCount(0)
 })
 

--- a/frontend/tests/game_section_navigation.spec.js
+++ b/frontend/tests/game_section_navigation.spec.js
@@ -1,0 +1,123 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 76,
+  slug: 'big-shot',
+  title: 'Big Shot',
+  title_ja: 'ビッグショット',
+  min_players: 2,
+  max_players: 4,
+  play_time: 45,
+  min_age: 10,
+  published_year: 2001,
+  summary: '土地を競り落とし、資金を管理しながら得点を競うオークションゲーム。',
+  setup_summary: '各プレイヤーは開始時の資金を受け取ります。',
+  gameplay_summary: '競りで土地を獲得し、資金配分を管理します。',
+  end_game_summary: '全区画の競りが終わったら得点を計算します。',
+  source_url: 'https://example.com/big-shot-source',
+  source_trust: 'third_party',
+  content_review_status: 'review_required',
+  rules_content: '# Big Shot Rules\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。',
+  structured_data: {
+    strategy_analysis: '## Strategy\n\n資金効率を優先します。',
+    persona_reviews: [{ persona: '慎重派', rating: 8, review_text: '資金管理が重要です。' }],
+    keywords: [],
+  },
+}
+
+async function mockGameApi(page, value = game) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${value.slug}`) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game: value }) })
+      return
+    }
+    if (url.pathname === `/api/games/${value.slug}/connections`) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'available', connections: [], algorithm_version: 'test' }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('GamePageのsection fragmentをdirect loadとBack/Forwardで復元する', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#setup')
+
+  const rules = page.getByRole('button', { name: '詳しいルール', exact: true })
+  const setup = page.getByRole('button', { name: '準備・流れ・終了', exact: true })
+
+  await expect(setup).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByText(game.setup_summary)).toBeVisible()
+
+  await rules.click()
+  await expect(page).toHaveURL(/#rules$/)
+  await expect(rules).toHaveAttribute('aria-pressed', 'true')
+
+  await setup.click()
+  await expect(page).toHaveURL(/#setup$/)
+  await expect(setup).toHaveAttribute('aria-pressed', 'true')
+
+  await page.goBack()
+  await expect(page).toHaveURL(/#rules$/)
+  await expect(rules).toHaveAttribute('aria-pressed', 'true')
+
+  await page.goForward()
+  await expect(page).toHaveURL(/#setup$/)
+  await expect(setup).toHaveAttribute('aria-pressed', 'true')
+})
+
+test('unknown fragmentと存在しないsectionは詳しいルールへ戻す', async ({ page }) => {
+  const withoutOptionalSections = {
+    ...game,
+    slug: 'minimal-game',
+    setup_summary: null,
+    gameplay_summary: null,
+    end_game_summary: null,
+    structured_data: {
+      ...game.structured_data,
+      strategy_analysis: null,
+      persona_reviews: [],
+    },
+  }
+  await mockGameApi(page, withoutOptionalSections)
+
+  await page.goto('/games/minimal-game#strategy')
+  await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByRole('button', { name: '戦略', exact: true })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'レビュー', exact: true })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '準備・流れ・終了', exact: true })).toHaveCount(0)
+
+  await page.goto('/games/minimal-game#obsolete')
+  await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toHaveAttribute('aria-pressed', 'true')
+})
+
+test('connections fragmentから関連ゲーム取得を開始する', async ({ page }) => {
+  let connectionRequests = 0
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/big-shot/connections') {
+      connectionRequests += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ status: 'available', connections: [], algorithm_version: 'test' }),
+      })
+      return
+    }
+    if (url.pathname === '/api/games/big-shot') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+
+  await page.goto('/games/big-shot#connections')
+  await expect(page.getByRole('button', { name: '関連ゲーム', exact: true })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByText('正準Concept上の関連ゲームはまだ登録されていません。')).toBeVisible()
+  expect(connectionRequests).toBe(1)
+})

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -134,7 +134,7 @@ async function expectLightSurface(locator, label) {
   expect(contrast, `${label} contrast ${contrast.toFixed(2)} must remain readable`).toBeGreaterThanOrEqual(4.5)
 }
 
-test('every game-detail view avoids legacy dark surfaces', async ({ page }, testInfo) => {
+test('every available game-detail view avoids legacy dark surfaces', async ({ page }, testInfo) => {
   await mockApi(page)
   await page.goto('/games/palette-audit')
   await expect(page.getByRole('heading', { name: '配色監査' })).toBeVisible()
@@ -146,15 +146,12 @@ test('every game-detail view avoids legacy dark surfaces', async ({ page }, test
     await expectLightSurface(coachSteps.nth(index), `coach step ${index + 1}`)
   }
 
-  await page.getByRole('button', { name: '戦略', exact: true }).click()
-  await expectLightSurface(page.locator('.game-empty-state'), 'strategy empty state')
-
-  await page.getByRole('button', { name: 'レビュー', exact: true }).click()
-  await expectLightSurface(page.locator('.game-empty-state'), 'review empty state')
-  await page.screenshot({ path: testInfo.outputPath('review-light-state.png'), fullPage: true, animations: 'disabled' })
+  await expect(page.getByRole('button', { name: '戦略', exact: true })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'レビュー', exact: true })).toHaveCount(0)
 
   await page.getByRole('button', { name: '関連ゲーム', exact: true }).click()
   await expectLightSurface(page.locator('.graph-perspective .game-empty-state'), 'related games empty state')
+  await page.screenshot({ path: testInfo.outputPath('related-games-light-state.png'), fullPage: true, animations: 'disabled' })
 
   const legacyDark = await page.locator('.game-detail-content').evaluate((root) => {
     const visible = [...root.querySelectorAll('*')].filter((element) => {


### PR DESCRIPTION
#193 の未完了項目のうち、表示切替のstable fragment / history同期を実装します。

観測可能な成功条件:
- `/games/<slug>#setup` を直接開くと「準備・流れ・終了」が開く
- 表示切替で `#rules/#setup/#strategy/#reviews/#connections/#visual` がURLに残る
- browser Back / Forwardで表示が復元される
- 存在しない戦略・レビュー・準備はnavigationに出さず、そのfragmentを開いても空画面にしない
- `#connections` direct loadで既存connections API取得が開始される

変更:
- GamePageの内部state名を公開URLに出さず、表示名に対応するfragment mappingを1箇所に定義
- `history.pushState` と `popstate/hashchange` を使い、既存React Routerやcanonical URLを増やさず同期
- 以前の#193作業意図どおり、内容がない戦略・レビューをprimary navigationから除外
- Playwright回帰テストを既存 `UI UX regression` に追加

新しいrule truth、schema、API、dependency、fallback、workflowは追加しません。

#193全体は閉じません。ルール本文内のstable section destinationとmobile local navigationは残件です。