### PR TITLE
未確認の旧戦略とAIレビューを公開画面から外す

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
-import ReactMarkdown from 'react-markdown'
 import { api } from '../lib/api'
 import { ShareButton, TwitterShareButton } from '../components/game/ShareButtons'
 import { TextToSpeech } from '../components/game/TextToSpeech'
@@ -34,8 +33,6 @@ const REVIEW_LABELS = {
 const TAB_HASHES = {
   rules: '#rules',
   coach: '#setup',
-  strategy: '#strategy',
-  reviews: '#reviews',
   graph: '#connections',
   infographics: '#visual',
 }
@@ -53,10 +50,8 @@ function formatPlayTime(game) {
   return game.play_time != null ? `${game.play_time}m` : 'N/A'
 }
 
-function isTabAvailable(tab, { hasCoachSummary, hasStrategy, hasReviews, hasInfographics }) {
+function isTabAvailable(tab, { hasCoachSummary, hasInfographics }) {
   if (tab === 'coach') return hasCoachSummary
-  if (tab === 'strategy') return hasStrategy
-  if (tab === 'reviews') return hasReviews
   if (tab === 'infographics') return hasInfographics
   return tab === 'rules' || tab === 'graph'
 }
@@ -74,7 +69,6 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const [connectionsError, setConnectionsError] = useState(false)
 
   const BASE_URL = 'https://bodoge-no-mikata.vercel.app'
-  const structuredData = game?.structured_data || {}
   const infographicsSourceUrl = game?.infographics_source_url || game?.source_url || null
   const hasInfographics = Boolean(
     game?.infographics &&
@@ -84,9 +78,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const hasCoachSummary = Boolean(
     game?.setup_summary || game?.gameplay_summary || game?.end_game_summary,
   )
-  const hasStrategy = Boolean(structuredData.strategy_analysis)
-  const hasReviews = Boolean(structuredData.persona_reviews?.length)
-  const tabAvailability = { hasCoachSummary, hasStrategy, hasReviews, hasInfographics }
+  const tabAvailability = { hasCoachSummary, hasInfographics }
 
   useEffect(() => {
     const fetchData = async () => {
@@ -127,7 +119,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
       window.removeEventListener('popstate', syncFromLocation)
       window.removeEventListener('hashchange', syncFromLocation)
     }
-  }, [game, hasCoachSummary, hasStrategy, hasReviews, hasInfographics])
+  }, [game, hasCoachSummary, hasInfographics])
 
   useEffect(() => {
     if (activeTab !== 'graph') return undefined
@@ -179,7 +171,6 @@ export default function GamePage({ slug: propSlug, initialGame }) {
 
   const title = game.title_ja || game.title || 'Untitled'
   const rules = game.rules_content || ''
-  const sd = game.structured_data || {}
   const coachSourceUrl = game.source_url || null
   const identityLabel = IDENTITY_LABELS[game.identity_status] || IDENTITY_LABELS.unverified
   const sourceTrustLabel = SOURCE_TRUST_LABELS[game.source_trust] || SOURCE_TRUST_LABELS.unknown
@@ -191,7 +182,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
     legacyInfographicsSourceUrl,
   )
 
-  const pageTitle = `「${title}」のルール${sd.strategy_analysis ? '・戦略' : ''}・インスト要約 | ボドゲのミカタ`
+  const pageTitle = `「${title}」のルール・インスト要約 | ボドゲのミカタ`
   const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
   const gameUrl = `${BASE_URL}/games/${slug}`
   const imageUrl = game.image_url || `${BASE_URL}/assets/no-image.webp`
@@ -262,16 +253,6 @@ export default function GamePage({ slug: propSlug, initialGame }) {
                 準備・流れ・終了
               </button>
             )}
-            {hasStrategy && (
-              <button type="button" aria-pressed={activeTab === 'strategy'} className={activeTab === 'strategy' ? 'active' : ''} onClick={() => navigateToTab('strategy')}>
-                戦略
-              </button>
-            )}
-            {hasReviews && (
-              <button type="button" aria-pressed={activeTab === 'reviews'} className={activeTab === 'reviews' ? 'active' : ''} onClick={() => navigateToTab('reviews')}>
-                レビュー
-              </button>
-            )}
             <button type="button" aria-pressed={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => navigateToTab('graph')}>
               関連ゲーム
             </button>
@@ -320,41 +301,6 @@ export default function GamePage({ slug: propSlug, initialGame }) {
                     </>
                   )}
                 </div>
-              </div>
-            )}
-
-            {activeTab === 'strategy' && (
-              <div className="markdown-content">
-                {sd.strategy_analysis ? (
-                  <ReactMarkdown>{sd.strategy_analysis}</ReactMarkdown>
-                ) : (
-                  <div className="game-empty-state" role="status">
-                    戦略解説はまだ登録されていません。
-                  </div>
-                )}
-              </div>
-            )}
-
-            {activeTab === 'reviews' && (
-              <div className="persona-reviews">
-                <div className="pro-card-title">SUB-AGENT PERSPECTIVES</div>
-                <p style={{ fontSize: '0.85rem', color: 'var(--text-muted)', marginBottom: '1.5rem' }}>
-                  異なるプレイスタイルのAIエージェントによる多角的な評価。
-                </p>
-
-                {sd.persona_reviews?.length > 0 ? sd.persona_reviews.map((rev, i) => (
-                  <div key={i} className="review-card">
-                    <div className="review-header">
-                      <span className="persona-badge">{rev.persona}</span>
-                      <span className="rating-badge">{rev.rating} / 10</span>
-                    </div>
-                    <div className="review-text">「{rev.review_text}」</div>
-                  </div>
-                )) : (
-                  <div className="game-empty-state" role="status">
-                    レビューはまだ登録されていません。
-                  </div>
-                )}
               </div>
             )}
 

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -19,6 +19,8 @@ const game = {
     keywords: [{ term: '旧データの用語', description: '正準用語集ではない旧データ' }],
     pro_tips: ['旧データの未確認ヒント'],
     rule_mistakes: ['旧データの未確認ルール誤り'],
+    strategy_analysis: '旧データの未確認戦略',
+    persona_reviews: [{ persona: '旧AIレビュー', rating: 10, review_text: '旧データの未確認評価' }],
   },
 }
 
