### PR TITLE
GamePageに詳細ルール内検索を追加

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 
 function headingLabel(markdownText) {
@@ -6,6 +6,23 @@ function headingLabel(markdownText) {
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
     .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
     .replace(/[`*_~]/g, '')
+    .trim()
+}
+
+function plainText(markdownText) {
+  return markdownText
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_~>#-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function normalizeSearchText(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
     .trim()
 }
 
@@ -25,10 +42,11 @@ function sectionId(label, occurrence = 1) {
 }
 
 function getRuleSections(markdown = '') {
+  const lines = markdown.split('\n')
   const occurrences = new Map()
-  const sections = []
+  const headings = []
 
-  markdown.split('\n').forEach((line, index) => {
+  lines.forEach((line, index) => {
     const match = /^(#{2,4})\s+(.+?)\s*#*\s*$/.exec(line)
     if (!match) return
 
@@ -40,15 +58,25 @@ function getRuleSections(markdown = '') {
     const occurrence = (occurrences.get(key) || 0) + 1
     occurrences.set(key, occurrence)
 
-    sections.push({
+    headings.push({
       id: sectionId(label, occurrence),
       label,
       level,
       line: index + 1,
+      lineIndex: index,
     })
   })
 
-  return sections
+  return headings.map((heading, index) => {
+    const nextHeading = headings[index + 1]
+    const bodyLines = lines.slice(heading.lineIndex + 1, nextHeading?.lineIndex ?? lines.length)
+    const body = plainText(bodyLines.join('\n'))
+    return {
+      ...heading,
+      body,
+      searchText: normalizeSearchText(`${heading.label} ${body}`),
+    }
+  })
 }
 
 function createHeadingComponents(sections) {
@@ -83,9 +111,29 @@ function decodedHash() {
   }
 }
 
+function searchSections(sections, query) {
+  const normalizedQuery = normalizeSearchText(query)
+  if (!normalizedQuery) return []
+
+  const tokens = normalizedQuery.split(' ').filter(Boolean)
+  return sections.filter((section) => tokens.every((token) => section.searchText.includes(token)))
+}
+
+function resultSnippet(section) {
+  if (!section.body) return 'この見出しへ移動します。'
+  return section.body.length > 140 ? `${section.body.slice(0, 140)}…` : section.body
+}
+
 function RuleMarkdown({ markdown = '' }) {
-  const sections = getRuleSections(markdown)
-  const headingComponents = createHeadingComponents(sections)
+  const [query, setQuery] = useState('')
+  const sections = useMemo(() => getRuleSections(markdown), [markdown])
+  const results = useMemo(() => searchSections(sections, query), [sections, query])
+  const headingComponents = useMemo(() => createHeadingComponents(sections), [sections])
+  const hasQuery = normalizeSearchText(query).length > 0
+
+  useEffect(() => {
+    setQuery('')
+  }, [markdown])
 
   useEffect(() => {
     const focusCurrentSection = () => {
@@ -112,16 +160,51 @@ function RuleMarkdown({ markdown = '' }) {
   return (
     <>
       {sections.length > 0 && (
-        <nav className="pro-card" aria-label="ルール内の見出し" style={{ marginBottom: '1rem' }}>
-          <div className="pro-card-title">ルール内の見出し</div>
-          <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
-            {sections.map((section) => (
-              <li key={section.id} style={{ marginBlock: '0.35rem' }}>
-                <a href={`#${section.id}`}>{section.label}</a>
-              </li>
-            ))}
-          </ul>
-        </nav>
+        <>
+          <section className="pro-card" aria-labelledby="rule-lookup-title" style={{ marginBottom: '1rem' }}>
+            <div id="rule-lookup-title" className="pro-card-title">ルール内を検索</div>
+            <label htmlFor="rule-lookup-input" style={{ display: 'block', marginBottom: '0.4rem' }}>
+              裁定・用語を入力
+            </label>
+            <input
+              id="rule-lookup-input"
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="例: 得点、2人、Mermaid"
+              autoComplete="off"
+              style={{ width: '100%', maxWidth: '36rem' }}
+            />
+            {hasQuery && (
+              <div style={{ marginTop: '0.75rem' }}>
+                <div role="status" aria-live="polite" style={{ marginBottom: '0.5rem' }}>
+                  {results.length > 0 ? `${results.length}件見つかりました` : '該当するルールは見つかりませんでした'}
+                </div>
+                {results.length > 0 && (
+                  <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
+                    {results.map((section) => (
+                      <li key={section.id} style={{ marginBlock: '0.6rem' }}>
+                        <a href={`#${section.id}`}><strong>{section.label}</strong></a>
+                        <div style={{ marginTop: '0.2rem' }}>{resultSnippet(section)}</div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            )}
+          </section>
+
+          <nav className="pro-card" aria-label="ルール内の見出し" style={{ marginBottom: '1rem' }}>
+            <div className="pro-card-title">ルール内の見出し</div>
+            <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
+              {sections.map((section) => (
+                <li key={section.id} style={{ marginBlock: '0.35rem' }}>
+                  <a href={`#${section.id}`}>{section.label}</a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </>
       )}
       <div className="markdown-content">
         <ReactMarkdown components={headingComponents}>{markdown}</ReactMarkdown>

--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -132,10 +132,6 @@ function RuleMarkdown({ markdown = '' }) {
   const hasQuery = normalizeSearchText(query).length > 0
 
   useEffect(() => {
-    setQuery('')
-  }, [markdown])
-
-  useEffect(() => {
     const focusCurrentSection = () => {
       const id = decodedHash()
       if (!id.startsWith('rule-')) return

--- a/frontend/tests/game_section_navigation.spec.js
+++ b/frontend/tests/game_section_navigation.spec.js
@@ -17,7 +17,7 @@ const game = {
   source_url: 'https://example.com/big-shot-source',
   source_trust: 'third_party',
   content_review_status: 'review_required',
-  rules_content: '# Big Shot Rules\n\n## 準備\n\n開始資金を受け取ります。\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\n獲得した土地から得点を計算します。\n\n## 2人プレイ\n\n2人用の条件を確認します。',
+  rules_content: '# Big Shot Rules\n\n## 準備\n\n開始資金を受け取ります。\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\n獲得した土地から得点を計算します。0ビッドの場合は得点計算が変わります。\n\n## 2人プレイ\n\n2人用の条件を確認します。\n\n## 特殊カード\n\nMermaid、Skull King、Pirateが同じトリックに出た場合の裁定を確認します。',
   structured_data: {
     strategy_analysis: '## Strategy\n\n資金効率を優先します。',
     persona_reviews: [{ persona: '慎重派', rating: 8, review_text: '資金管理が重要です。' }],
@@ -150,4 +150,45 @@ test('375pxでも詳細ルール見出しへ1回のsection link操作で移動�
   await sectionNav.getByRole('link', { name: 'ゲームの流れ', exact: true }).click()
 
   await expect(page.getByRole('heading', { name: 'ゲームの流れ', exact: true })).toBeFocused()
+})
+
+test('ルール本文を検索し、結果からcanonical fragmentへ移動できる', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#rules')
+
+  const search = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  await search.fill('Mermaid Pirate')
+
+  await expect(page.getByRole('status')).toContainText('1件見つかりました')
+  const result = page.getByRole('link', { name: '特殊カード', exact: true }).first()
+  await expect(result).toBeVisible()
+  await result.click()
+
+  await expect(page).toHaveURL(/#rule-%E7%89%B9%E6%AE%8A%E3%82%AB%E3%83%BC%E3%83%89$/)
+  await expect(page.getByRole('heading', { name: '特殊カード', exact: true })).toBeFocused()
+})
+
+test('0ビッドと2人の検索は対応sectionだけを返し、検索語をURLへ保存しない', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#rules')
+
+  const search = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  await search.fill('0ビッド')
+  await expect(page.getByRole('status')).toContainText('1件見つかりました')
+  await expect(page.getByRole('link', { name: '得点', exact: true }).first()).toBeVisible()
+  await expect(page).toHaveURL(/#rules$/)
+
+  await search.fill('2人')
+  await expect(page.getByRole('status')).toContainText('1件見つかりました')
+  await expect(page.getByRole('link', { name: '2人プレイ', exact: true }).first()).toBeVisible()
+  await expect(page.getByRole('link', { name: '得点', exact: true }).first()).toHaveCount(0)
+})
+
+test('該当ルールがない検索は明示的な0件状態になる', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#rules')
+
+  await page.getByRole('searchbox', { name: '裁定・用語を入力' }).fill('存在しない裁定')
+  await expect(page.getByRole('status')).toHaveText('該当するルールは見つかりませんでした')
 })

--- a/frontend/tests/game_section_navigation.spec.js
+++ b/frontend/tests/game_section_navigation.spec.js
@@ -156,11 +156,12 @@ test('ルール本文を検索し、結果からcanonical fragmentへ移動で�
   await mockGameApi(page)
   await page.goto('/games/big-shot#rules')
 
-  const search = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  const lookup = page.getByRole('region', { name: 'ルール内を検索' })
+  const search = lookup.getByRole('searchbox', { name: '裁定・用語を入力' })
   await search.fill('Mermaid Pirate')
 
-  await expect(page.getByRole('status')).toContainText('1件見つかりました')
-  const result = page.getByRole('link', { name: '特殊カード', exact: true }).first()
+  await expect(lookup.getByRole('status')).toContainText('1件見つかりました')
+  const result = lookup.getByRole('link', { name: '特殊カード', exact: true })
   await expect(result).toBeVisible()
   await result.click()
 
@@ -172,16 +173,17 @@ test('0ビッドと2人の検索は対応sectionだけを返し、検索語をUR
   await mockGameApi(page)
   await page.goto('/games/big-shot#rules')
 
-  const search = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  const lookup = page.getByRole('region', { name: 'ルール内を検索' })
+  const search = lookup.getByRole('searchbox', { name: '裁定・用語を入力' })
   await search.fill('0ビッド')
-  await expect(page.getByRole('status')).toContainText('1件見つかりました')
-  await expect(page.getByRole('link', { name: '得点', exact: true }).first()).toBeVisible()
+  await expect(lookup.getByRole('status')).toContainText('1件見つかりました')
+  await expect(lookup.getByRole('link', { name: '得点', exact: true })).toBeVisible()
   await expect(page).toHaveURL(/#rules$/)
 
   await search.fill('2人')
-  await expect(page.getByRole('status')).toContainText('1件見つかりました')
-  await expect(page.getByRole('link', { name: '2人プレイ', exact: true }).first()).toBeVisible()
-  await expect(page.getByRole('link', { name: '得点', exact: true }).first()).toHaveCount(0)
+  await expect(lookup.getByRole('status')).toContainText('1件見つかりました')
+  await expect(lookup.getByRole('link', { name: '2人プレイ', exact: true })).toBeVisible()
+  await expect(lookup.getByRole('link', { name: '得点', exact: true })).toHaveCount(0)
 })
 
 test('該当ルールがない検索は明示的な0件状態になる', async ({ page }) => {
@@ -189,6 +191,7 @@ test('該当ルールがない検索は明示的な0件状態になる', async (
   await mockGameApi(page)
   await page.goto('/games/big-shot#rules')
 
-  await page.getByRole('searchbox', { name: '裁定・用語を入力' }).fill('存在しない裁定')
-  await expect(page.getByRole('status')).toHaveText('該当するルールは見つかりませんでした')
+  const lookup = page.getByRole('region', { name: 'ルール内を検索' })
+  await lookup.getByRole('searchbox', { name: '裁定・用語を入力' }).fill('存在しない裁定')
+  await expect(lookup.getByRole('status')).toHaveText('該当するルールは見つかりませんでした')
 })


### PR DESCRIPTION
#272 の第一段階です。

利用者向け成功条件:
- GamePageで裁定・用語を検索し、検索結果から同じ詳細ルール本文の `rule-...` 見出しへ直接移動できる。

変更:
- 現在表示中の `rules_content` をその場で検索し、別の検索用ルール本文を保存しない
- Unicode NFKC + 小文字化で複数語を決定的に照合
- 結果は既存のstable `rule-...` fragmentへリンク
- 検索語をindexable URLへ保存しない
- 0件状態と件数を `role=status` で通知
- 既存 `game_section_navigation.spec.js` に検索→canonical fragment、0ビッド、2人、0件、375pxの回帰を統合

境界:
- v1では外部検索サービス、vector DB、LLM回答生成を追加しない
- glossary alias / FAQ / selected RuleSet API統合は #272 の残件として維持する