### PR TITLE
正準用語集を別名でも検索できるようにする

### DIFF
--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -2,8 +2,17 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
 
+function normalizeSearchText(value) {
+  return String(value || '')
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 export function ConceptGlossary({ slug }) {
   const [entries, setEntries] = useState([])
+  const [query, setQuery] = useState('')
   const [selectedId, setSelectedId] = useState(null)
   const [detail, setDetail] = useState(null)
   const [fetchStatus, setFetchStatus] = useState('loading')
@@ -30,6 +39,19 @@ export function ConceptGlossary({ slug }) {
 
     return () => { cancelled = true }
   }, [slug])
+
+  const normalizedQuery = normalizeSearchText(query)
+  const filteredEntries = useMemo(() => {
+    if (!normalizedQuery) return entries
+    const tokens = normalizedQuery.split(' ').filter(Boolean)
+    return entries.filter((entry) => {
+      const searchable = normalizeSearchText([
+        entry.label,
+        ...(entry.aliases || []),
+      ].join(' '))
+      return tokens.every((token) => searchable.includes(token))
+    })
+  }, [entries, normalizedQuery])
 
   const selected = useMemo(
     () => entries.find((entry) => entry.concept_id === selectedId) || null,
@@ -84,20 +106,41 @@ export function ConceptGlossary({ slug }) {
   return (
     <div className="pro-card" aria-label="用語集">
       <div className="pro-card-title">GLOSSARY · LINKED VIEW</div>
-      <div className="tag-list">
-        {entries.map((entry) => (
-          <button
-            key={entry.concept_id}
-            type="button"
-            className="tag-item"
-            aria-expanded={selectedId === entry.concept_id}
-            onClick={() => selectConcept(entry.concept_id)}
-            style={{ cursor: 'pointer', font: 'inherit' }}
-          >
-            {entry.label}
-          </button>
-        ))}
-      </div>
+      <label htmlFor={`glossary-search-${slug}`} style={{ display: 'block', marginBottom: '0.4rem' }}>
+        用語集を検索
+      </label>
+      <input
+        id={`glossary-search-${slug}`}
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="用語・別名を入力"
+        autoComplete="off"
+        style={{ width: '100%', marginBottom: '0.75rem' }}
+      />
+      {normalizedQuery && (
+        <div role="status" aria-live="polite" className="game-empty-note" style={{ marginBottom: '0.75rem' }}>
+          {filteredEntries.length > 0
+            ? `${filteredEntries.length}件の用語が見つかりました`
+            : '該当する用語は見つかりませんでした'}
+        </div>
+      )}
+      {filteredEntries.length > 0 && (
+        <div className="tag-list">
+          {filteredEntries.map((entry) => (
+            <button
+              key={entry.concept_id}
+              type="button"
+              className="tag-item"
+              aria-expanded={selectedId === entry.concept_id}
+              onClick={() => selectConcept(entry.concept_id)}
+              style={{ cursor: 'pointer', font: 'inherit' }}
+            >
+              {entry.label}
+            </button>
+          ))}
+        </div>
+      )}
 
       {selected && (
         <div

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -106,3 +106,36 @@ test('旧keywordsがなくても正準用語集がavailableなら表示する', 
   const glossary = page.locator('[aria-label="用語集"]')
   await expect(glossary.getByRole('button', { name: '得点', exact: true })).toBeVisible()
 })
+
+test('正準用語集を日本語名と英語別名のどちらからでも検索できる', async ({ page }) => {
+  await mockGameAndGlossary(page, {
+    status: 'available',
+    entries: [
+      {
+        concept_id: 'zero-bid',
+        label: '0ビッド',
+        definition: '0を宣言したビッドです。',
+        aliases: ['0 bid', 'zero bid'],
+      },
+      {
+        concept_id: 'mermaid',
+        label: 'Mermaid',
+        definition: '特殊カードです。',
+        aliases: ['人魚'],
+      },
+    ],
+  })
+  await page.goto('/games/glossary-test#rules')
+
+  const glossary = page.locator('[aria-label="用語集"]')
+  const search = glossary.getByRole('searchbox', { name: '用語集を検索' })
+
+  await search.fill('0 bid')
+  await expect(glossary.getByRole('status')).toHaveText('1件の用語が見つかりました')
+  await expect(glossary.getByRole('button', { name: '0ビッド', exact: true })).toBeVisible()
+  await expect(glossary.getByRole('button', { name: 'Mermaid', exact: true })).toHaveCount(0)
+
+  await search.fill('人魚')
+  await expect(glossary.getByRole('status')).toHaveText('1件の用語が見つかりました')
+  await expect(glossary.getByRole('button', { name: 'Mermaid', exact: true })).toBeVisible()
+})


### PR DESCRIPTION
Closes part of #272.

## 利用者への変化
- 正準Glossaryの日本語名だけでなく、登録済みaliasから同じConceptを見つけられるようにする。
- `0 bid` → `0ビッド` のような検索を、legacy `structured_data.keywords`へ戻さず成立させる。
- 用語集が未整備・取得失敗の場合は従来どおり明示し、別データへfallbackしない。

## 成功条件
正準Glossaryに `0ビッド` / alias `0 bid` が存在する場合、GamePageの用語集で `0 bid` を入力すると `0ビッド` だけが検索結果として表示される。

## 検証
既存のcanonical glossary Playwrightへ日本語名・英語alias検索の回帰テストを追加した。新API・schema・workflow・ゲーム専用処理は追加していない。