### PR TITLE
未確認の旧ヒントとルール誤りを公開画面から外す

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -443,28 +443,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
             <div className="game-empty-note">{reviewLabel}</div>
           </div>
 
-          {sd.pro_tips?.length > 0 && (
-            <div className="pro-card">
-              <div className="pro-card-title">💡 PRO TIPS</div>
-              {sd.pro_tips.map((tip, i) => (
-                <div key={i} className="tip-item">
-                  <span className="tip-bullet">»</span>
-                  <span>{tip}</span>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {sd.rule_mistakes?.length > 0 && (
-            <div className="pro-card">
-              <div className="pro-card-title">⚠️ COMMON ERRORS</div>
-              {sd.rule_mistakes.map((err, i) => (
-                <div key={i} className="mistake-item">{err}</div>
-              ))}
-            </div>
-          )}
-
-          <ConceptGlossary slug={slug} legacyKeywords={sd.keywords || []} />
+          <ConceptGlossary slug={slug} />
 
           <div className="pro-card">
             <div className="pro-card-title">LINKS</div>

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -17,6 +17,8 @@ const game = {
   rules_content: '# Rules\n\n## 得点\n\n得点を計算します。',
   structured_data: {
     keywords: [{ term: '旧データの用語', description: '正準用語集ではない旧データ' }],
+    pro_tips: ['旧データの未確認ヒント'],
+    rule_mistakes: ['旧データの未確認ルール誤り'],
   },
 }
 
@@ -35,13 +37,15 @@ async function mockGameAndGlossary(page, glossaryResponse) {
   })
 }
 
-test('正準用語集が未整備なら旧keywordsへ戻らず未整備を明示する', async ({ page }) => {
+test('正準用語集が未整備なら旧structured_dataを公開表示へ戻さない', async ({ page }) => {
   await mockGameAndGlossary(page, { status: 'not_available', entries: [] })
   await page.goto('/games/glossary-test#rules')
 
   const glossary = page.locator('[aria-label="用語集"]')
   await expect(glossary.getByText('用語集の正準データは未整備です。', { exact: true })).toBeVisible()
   await expect(page.getByText('旧データの用語')).toHaveCount(0)
+  await expect(page.getByText('旧データの未確認ヒント')).toHaveCount(0)
+  await expect(page.getByText('旧データの未確認ルール誤り')).toHaveCount(0)
 })
 
 test('正準用語集の取得失敗を旧keywordsで隠さず明示する', async ({ page }) => {


### PR DESCRIPTION
Closes part of #153

## 利用者向けの完了条件
`structured_data.pro_tips` と `structured_data.rule_mistakes` に値が残っていても、GamePageで未確認情報として公開表示されないこと。

## 変更
- `PRO TIPS` と `COMMON ERRORS` のlegacy公開readを削除
- `ConceptGlossary` へ旧`keywords`を渡す不要なpropも削除
- 既存 `canonical_glossary.spec.js` に再表示防止テストを統合

正準Claim / Evidenceへの移行が確認できるまでは、旧データをverified相当へ自動昇格しません。新しいfallback、schema、workflowは追加していません。