### PR TITLE
GamePageの削除された回帰テストを復元する

### DIFF
--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -225,3 +225,55 @@ test('game share uses Web Share when available', async ({ page }) => {
   })
   await expect(page.getByRole('button', { name: '共有しました' })).toBeVisible()
 })
+
+test('game share copies canonical URL when Web Share is unavailable', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__copied = null
+    Object.defineProperty(navigator, 'share', { configurable: true, value: undefined })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async text => { window.__copied = text } },
+    })
+  })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+
+  await page.getByRole('button', { name: 'リンクをコピー' }).click()
+  expect(await page.evaluate(() => window.__copied)).toBe(
+    'https://bodoge-no-mikata.vercel.app/games/big-shot',
+  )
+  await expect(page.getByRole('button', { name: 'コピーしました' })).toBeVisible()
+})
+
+test('X share copy stays factual and uses the canonical game URL', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__openedShareUrl = null
+    window.open = (url) => {
+      window.__openedShareUrl = url
+      return null
+    }
+  })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+
+  await page.getByRole('button', { name: 'Xで共有' }).click()
+  const shareUrl = await page.evaluate(() => window.__openedShareUrl)
+  const parsed = new URL(shareUrl)
+  expect(parsed.searchParams.get('text')).toBe('ボードゲーム「ビッグショット」のルールを見る')
+  expect(parsed.searchParams.get('url')).toBe('https://bodoge-no-mikata.vercel.app/games/big-shot')
+  expect(parsed.searchParams.get('text')).not.toContain('3分')
+})
+
+test('text-to-speech control identifies that it reads page highlights', async ({ page }) => {
+  await page.addInitScript(() => {
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: { cancel() {}, speak() {} },
+    })
+  })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot')
+
+  await expect(page.getByRole('button', { name: 'ページの要点を読み上げ' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Text to speech' })).toHaveCount(0)
+})


### PR DESCRIPTION
PR #574 のmain read-backで、`game_layout.spec.js` の部分取得を全置換に使ったため、末尾の既存回帰テスト3件が意図せず削除されていることを検出しました。

このPRは削除された次の検証だけを復元します。
- Web Share非対応時のcanonical URLコピー
- X共有文面とcanonical URL
- 読み上げ操作の表示名

#574で導入した詳細ルールfragmentやfixture route安定化は変更しません。