### PR TITLE
ルール検索結果に一致箇所の文脈を表示する

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -119,8 +119,20 @@ function searchSections(sections, query) {
   return sections.filter((section) => tokens.every((token) => section.searchText.includes(token)))
 }
 
-function resultSnippet(section) {
+function resultSnippet(section, query) {
   if (!section.body) return 'この見出しへ移動します。'
+
+  const tokens = normalizeSearchText(query).split(' ').filter(Boolean)
+  const sentences = section.body.match(/[^。！？!?]+[。！？!?]?/gu) || [section.body]
+  const matchedSentences = sentences.filter((sentence) => {
+    const normalizedSentence = normalizeSearchText(sentence)
+    return tokens.some((token) => normalizedSentence.includes(token))
+  })
+
+  if (matchedSentences.length > 0) {
+    return matchedSentences.slice(0, 2).join(' ').trim()
+  }
+
   return section.body.length > 140 ? `${section.body.slice(0, 140)}…` : section.body
 }
 
@@ -181,7 +193,7 @@ function RuleMarkdown({ markdown = '' }) {
                     {results.map((section) => (
                       <li key={section.id} style={{ marginBlock: '0.6rem' }}>
                         <a href={`#${section.id}`}><strong>{section.label}</strong></a>
-                        <div style={{ marginTop: '0.2rem' }}>{resultSnippet(section)}</div>
+                        <div style={{ marginTop: '0.2rem' }}>{resultSnippet(section, query)}</div>
                       </li>
                     ))}
                   </ul>

--- a/frontend/tests/game_section_navigation.spec.js
+++ b/frontend/tests/game_section_navigation.spec.js
@@ -17,7 +17,7 @@ const game = {
   source_url: 'https://example.com/big-shot-source',
   source_trust: 'third_party',
   content_review_status: 'review_required',
-  rules_content: '# Big Shot Rules\n\n## 準備\n\n開始資金を受け取ります。\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\n獲得した土地から得点を計算します。0ビッドの場合は得点計算が変わります。\n\n## 2人プレイ\n\n2人用の条件を確認します。\n\n## 特殊カード\n\nMermaid、Skull King、Pirateが同じトリックに出た場合の裁定を確認します。',
+  rules_content: '# Big Shot Rules\n\n## 準備\n\n開始資金を受け取ります。\n\n## ゲームの流れ\n\n競りを行い、土地を獲得します。\n\n## 得点\n\n獲得した土地から得点を計算します。0ビッドの場合は得点計算が変わります。\n\n## 2人プレイ\n\n2人用の条件を確認します。\n\n## 特殊カード\n\nMermaid、Skull King、Pirateが同じトリックに出た場合の裁定を確認します。\n\n## 長い裁定\n\nこの段落は検索結果の先頭だけを表示すると一致理由が見えないケースを再現するためのテスト用文章です。前提や背景の説明が長く続き、利用者が探している語が本文の後半に現れる状況を作ります。さらに検索対象とは直接関係しない説明を追加して、従来の140文字固定snippetでは一致箇所が見えない長さにします。Graybeardに関する確認事項はこの文にあります。',
   structured_data: {
     strategy_analysis: '## Strategy\n\n資金効率を優先します。',
     persona_reviews: [{ persona: '慎重派', rating: 8, review_text: '資金管理が重要です。' }],
@@ -167,6 +167,19 @@ test('ルール本文を検索し、結果からcanonical fragmentへ移動で�
 
   await expect(page).toHaveURL(/#rule-%E7%89%B9%E6%AE%8A%E3%82%AB%E3%83%BC%E3%83%89$/)
   await expect(page.getByRole('heading', { name: '特殊カード', exact: true })).toBeFocused()
+})
+
+test('検索語が長いsectionの後半にあっても、一致箇所をsnippetへ表示する', async ({ page }) => {
+  await mockGameApi(page)
+  await page.goto('/games/big-shot#rules')
+
+  const lookup = page.getByRole('region', { name: 'ルール内を検索' })
+  await lookup.getByRole('searchbox', { name: '裁定・用語を入力' }).fill('Graybeard')
+
+  await expect(lookup.getByRole('status')).toContainText('1件見つかりました')
+  const result = lookup.getByRole('link', { name: '長い裁定', exact: true })
+  await expect(result).toBeVisible()
+  await expect(result.locator('..')).toContainText('Graybeard')
 })
 
 test('0ビッドと2人の検索は対応sectionだけを返し、検索語をURLへ保存しない', async ({ page }) => {


### PR DESCRIPTION
Closes no issue; #272 の継続変更です。

プレイヤー向け成功条件:
- 長いルールsectionで検索語が本文先頭140文字より後ろにあっても、検索結果snippetから一致語と周辺文脈を確認できる。

変更:
- 検索結果snippetを本文先頭固定ではなく、一致語を含む文から導出する。
- 検索対象・表示本文・fragmentは従来どおり同じrules_contentから導出し、別の検索truthを追加しない。
- 長いsection後半に検索語があるfixtureを既存GamePage Playwrightへ追加する。

検証:
- existing Frontend PR build / UI UX regressionを使用する。
- productionではdeploy後に実GamePageの検索結果が一致文脈を表示することを確認する。