@@ -46,6 +48,12 @@ test('正準用語集が未整備なら旧structured_dataを公開表示へ戻�
   await expect(page.getByText('旧データの用語')).toHaveCount(0)
   await expect(page.getByText('旧データの未確認ヒント')).toHaveCount(0)
   await expect(page.getByText('旧データの未確認ルール誤り')).toHaveCount(0)
+  await expect(page.getByText('旧データの未確認戦略')).toHaveCount(0)
+  await expect(page.getByText('旧AIレビュー')).toHaveCount(0)
+  await expect(page.getByText('旧データの未確認評価')).toHaveCount(0)
+  await expect(page.getByRole('button', { name: '戦略', exact: true })).toHaveCount(0)
+  await expect(page.getByRole('button', { name: 'レビュー', exact: true })).toHaveCount(0)
+  await expect(page).toHaveTitle(/「用語集テスト」のルール・インスト要約/)
 })
 
 test('正準用語集の取得失敗を旧keywordsで隠さず明示する', async ({ page }) => {

--- a/frontend/tests/game_layout.spec.js
+++ b/frontend/tests/game_layout.spec.js
@@ -102,26 +102,10 @@ test('game detail keeps one primary flow and readable long-form measure', async 
   await expect(page.locator('.quick-rules-panel')).toHaveCount(0)
 })
 
-test('game page title advertises strategy only when strategy content exists', async ({ page }) => {
+test('legacy strategy content does not change the public page title', async ({ page }) => {
   await mockGameApi(page)
   await page.goto('/games/big-shot')
-  await expect(page).toHaveTitle('「ビッグショット」のルール・戦略・インスト要約 | ボドゲのミカタ')
-})
-
-test('game page title omits strategy when strategy content is absent', async ({ page }) => {
-  const withoutStrategy = {
-    ...bigShot,
-    slug: 'no-strategy',
-    title_ja: '戦略なしゲーム',
-    structured_data: {
-      ...bigShot.structured_data,
-      strategy_analysis: null,
-    },
-  }
-
-  await mockGameApi(page, withoutStrategy)
-  await page.goto('/games/no-strategy')
-  await expect(page).toHaveTitle('「戦略なしゲーム」のルール・インスト要約 | ボドゲのミカタ')
+  await expect(page).toHaveTitle('「ビッグショット」のルール・インスト要約 | ボドゲのミカタ')
 })
 
 test('game detail uses one native button group for canonical game detail views', async ({ page }) => {
@@ -186,25 +170,24 @@ test('preparation flow only appears when at least one game-specific summary exis
   await expect(page.getByText(bigShot.end_game_summary)).toBeVisible()
 })
 
-test('empty strategy and review states are not exposed as detail destinations', async ({ page }) => {
-  const withoutOptionalContent = {
+test('legacy strategy and AI reviews are not exposed as detail destinations', async ({ page }) => {
+  const withLegacyOptionalContent = {
     ...bigShot,
-    slug: 'empty-optional-content',
+    slug: 'legacy-optional-content',
     structured_data: {
       ...bigShot.structured_data,
-      strategy_analysis: null,
-      persona_reviews: [],
+      persona_reviews: [{ persona: '旧AIレビュー', rating: 10, review_text: '旧データの未確認評価' }],
     },
   }
 
-  await mockGameApi(page, withoutOptionalContent)
-  await page.goto('/games/empty-optional-content')
+  await mockGameApi(page, withLegacyOptionalContent)
+  await page.goto('/games/legacy-optional-content')
 
   await expect(page.getByRole('button', { name: '戦略', exact: true })).toHaveCount(0)
   await expect(page.getByRole('button', { name: 'レビュー', exact: true })).toHaveCount(0)
-  await expect(page.getByText('戦略解説はまだ登録されていません。', { exact: true })).toHaveCount(0)
-  await expect(page.getByText('レビューはまだ登録されていません。', { exact: true })).toHaveCount(0)
-  await expect(page.getByText(/再生成してください/)).toHaveCount(0)
+  await expect(page.getByText('資金効率を優先します。')).toHaveCount(0)
+  await expect(page.getByText('旧AIレビュー')).toHaveCount(0)
+  await expect(page.getByText('旧データの未確認評価')).toHaveCount(0)
 })
 
 test('game share uses Web Share when available', async ({ page }) => {
@@ -220,7 +203,7 @@ test('game share uses Web Share when available', async ({ page }) => {
 
   await page.getByRole('button', { name: '共有', exact: true }).click()
   expect(await page.evaluate(() => window.__shared)).toEqual({
-    title: '「ビッグショット」のルール・戦略・インスト要約 | ボドゲのミカタ',
+    title: '「ビッグショット」のルール・インスト要約 | ボドゲのミカタ',
     url: 'https://bodoge-no-mikata.vercel.app/games/big-shot',
   })
   await expect(page.getByRole('button', { name: '共有しました' })).toBeVisible()


### PR DESCRIPTION
## 目的

`structured_data.strategy_analysis` と `structured_data.persona_reviews` は、正準のStrategy / Advice・Review / Interpretationへ移行済みという証拠がないままGamePageで直接表示されていました。

## ユーザー向け成功条件

旧 `structured_data` に戦略やAIレビューが残っていても、公開GamePageのタブ、本文、ページタイトルへ表示されないこと。

## 変更

- 旧 `strategy_analysis` 由来の「戦略」タブと本文を削除
- 旧 `persona_reviews` 由来の「レビュー」タブと本文を削除
- `strategy_analysis` の存在でSEOタイトルへ「戦略」を足す処理を削除
- 不要になった `ReactMarkdown` と旧tab判定を削除
- 既存 `canonical_glossary.spec.js` に再表示防止を追加

## 境界

正準データを新設せず、未確認のlegacy readだけを削除します。データベース内の旧fieldはこのPRでは削除しません。

#153 の一部を進めます。