### PR TITLE
用語集を正準APIだけから表示する

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -110,6 +110,7 @@ jobs:
           tests/pili_pili_ruleset_context.spec.js
           tests/directory-source-trust.spec.js
           tests/ruleset-public-projection.spec.js
+          tests/canonical_glossary.spec.js
           --project=chromium
 
       - name: Gate responsive geometry and pixel screenshot baselines

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -2,53 +2,36 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
 
-function LegacyGlossary({ keywords }) {
-  if (!keywords?.length) return null
-  return (
-    <div className="pro-card">
-      <div className="pro-card-title">GLOSSARY</div>
-      <div className="tag-list">
-        {keywords.map((kw, i) => (
-          <div key={`${kw.term}-${i}`} className="tag-item" title={kw.description}>{kw.term}</div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-export function ConceptGlossary({ slug, legacyKeywords = [] }) {
+export function ConceptGlossary({ slug }) {
   const [entries, setEntries] = useState([])
   const [selectedId, setSelectedId] = useState(null)
   const [detail, setDetail] = useState(null)
-  const [canonicalAvailable, setCanonicalAvailable] = useState(false)
-  const [loadedSlug, setLoadedSlug] = useState(null)
-  const hasGlossary = legacyKeywords.length > 0
+  const [status, setStatus] = useState('loading')
+  const [detailError, setDetailError] = useState(false)
 
   useEffect(() => {
-    if (!hasGlossary) return undefined
-
     let cancelled = false
+    setStatus('loading')
+    setEntries([])
+    setSelectedId(null)
+    setDetail(null)
+    setDetailError(false)
+
     api.get(`/api/games/${slug}/glossary?language_code=ja`)
       .then((data) => {
         if (cancelled) return
         const available = data?.status === 'available' && data.entries?.length > 0
         setEntries(available ? data.entries : [])
-        setSelectedId(null)
-        setDetail(null)
-        setCanonicalAvailable(Boolean(available))
-        setLoadedSlug(slug)
+        setStatus(available ? 'available' : 'unavailable')
       })
-      .catch(() => {
+      .catch((err) => {
+        console.error('Failed to fetch canonical glossary:', err)
         if (cancelled) return
-        setEntries([])
-        setSelectedId(null)
-        setDetail(null)
-        setCanonicalAvailable(false)
-        setLoadedSlug(slug)
+        setStatus('error')
       })
 
     return () => { cancelled = true }
-  }, [slug, hasGlossary])
+  }, [slug])
 
   const selected = useMemo(
     () => entries.find((entry) => entry.concept_id === selectedId) || null,
@@ -59,20 +42,46 @@ export function ConceptGlossary({ slug, legacyKeywords = [] }) {
     if (selectedId === conceptId) {
       setSelectedId(null)
       setDetail(null)
+      setDetailError(false)
       return
     }
     setSelectedId(conceptId)
     setDetail(null)
+    setDetailError(false)
     try {
       const response = await api.get(`/api/concepts/${encodeURIComponent(conceptId)}`)
       setDetail(response)
-    } catch {
-      // The game glossary remains useful even if the deeper backlink view is unavailable.
+    } catch (err) {
+      console.error('Failed to fetch canonical concept detail:', err)
+      setDetailError(true)
     }
   }
 
-  if (!hasGlossary || loadedSlug !== slug || !canonicalAvailable) {
-    return <LegacyGlossary keywords={legacyKeywords} />
+  if (status === 'loading') {
+    return (
+      <div className="pro-card" aria-label="用語集">
+        <div className="pro-card-title">GLOSSARY</div>
+        <div className="game-empty-state" role="status">用語集を確認しています...</div>
+      </div>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="pro-card" aria-label="用語集">
+        <div className="pro-card-title">GLOSSARY</div>
+        <div className="game-empty-state" role="status">用語集の正準データを取得できませんでした。</div>
+      </div>
+    )
+  }
+
+  if (status === 'unavailable') {
+    return (
+      <div className="pro-card" aria-label="用語集">
+        <div className="pro-card-title">GLOSSARY</div>
+        <div className="game-empty-state" role="status">用語集の正準データは未整備です。</div>
+      </div>
+    )
   }
 
   return (
@@ -124,6 +133,11 @@ export function ConceptGlossary({ slug, legacyKeywords = [] }) {
                   {reference.normalized_statement}
                 </div>
               ))}
+            </div>
+          )}
+          {detailError && (
+            <div className="game-empty-note" role="status" style={{ marginTop: '0.75rem' }}>
+              この用語の関連ゲーム情報を取得できませんでした。
             </div>
           )}
           {detail?.game_backlinks?.length > 0 && (

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -6,28 +6,27 @@ export function ConceptGlossary({ slug }) {
   const [entries, setEntries] = useState([])
   const [selectedId, setSelectedId] = useState(null)
   const [detail, setDetail] = useState(null)
-  const [status, setStatus] = useState('loading')
+  const [fetchStatus, setFetchStatus] = useState('loading')
+  const [loadedSlug, setLoadedSlug] = useState(null)
   const [detailError, setDetailError] = useState(false)
 
   useEffect(() => {
     let cancelled = false
-    setStatus('loading')
-    setEntries([])
-    setSelectedId(null)
-    setDetail(null)
-    setDetailError(false)
 
     api.get(`/api/games/${slug}/glossary?language_code=ja`)
       .then((data) => {
         if (cancelled) return
         const available = data?.status === 'available' && data.entries?.length > 0
         setEntries(available ? data.entries : [])
-        setStatus(available ? 'available' : 'unavailable')
+        setFetchStatus(available ? 'available' : 'unavailable')
+        setLoadedSlug(slug)
       })
       .catch((err) => {
         console.error('Failed to fetch canonical glossary:', err)
         if (cancelled) return
-        setStatus('error')
+        setEntries([])
+        setFetchStatus('error')
+        setLoadedSlug(slug)
       })
 
     return () => { cancelled = true }
@@ -57,7 +56,7 @@ export function ConceptGlossary({ slug }) {
     }
   }
 
-  if (status === 'loading') {
+  if (loadedSlug !== slug) {
     return (
       <div className="pro-card" aria-label="用語集">
         <div className="pro-card-title">GLOSSARY</div>
@@ -66,7 +65,7 @@ export function ConceptGlossary({ slug }) {
     )
   }
 
-  if (status === 'error') {
+  if (fetchStatus === 'error') {
     return (
       <div className="pro-card" aria-label="用語集">
         <div className="pro-card-title">GLOSSARY</div>
@@ -75,7 +74,7 @@ export function ConceptGlossary({ slug }) {
     )
   }
 
-  if (status === 'unavailable') {
+  if (fetchStatus === 'unavailable') {
     return (
       <div className="pro-card" aria-label="用語集">
         <div className="pro-card-title">GLOSSARY</div>

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -21,8 +21,7 @@ export function ConceptGlossary({ slug }) {
         setFetchStatus(available ? 'available' : 'unavailable')
         setLoadedSlug(slug)
       })
-      .catch((err) => {
-        console.error('Failed to fetch canonical glossary:', err)
+      .catch(() => {
         if (cancelled) return
         setEntries([])
         setFetchStatus('error')
@@ -50,8 +49,7 @@ export function ConceptGlossary({ slug }) {
     try {
       const response = await api.get(`/api/concepts/${encodeURIComponent(conceptId)}`)
       setDetail(response)
-    } catch (err) {
-      console.error('Failed to fetch canonical concept detail:', err)
+    } catch {
       setDetailError(true)
     }
   }
@@ -69,7 +67,7 @@ export function ConceptGlossary({ slug }) {
     return (
       <div className="pro-card" aria-label="用語集">
         <div className="pro-card-title">GLOSSARY</div>
-        <div className="game-empty-state" role="status">用語集の正準データを取得できませんでした。</div>
+        <div className="game-empty-state" role="alert">用語集の正準データを取得できませんでした。</div>
       </div>
     )
   }
@@ -78,7 +76,7 @@ export function ConceptGlossary({ slug }) {
     return (
       <div className="pro-card" aria-label="用語集">
         <div className="pro-card-title">GLOSSARY</div>
-        <div className="game-empty-state" role="status">用語集の正準データは未整備です。</div>
+        <div className="game-empty-state">用語集の正準データは未整備です。</div>
       </div>
     )
   }
@@ -135,7 +133,7 @@ export function ConceptGlossary({ slug }) {
             </div>
           )}
           {detailError && (
-            <div className="game-empty-note" role="status" style={{ marginTop: '0.75rem' }}>
+            <div className="game-empty-note" role="alert" style={{ marginTop: '0.75rem' }}>
               この用語の関連ゲーム情報を取得できませんでした。
             </div>
           )}

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -40,7 +40,7 @@ test('正準用語集が未整備なら旧keywordsへ戻らず未整備を明示
   await page.goto('/games/glossary-test#rules')
 
   const glossary = page.locator('[aria-label="用語集"]')
-  await expect(glossary.getByRole('status')).toHaveText('用語集の正準データは未整備です。')
+  await expect(glossary.getByText('用語集の正準データは未整備です。', { exact: true })).toBeVisible()
   await expect(page.getByText('旧データの用語')).toHaveCount(0)
 })
 
@@ -60,7 +60,7 @@ test('正準用語集の取得失敗を旧keywordsで隠さず明示する', asy
 
   await page.goto('/games/glossary-test#rules')
   const glossary = page.locator('[aria-label="用語集"]')
-  await expect(glossary.getByRole('status')).toHaveText('用語集の正準データを取得できませんでした。')
+  await expect(glossary.getByRole('alert')).toHaveText('用語集の正準データを取得できませんでした。')
   await expect(page.getByText('旧データの用語')).toHaveCount(0)
 })
 

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -39,7 +39,7 @@ test('正準用語集が未整備なら旧keywordsへ戻らず未整備を明示
   await mockGameAndGlossary(page, { status: 'not_available', entries: [] })
   await page.goto('/games/glossary-test#rules')
 
-  const glossary = page.getByRole('complementary', { name: '補足情報' }).getByLabel('用語集')
+  const glossary = page.locator('[aria-label="用語集"]')
   await expect(glossary.getByRole('status')).toHaveText('用語集の正準データは未整備です。')
   await expect(page.getByText('旧データの用語')).toHaveCount(0)
 })
@@ -71,6 +71,6 @@ test('旧keywordsがなくても正準用語集がavailableなら表示する', 
   })
 
   await page.goto('/games/glossary-test#rules')
-  const glossary = page.getByRole('complementary', { name: '補足情報' }).getByLabel('用語集')
+  const glossary = page.locator('[aria-label="用語集"]')
   await expect(glossary.getByRole('button', { name: '得点', exact: true })).toBeVisible()
 })

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -44,6 +44,26 @@ test('正準用語集が未整備なら旧keywordsへ戻らず未整備を明示
   await expect(page.getByText('旧データの用語')).toHaveCount(0)
 })
 
+test('正準用語集の取得失敗を旧keywordsで隠さず明示する', async ({ page }) => {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/glossary-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === '/api/games/glossary-test/glossary') {
+      await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ detail: 'unavailable' }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+
+  await page.goto('/games/glossary-test#rules')
+  const glossary = page.locator('[aria-label="用語集"]')
+  await expect(glossary.getByRole('status')).toHaveText('用語集の正準データを取得できませんでした。')
+  await expect(page.getByText('旧データの用語')).toHaveCount(0)
+})
+
 test('旧keywordsがなくても正準用語集がavailableなら表示する', async ({ page }) => {
   const gameWithoutLegacyKeywords = {
     ...game,

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -1,0 +1,76 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 901,
+  slug: 'glossary-test',
+  title: 'Glossary Test',
+  title_ja: '用語集テスト',
+  min_players: 2,
+  max_players: 4,
+  play_time: 30,
+  min_age: 10,
+  published_year: 2026,
+  summary: '用語集表示の回帰テスト用ゲーム。',
+  source_url: 'https://example.com/source',
+  source_trust: 'official_publisher',
+  content_review_status: 'review_required',
+  rules_content: '# Rules\n\n## 得点\n\n得点を計算します。',
+  structured_data: {
+    keywords: [{ term: '旧データの用語', description: '正準用語集ではない旧データ' }],
+  },
+}
+
+async function mockGameAndGlossary(page, glossaryResponse) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/glossary-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === '/api/games/glossary-test/glossary') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(glossaryResponse) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('正準用語集が未整備なら旧keywordsへ戻らず未整備を明示する', async ({ page }) => {
+  await mockGameAndGlossary(page, { status: 'not_available', entries: [] })
+  await page.goto('/games/glossary-test#rules')
+
+  const glossary = page.getByRole('complementary', { name: '補足情報' }).getByLabel('用語集')
+  await expect(glossary.getByRole('status')).toHaveText('用語集の正準データは未整備です。')
+  await expect(page.getByText('旧データの用語')).toHaveCount(0)
+})
+
+test('旧keywordsがなくても正準用語集がavailableなら表示する', async ({ page }) => {
+  const gameWithoutLegacyKeywords = {
+    ...game,
+    structured_data: { keywords: [] },
+  }
+
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/glossary-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game: gameWithoutLegacyKeywords }) })
+      return
+    }
+    if (url.pathname === '/api/games/glossary-test/glossary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'available',
+          entries: [{ concept_id: 'scoring', label: '得点', definition: 'ゲームの得点に関する用語です。', aliases: [] }],
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+
+  await page.goto('/games/glossary-test#rules')
+  const glossary = page.getByRole('complementary', { name: '補足情報' }).getByLabel('用語集')
+  await expect(glossary.getByRole('button', { name: '得点', exact: true })).toBeVisible()
+})

--- a/frontend/tests/lists.spec.js
+++ b/frontend/tests/lists.spec.js
@@ -162,7 +162,7 @@ test('game detail saves canonical game id to selected custom list with bearer to
   await page.goto('/games/game-one')
   await expect(page.getByRole('button', { name: 'リストに保存' })).toBeVisible()
   await page.getByRole('button', { name: 'リストに保存' }).click()
-  await expect(page.getByRole('status', { name: '保存しました' })).toBeVisible()
+  await expect(page.getByText('保存しました', { exact: true })).toBeVisible()
   expect(saved).toBe(true)
 })
 

--- a/frontend/tests/lists.spec.js
+++ b/frontend/tests/lists.spec.js
@@ -162,7 +162,7 @@ test('game detail saves canonical game id to selected custom list with bearer to
   await page.goto('/games/game-one')
   await expect(page.getByRole('button', { name: 'リストに保存' })).toBeVisible()
   await page.getByRole('button', { name: 'リストに保存' }).click()
-  await expect(page.getByRole('status')).toContainText('保存しました')
+  await expect(page.getByRole('status', { name: '保存しました' })).toBeVisible()
   expect(saved).toBe(true)
 })
 

--- a/frontend/tests/performance.spec.js
+++ b/frontend/tests/performance.spec.js
@@ -72,7 +72,7 @@ test('game detail coalesces duplicate GET and gives mutation feedback within one
   }))
   expect(feedback.elapsedMs).toBeLessThan(100)
   expect(feedback.text).toContain('保存中')
-  await expect(page.getByRole('status')).toContainText('保存しました')
+  await expect(page.getByText('保存しました', { exact: true })).toBeVisible()
   expect(saveRequests).toBe(1)
 })
 

--- a/frontend/tests/ui_ux_regression.spec.js
+++ b/frontend/tests/ui_ux_regression.spec.js
@@ -157,6 +157,17 @@ async function mockApi(page, state) {
       return
     }
 
+    const glossaryMatch = path.match(/^\/api\/games\/([^/]+)\/glossary$/)
+    if (glossaryMatch && method === 'GET') {
+      const game = games.find((candidate) => candidate.slug === decodeURIComponent(glossaryMatch[1]))
+      await route.fulfill({
+        status: game ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(game ? { status: 'not_available', entries: [] } : { detail: 'not found' }),
+      })
+      return
+    }
+
     if (path === '/api/lists') {
       if (method === 'GET') {
         await delay(120)
@@ -308,7 +319,7 @@ test('authenticated list lifecycle survives navigation, reload, reorder, and des
   expect(await page.evaluate(() => window.__uiUxDocumentMarker)).toBe('alive')
 
   await page.getByRole('button', { name: 'リストに保存' }).click()
-  await expect(page.getByRole('status')).toContainText('保存しました')
+  await expect(page.getByText('保存しました', { exact: true })).toBeVisible()
   await page.goBack()
   await expect(page.getByText('ゲーム2', { exact: true }).first()).toBeVisible()
   await page.getByRole('link', { name: /ゲーム2/ }).first().click()
@@ -316,7 +327,7 @@ test('authenticated list lifecycle survives navigation, reload, reorder, and des
   expect(await page.evaluate(() => window.__uiUxDocumentMarker)).toBe('alive')
 
   await page.getByRole('button', { name: 'リストに保存' }).click()
-  await expect(page.getByRole('status')).toContainText('保存しました')
+  await expect(page.getByText('保存しました', { exact: true })).toBeVisible()
   await page.getByRole('link', { name: '一覧で確認' }).click()
   await expect(page).toHaveURL(new RegExp(`/lists\\?list=${LIST_ID}`))
   await expect(page.locator('.lists-item')).toHaveCount(2)


### PR DESCRIPTION
## 目的
GamePageの用語集で、正準Glossary APIが未整備・取得失敗のときに旧 `structured_data.keywords` へ黙って戻る経路を削除します。

## 利用者向け完了条件
- 正準Glossaryが `available` の場合だけ登録済みConceptを表示する
- 未整備なら「用語集の正準データは未整備です。」と明示する
- 取得失敗なら「用語集の正準データを取得できませんでした。」と明示する
- 旧 `structured_data.keywords` は公開用語集として表示しない
- 旧keywordsが空でも正準Glossaryがavailableなら表示する

## 変更
- `LegacyGlossary` を削除
- 旧keywordsの有無で正準Glossary取得を止める条件を削除
- Glossary APIとConcept detail取得失敗を画面上で明示
- Playwright回帰テストを追加

新しいAPI、schema、workflow、ゲーム専用処理は追加していません。