### PR TITLE
日本語用語集から公式英語名称でもConceptを検索できるようにする

### DIFF
--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -74,7 +74,7 @@ class ConceptTaxonomyService:
                 label = next(iter(reference.preferred_labels.values()))
             if not label:
                 continue
-            aliases = reference.alternate_labels.get(language_code, [])
+            aliases = self._glossary_aliases(reference, language_code, label)
             entries.append(
                 GlossaryEntry(
                     concept_id=reference.concept_id,
@@ -88,6 +88,22 @@ class ConceptTaxonomyService:
         if not entries:
             return GameGlossaryReadResponse(status="not_available", **base)
         return GameGlossaryReadResponse(status="available", entries=entries, **base)
+
+    @staticmethod
+    def _glossary_aliases(reference: GameConceptReference, language_code: str, label: str) -> list[str]:
+        languages = [language_code]
+        if language_code.lower() != "en":
+            languages.append("en")
+
+        aliases: list[str] = []
+        for language in languages:
+            preferred = reference.preferred_labels.get(language)
+            if preferred and preferred != label and preferred not in aliases:
+                aliases.append(preferred)
+            for alternate in reference.alternate_labels.get(language, []):
+                if alternate != label and alternate not in aliases:
+                    aliases.append(alternate)
+        return aliases
 
     @classmethod
     def _load_concept(cls, concept_id: str) -> ConceptDetailResponse | None:

--- a/backend/tests/test_glossary_search_labels.py
+++ b/backend/tests/test_glossary_search_labels.py
@@ -1,0 +1,30 @@
+from app.models.concept_taxonomy import GameConceptReference
+from app.services.concept_taxonomy import ConceptTaxonomyService
+
+
+def test_japanese_glossary_includes_canonical_english_label_for_search():
+    reference = GameConceptReference(
+        concept_id="player-action.bid",
+        concept_type="player_action",
+        usage_role="glossary",
+        preferred_labels={"ja": "ビッド", "en": "Bid"},
+        alternate_labels={"ja": ["入札"], "en": ["Bidding"]},
+    )
+
+    aliases = ConceptTaxonomyService._glossary_aliases(reference, "ja", "ビッド")
+
+    assert aliases == ["入札", "Bid", "Bidding"]
+
+
+def test_english_glossary_does_not_mix_unrequested_language_labels():
+    reference = GameConceptReference(
+        concept_id="player-action.bid",
+        concept_type="player_action",
+        usage_role="glossary",
+        preferred_labels={"ja": "ビッド", "en": "Bid"},
+        alternate_labels={"ja": ["入札"], "en": ["Bidding"]},
+    )
+
+    aliases = ConceptTaxonomyService._glossary_aliases(reference, "en", "Bid")
+
+    assert aliases == ["Bidding"]


### PR DESCRIPTION
## Before → After

日本語Glossaryは日本語の別名だけを`aliases`へ返していたため、同じ正準Conceptに公式英語名称が登録済みでも、`Bid`など英語名称から検索できませんでした。

このPRでは新しい用語データを作らず、既存`concept_labels`の正準英語名称・英語別名を日本語Glossaryの検索候補へ投影します。

## 利用者向け成功条件

- `language_code=ja`で表示名が「ビッド」のConceptに公式英語名称`Bid`がある場合、`Bid`でも同じConceptを検索できる
- 日本語の既存別名を維持する
- 英語Glossaryでは要求していない日本語labelを混ぜない
- legacy `structured_data.keywords`へfallbackしない

## 根拠

Skull Kingの正準Concept seedには、日本語「ビッド」と英語`Bid`など同一Conceptの正式labelが既に登録されています。

Grandpa Beck's Games current Skull King rules:
https://www.grandpabecksgames.com/pages/skull-king

#272 の日本語 / 英語lookup要件を進めます。