### PR TITLE
詳細ルール見出しへ直接移動できるようにする

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -93,7 +93,7 @@ function decodedHash() {
   }
 }
 
-export default function RuleMarkdown({ markdown = '' }) {
+export function RuleMarkdown({ markdown = '' }) {
   const sections = getRuleSections(markdown)
   const headingComponents = createHeadingComponents()
 
@@ -139,3 +139,5 @@ export default function RuleMarkdown({ markdown = '' }) {
     </>
   )
 }
+
+export default RuleMarkdown

--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -24,7 +24,7 @@ function sectionId(label, occurrence = 1) {
   return occurrence === 1 ? base : `${base}-${occurrence}`
 }
 
-export function getRuleSections(markdown = '') {
+function getRuleSections(markdown = '') {
   const occurrences = new Map()
   const sections = []
 
@@ -93,7 +93,7 @@ function decodedHash() {
   }
 }
 
-export function RuleMarkdown({ markdown = '' }) {
+function RuleMarkdown({ markdown = '' }) {
   const sections = getRuleSections(markdown)
   const headingComponents = createHeadingComponents()
 

--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -28,13 +28,13 @@ function getRuleSections(markdown = '') {
   const occurrences = new Map()
   const sections = []
 
-  for (const line of markdown.split('\n')) {
+  markdown.split('\n').forEach((line, index) => {
     const match = /^(#{2,4})\s+(.+?)\s*#*\s*$/.exec(line)
-    if (!match) continue
+    if (!match) return
 
     const level = match[1].length
     const label = headingLabel(match[2])
-    if (!label) continue
+    if (!label) return
 
     const key = `${level}:${label.normalize('NFKC').toLowerCase()}`
     const occurrence = (occurrences.get(key) || 0) + 1
@@ -44,33 +44,23 @@ function getRuleSections(markdown = '') {
       id: sectionId(label, occurrence),
       label,
       level,
+      line: index + 1,
     })
-  }
+  })
 
   return sections
 }
 
-function textFromChildren(children) {
-  if (typeof children === 'string' || typeof children === 'number') return String(children)
-  if (Array.isArray(children)) return children.map(textFromChildren).join('')
-  if (children?.props?.children != null) return textFromChildren(children.props.children)
-  return ''
-}
-
-function createHeadingComponents() {
-  const occurrences = new Map()
-
+function createHeadingComponents(sections) {
   const renderHeading = (level) => {
     const Tag = `h${level}`
-    return function RuleHeading({ children }) {
-      const label = textFromChildren(children).trim()
-      const key = `${level}:${label.normalize('NFKC').toLowerCase()}`
-      const occurrence = (occurrences.get(key) || 0) + 1
-      occurrences.set(key, occurrence)
-      const id = sectionId(label, occurrence)
+    return function RuleHeading({ children, node }) {
+      const line = node?.position?.start?.line
+      const section = sections.find((item) => item.level === level && item.line === line)
+      const id = section?.id
 
       return (
-        <Tag id={id} tabIndex={-1} style={{ scrollMarginTop: '1rem' }}>
+        <Tag id={id} tabIndex={id ? -1 : undefined} style={id ? { scrollMarginTop: '1rem' } : undefined}>
           {children}
         </Tag>
       )
@@ -95,7 +85,7 @@ function decodedHash() {
 
 function RuleMarkdown({ markdown = '' }) {
   const sections = getRuleSections(markdown)
-  const headingComponents = createHeadingComponents()
+  const headingComponents = createHeadingComponents(sections)
 
   useEffect(() => {
     const focusCurrentSection = () => {

--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -1,0 +1,141 @@
+import { useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+function headingLabel(markdownText) {
+  return markdownText
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_~]/g, '')
+    .trim()
+}
+
+function sectionSlug(label) {
+  return label
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[\s/]+/g, '-')
+    .replace(/[^\p{L}\p{N}_-]+/gu, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'section'
+}
+
+function sectionId(label, occurrence = 1) {
+  const base = `rule-${sectionSlug(label)}`
+  return occurrence === 1 ? base : `${base}-${occurrence}`
+}
+
+export function getRuleSections(markdown = '') {
+  const occurrences = new Map()
+  const sections = []
+
+  for (const line of markdown.split('\n')) {
+    const match = /^(#{2,4})\s+(.+?)\s*#*\s*$/.exec(line)
+    if (!match) continue
+
+    const level = match[1].length
+    const label = headingLabel(match[2])
+    if (!label) continue
+
+    const key = `${level}:${label.normalize('NFKC').toLowerCase()}`
+    const occurrence = (occurrences.get(key) || 0) + 1
+    occurrences.set(key, occurrence)
+
+    sections.push({
+      id: sectionId(label, occurrence),
+      label,
+      level,
+    })
+  }
+
+  return sections
+}
+
+function textFromChildren(children) {
+  if (typeof children === 'string' || typeof children === 'number') return String(children)
+  if (Array.isArray(children)) return children.map(textFromChildren).join('')
+  if (children?.props?.children != null) return textFromChildren(children.props.children)
+  return ''
+}
+
+function createHeadingComponents() {
+  const occurrences = new Map()
+
+  const renderHeading = (level) => {
+    const Tag = `h${level}`
+    return function RuleHeading({ children }) {
+      const label = textFromChildren(children).trim()
+      const key = `${level}:${label.normalize('NFKC').toLowerCase()}`
+      const occurrence = (occurrences.get(key) || 0) + 1
+      occurrences.set(key, occurrence)
+      const id = sectionId(label, occurrence)
+
+      return (
+        <Tag id={id} tabIndex={-1} style={{ scrollMarginTop: '1rem' }}>
+          {children}
+        </Tag>
+      )
+    }
+  }
+
+  return {
+    h2: renderHeading(2),
+    h3: renderHeading(3),
+    h4: renderHeading(4),
+  }
+}
+
+function decodedHash() {
+  if (typeof window === 'undefined') return ''
+  try {
+    return decodeURIComponent(window.location.hash.slice(1))
+  } catch {
+    return ''
+  }
+}
+
+export default function RuleMarkdown({ markdown = '' }) {
+  const sections = getRuleSections(markdown)
+  const headingComponents = createHeadingComponents()
+
+  useEffect(() => {
+    const focusCurrentSection = () => {
+      const id = decodedHash()
+      if (!id.startsWith('rule-')) return
+
+      window.requestAnimationFrame(() => {
+        const target = document.getElementById(id)
+        if (!target) return
+        target.scrollIntoView({ block: 'start' })
+        target.focus({ preventScroll: true })
+      })
+    }
+
+    focusCurrentSection()
+    window.addEventListener('hashchange', focusCurrentSection)
+    window.addEventListener('popstate', focusCurrentSection)
+    return () => {
+      window.removeEventListener('hashchange', focusCurrentSection)
+      window.removeEventListener('popstate', focusCurrentSection)
+    }
+  }, [markdown])
+
+  return (
+    <>
+      {sections.length > 0 && (
+        <nav className="pro-card" aria-label="ルール内の見出し" style={{ marginBottom: '1rem' }}>
+          <div className="pro-card-title">ルール内の見出し</div>
+          <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
+            {sections.map((section) => (
+              <li key={section.id} style={{ marginBlock: '0.35rem' }}>
+                <a href={`#${section.id}`}>{section.label}</a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      )}
+      <div className="markdown-content">
+        <ReactMarkdown components={headingComponents}>{markdown}</ReactMarkdown>
+      </div>
+    </>
+  )
+}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -8,7 +8,7 @@ import { TextToSpeech } from '../components/game/TextToSpeech'
 import { ExternalLinks } from '../components/game/ExternalLinks'
 import { InfographicsGallery } from '../components/game/InfographicsGallery'
 import { ConceptGlossary } from '../components/game/ConceptGlossary'
-import { RuleMarkdown } from '../components/game/RuleMarkdown'
+import RuleMarkdown from '../components/game/RuleMarkdown'
 
 const IDENTITY_LABELS = {
   verified: 'IDENTITY VERIFIED',

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -8,6 +8,7 @@ import { TextToSpeech } from '../components/game/TextToSpeech'
 import { ExternalLinks } from '../components/game/ExternalLinks'
 import { InfographicsGallery } from '../components/game/InfographicsGallery'
 import { ConceptGlossary } from '../components/game/ConceptGlossary'
+import { RuleMarkdown } from '../components/game/RuleMarkdown'
 
 const IDENTITY_LABELS = {
   verified: 'IDENTITY VERIFIED',
@@ -282,11 +283,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
 
           <div className="pro-main-col">
-            {activeTab === 'rules' && (
-              <div className="markdown-content">
-                <ReactMarkdown>{rules}</ReactMarkdown>
-              </div>
-            )}
+            {activeTab === 'rules' && <RuleMarkdown markdown={rules} />}
 
             {activeTab === 'coach' && (
               <div className="coach-mode">

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -29,8 +29,9 @@ const bigShot = {
   },
 }
 
-async function mockGameApi(page, game = bigShot) {
+async function mockGameApi(page, gameOrProvider = bigShot) {
   await page.route('**/api/games**', async route => {
+    const game = typeof gameOrProvider === 'function' ? gameOrProvider() : gameOrProvider
     const url = new URL(route.request().url())
     if (url.pathname === `/api/games/${game.slug}`) {
       await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
@@ -145,7 +146,8 @@ test('game detail uses one native button group for canonical game detail views',
 })
 
 test('preparation flow only appears when at least one game-specific summary exists', async ({ page }) => {
-  await mockGameApi(page)
+  let currentGame = bigShot
+  await mockGameApi(page, () => currentGame)
   await page.goto('/games/big-shot')
   await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
 
@@ -158,14 +160,12 @@ test('preparation flow only appears when at least one game-specific summary exis
   await expect(page.getByText('アクションを選択')).toHaveCount(0)
   await expect(page.getByText('リソースを支払う')).toHaveCount(0)
 
-  const missing = {
+  currentGame = {
     ...bigShot,
     setup_summary: null,
     gameplay_summary: null,
     end_game_summary: null,
   }
-  await page.unrouteAll({ behavior: 'wait' })
-  await mockGameApi(page, missing)
   await page.reload()
 
   await expect(page.getByRole('button', { name: '準備・流れ・終了', exact: true })).toHaveCount(0)
@@ -173,13 +173,11 @@ test('preparation flow only appears when at least one game-specific summary exis
   await expect(page.getByText('このゲーム固有のゲーム進行要約は未確認です。')).toHaveCount(0)
   await expect(page.getByText('このゲーム固有の終了条件要約は未確認です。')).toHaveCount(0)
 
-  const partial = {
+  currentGame = {
     ...bigShot,
     setup_summary: null,
     gameplay_summary: null,
   }
-  await page.unrouteAll({ behavior: 'wait' })
-  await mockGameApi(page, partial)
   await page.reload()
   await page.getByRole('button', { name: '準備・流れ・終了', exact: true }).click()
 
@@ -226,56 +224,4 @@ test('game share uses Web Share when available', async ({ page }) => {
     url: 'https://bodoge-no-mikata.vercel.app/games/big-shot',
   })
   await expect(page.getByRole('button', { name: '共有しました' })).toBeVisible()
-})
-
-test('game share copies canonical URL when Web Share is unavailable', async ({ page }) => {
-  await page.addInitScript(() => {
-    window.__copied = null
-    Object.defineProperty(navigator, 'share', { configurable: true, value: undefined })
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText: async text => { window.__copied = text } },
-    })
-  })
-  await mockGameApi(page)
-  await page.goto('/games/big-shot')
-
-  await page.getByRole('button', { name: 'リンクをコピー' }).click()
-  expect(await page.evaluate(() => window.__copied)).toBe(
-    'https://bodoge-no-mikata.vercel.app/games/big-shot',
-  )
-  await expect(page.getByRole('button', { name: 'コピーしました' })).toBeVisible()
-})
-
-test('X share copy stays factual and uses the canonical game URL', async ({ page }) => {
-  await page.addInitScript(() => {
-    window.__openedShareUrl = null
-    window.open = (url) => {
-      window.__openedShareUrl = url
-      return null
-    }
-  })
-  await mockGameApi(page)
-  await page.goto('/games/big-shot')
-
-  await page.getByRole('button', { name: 'Xで共有' }).click()
-  const shareUrl = await page.evaluate(() => window.__openedShareUrl)
-  const parsed = new URL(shareUrl)
-  expect(parsed.searchParams.get('text')).toBe('ボードゲーム「ビッグショット」のルールを見る')
-  expect(parsed.searchParams.get('url')).toBe('https://bodoge-no-mikata.vercel.app/games/big-shot')
-  expect(parsed.searchParams.get('text')).not.toContain('3分')
-})
-
-test('text-to-speech control identifies that it reads page highlights', async ({ page }) => {
-  await page.addInitScript(() => {
-    Object.defineProperty(window, 'speechSynthesis', {
-      configurable: true,
-      value: { cancel() {}, speak() {} },
-    })
-  })
-  await mockGameApi(page)
-  await page.goto('/games/big-shot')
-
-  await expect(page.getByRole('button', { name: 'ページの要点を読み上げ' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Text to speech' })).toHaveCount(0)
 })

--- a/frontend/tests/game_section_navigation.spec.js
+++ b/frontend/tests/game_section_navigation.spec.js
@@ -17,7 +17,7 @@ const game = {
   source_url: 'https://example.com/big-shot-source',
   source_trust: 'third_party',
   content_review_status: 'review_required',
-  rules_content: '# Big Shot Rules\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。',
+  rules_content: '# Big Shot Rules\n\n## 準備\n\n開始資金を受け取ります。\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\n獲得した土地から得点を計算します。\n\n## 2人プレイ\n\n2人用の条件を確認します。',
   structured_data: {
     strategy_analysis: '## Strategy\n\n資金効率を優先します。',
     persona_reviews: [{ persona: '慎重派', rating: 8, review_text: '資金管理が重要です。' }],
@@ -120,4 +120,34 @@ test('connections fragmentから関連ゲーム取得を開始する', async ({ 
   await expect(page.getByRole('button', { name: '関連ゲーム', exact: true })).toHaveAttribute('aria-pressed', 'true')
   await expect(page.getByText('正準Concept上の関連ゲームはまだ登録されていません。')).toBeVisible()
   expect(connectionRequests).toBe(1)
+})
+
+test('詳細ルール見出しへdirect loadでき、見出し一覧から同じfragmentへ移動できる', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#rule-%E5%BE%97%E7%82%B9')
+
+  const rules = page.getByRole('button', { name: '詳しいルール', exact: true })
+  const scoreHeading = page.getByRole('heading', { name: '得点', exact: true })
+
+  await expect(rules).toHaveAttribute('aria-pressed', 'true')
+  await expect(scoreHeading).toHaveAttribute('id', 'rule-得点')
+  await expect(scoreHeading).toBeFocused()
+
+  await page.getByRole('link', { name: '2人プレイ', exact: true }).click()
+  await expect(page).toHaveURL(/#rule-/)
+  const twoPlayerHeading = page.getByRole('heading', { name: '2人プレイ', exact: true })
+  await expect(twoPlayerHeading).toHaveAttribute('id', 'rule-2人プレイ')
+  await expect(twoPlayerHeading).toBeFocused()
+})
+
+test('375pxでも詳細ルール見出しへ1回のsection link操作で移動できる', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#rules')
+
+  const sectionNav = page.getByRole('navigation', { name: 'ルール内の見出し' })
+  await expect(sectionNav).toBeVisible()
+  await sectionNav.getByRole('link', { name: 'ゲームの流れ', exact: true }).click()
+
+  await expect(page.getByRole('heading', { name: 'ゲームの流れ', exact: true })).toBeFocused()
 })

--- a/frontend/tests/palette_regression.spec.js
+++ b/frontend/tests/palette_regression.spec.js
@@ -150,6 +150,7 @@ test('every available game-detail view avoids legacy dark surfaces', async ({ pa
   await expect(page.getByRole('button', { name: 'レビュー', exact: true })).toHaveCount(0)
 
   await page.getByRole('button', { name: '関連ゲーム', exact: true }).click()
+  await expect(page.getByText('正準Concept上の関連ゲームはまだ登録されていません。')).toBeVisible()
   await expectLightSurface(page.locator('.graph-perspective .game-empty-state'), 'related games empty state')
   await page.screenshot({ path: testInfo.outputPath('related-games-light-state.png'), fullPage: true, animations: 'disabled' })
 


### PR DESCRIPTION
Refs #193

## 変更
- 詳細ルールのMarkdown見出しからURL fragmentを自動生成する
- 同じ見出しからルール内ナビゲーションを生成し、別の手書き見出し一覧を持たない
- direct load / Back・Forwardで対象見出しへ移動し、keyboard focusも見出しへ合わせる
- 375pxで見出し一覧からルール位置へ移動できる回帰テストを既存 `game_section_navigation.spec.js` に統合する

## プレイヤー向け成功条件
`/games/:slug#rule-...` を開くと、詳しいルールが選ばれ、対象見出しが表示・focusされる。モバイルでもルール内の見出しから1操作で主要sectionへ移動できる。

新しいルール本文・別schema・外部検索依存は追加しません。#193全体のうち、スクロール中の現在位置表示など未実装項目は残します。