### PR TITLE
未確認の用語集ルール参照を公開しない

### DIFF
--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -10,6 +10,10 @@ function normalizeSearchText(value) {
     .trim()
 }
 
+function isVerifiedRuleReference(reference) {
+  return reference?.verification_status === 'source_bound' || reference?.verification_status === 'verified'
+}
+
 export function ConceptGlossary({ slug }) {
   const [entries, setEntries] = useState([])
   const [query, setQuery] = useState('')
@@ -56,6 +60,10 @@ export function ConceptGlossary({ slug }) {
   const selected = useMemo(
     () => entries.find((entry) => entry.concept_id === selectedId) || null,
     [entries, selectedId],
+  )
+  const verifiedRuleReferences = useMemo(
+    () => selected?.rule_references?.filter(isVerifiedRuleReference) || [],
+    [selected],
   )
 
   const selectConcept = async (conceptId) => {
@@ -165,14 +173,19 @@ export function ConceptGlossary({ slug }) {
               <div className="game-empty-note">{selected.related_concept_ids.join(' · ')}</div>
             </div>
           )}
-          {selected.rule_references?.length > 0 && (
+          {verifiedRuleReferences.length > 0 && (
             <div style={{ marginTop: '0.75rem' }}>
               <strong style={{ fontSize: '0.78rem' }}>このゲームでは</strong>
-              {selected.rule_references.map((reference) => (
+              {verifiedRuleReferences.map((reference) => (
                 <div key={`${reference.rule_id}-${reference.reference_kind}`} className="game-empty-note" style={{ marginTop: '6px' }}>
                   {reference.normalized_statement}
                 </div>
               ))}
+            </div>
+          )}
+          {selected.rule_references?.length > 0 && verifiedRuleReferences.length === 0 && (
+            <div className="game-empty-note" style={{ marginTop: '0.75rem' }}>
+              確認済みの関連ルールはありません。
             </div>
           )}
           {detailError && (

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -139,3 +139,70 @@ test('正準用語集を日本語名と英語別名のどちらからでも検�
   await expect(glossary.getByRole('status')).toHaveText('1件の用語が見つかりました')
   await expect(glossary.getByRole('button', { name: 'Mermaid', exact: true })).toBeVisible()
 })
+
+test('未確認の関連ルールは表示せず、確認済みの参照だけ表示する', async ({ page }) => {
+  await mockGameAndGlossary(page, {
+    status: 'available',
+    entries: [
+      {
+        concept_id: 'scoring',
+        label: '得点',
+        definition: 'ゲームの得点に関する用語です。',
+        aliases: [],
+        rule_references: [
+          {
+            rule_id: 'rule-unverified',
+            node_type: 'scoring',
+            normalized_statement: '未確認の得点ルールです。',
+            reference_kind: 'mentions',
+            verification_status: 'unknown',
+          },
+          {
+            rule_id: 'rule-verified',
+            node_type: 'scoring',
+            normalized_statement: '確認済みの得点ルールです。',
+            reference_kind: 'defines',
+            verification_status: 'verified',
+          },
+        ],
+      },
+    ],
+  })
+  await page.goto('/games/glossary-test#rules')
+
+  const glossary = page.locator('[aria-label="用語集"]')
+  await glossary.getByRole('button', { name: '得点', exact: true }).click()
+
+  await expect(glossary.getByText('確認済みの得点ルールです。', { exact: true })).toBeVisible()
+  await expect(glossary.getByText('未確認の得点ルールです。', { exact: true })).toHaveCount(0)
+})
+
+test('関連ルールが未確認だけなら未確認文を隠して状態を明示する', async ({ page }) => {
+  await mockGameAndGlossary(page, {
+    status: 'available',
+    entries: [
+      {
+        concept_id: 'scoring',
+        label: '得点',
+        definition: 'ゲームの得点に関する用語です。',
+        aliases: [],
+        rule_references: [
+          {
+            rule_id: 'rule-unverified',
+            node_type: 'scoring',
+            normalized_statement: '未確認の得点ルールです。',
+            reference_kind: 'mentions',
+            verification_status: 'unknown',
+          },
+        ],
+      },
+    ],
+  })
+  await page.goto('/games/glossary-test#rules')
+
+  const glossary = page.locator('[aria-label="用語集"]')
+  await glossary.getByRole('button', { name: '得点', exact: true }).click()
+
+  await expect(glossary.getByText('未確認の得点ルールです。', { exact: true })).toHaveCount(0)
+  await expect(glossary.getByText('確認済みの関連ルールはありません。', { exact: true })).toBeVisible()
+})


### PR DESCRIPTION
## ユーザー向けの問題

正準Glossaryの`rule_references`には確認状態がありますが、GamePageは`unknown`の参照も「このゲームでは」と断定表示していました。

## 成功条件

- `verification_status=source_bound`または`verified`の関連ルールだけを表示する
- `unknown`の文は公開しない
- 関連ルールが未確認だけの場合は「確認済みの関連ルールはありません。」と明示する
- legacyデータや別のfallbackを追加しない

## 変更

- `ConceptGlossary`で確認済みの`rule_references`だけを表示
- 既存`canonical_glossary.spec.js`へ混在ケースと未確認のみケースの回帰テストを統合

#272 のGlossary→canonical rule接続を進める前に、未確認参照を利用者へ断定表示しないための信頼性修正です。