### PR TITLE
確認済み用語ルールから登録済み出典を開けるようにする

### DIFF
--- a/backend/app/models/concept_taxonomy.py
+++ b/backend/app/models/concept_taxonomy.py
@@ -140,6 +140,9 @@ class RuleConceptReference(TaxonomyModel):
     normalized_statement: str
     reference_kind: RuleConceptReferenceKind
     verification_status: ConceptVerificationStatus = ConceptVerificationStatus.UNKNOWN
+    rule_set_id: str | None = None
+    source_url: str | None = None
+    source_locator: str | None = None
 
 
 class ConceptGameBacklink(TaxonomyModel):

--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -244,7 +244,7 @@ class ConceptTaxonomyService:
         for link in links:
             nodes = (
                 client.table("rule_nodes")
-                .select("rule_id,node_type,normalized_statement")
+                .select("rule_id,node_type,normalized_statement,source_url,source_locator")
                 .eq("rule_set_id", rule_set_id)
                 .eq("rule_id", link["rule_id"])
                 .limit(1)
@@ -261,6 +261,9 @@ class ConceptTaxonomyService:
                     normalized_statement=node["normalized_statement"],
                     reference_kind=link["reference_kind"],
                     verification_status=link.get("verification_status", "unknown"),
+                    rule_set_id=str(rule_set_id),
+                    source_url=node.get("source_url"),
+                    source_locator=node.get("source_locator"),
                 )
             )
         return references

--- a/backend/tests/test_glossary_search_labels.py
+++ b/backend/tests/test_glossary_search_labels.py
@@ -1,4 +1,4 @@
-from app.models.concept_taxonomy import GameConceptReference
+from app.models.concept_taxonomy import GameConceptReference, RuleConceptReference
 from app.services.concept_taxonomy import ConceptTaxonomyService
 
 
@@ -28,3 +28,20 @@ def test_english_glossary_does_not_mix_unrequested_language_labels():
     aliases = ConceptTaxonomyService._glossary_aliases(reference, "en", "Bid")
 
     assert aliases == ["Bidding"]
+
+
+def test_rule_reference_preserves_existing_ruleset_and_source_provenance():
+    reference = RuleConceptReference(
+        rule_id="round.bid",
+        node_type="turn",
+        normalized_statement="各ラウンドの開始時にビッドします。",
+        reference_kind="defines",
+        verification_status="source_bound",
+        rule_set_id="ruleset-current",
+        source_url="https://example.com/official-rules",
+        source_locator="rules:bid",
+    )
+
+    assert reference.rule_set_id == "ruleset-current"
+    assert reference.source_url == "https://example.com/official-rules"
+    assert reference.source_locator == "rules:bid"

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -178,7 +178,12 @@ export function ConceptGlossary({ slug }) {
               <strong style={{ fontSize: '0.78rem' }}>このゲームでは</strong>
               {verifiedRuleReferences.map((reference) => (
                 <div key={`${reference.rule_id}-${reference.reference_kind}`} className="game-empty-note" style={{ marginTop: '6px' }}>
-                  {reference.normalized_statement}
+                  <div>{reference.normalized_statement}</div>
+                  {reference.source_url && (
+                    <a href={reference.source_url} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: '4px' }}>
+                      出典を確認
+                    </a>
+                  )}
                 </div>
               ))}
             </div>

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -140,7 +140,7 @@ test('正準用語集を日本語名と英語別名のどちらからでも検�
   await expect(glossary.getByRole('button', { name: 'Mermaid', exact: true })).toBeVisible()
 })
 
-test('未確認の関連ルールは表示せず、確認済みの参照だけ表示する', async ({ page }) => {
+test('未確認の関連ルールは表示せず、確認済みの参照と登録済み出典だけ表示する', async ({ page }) => {
   await mockGameAndGlossary(page, {
     status: 'available',
     entries: [
@@ -156,6 +156,7 @@ test('未確認の関連ルールは表示せず、確認済みの参照だけ�
             normalized_statement: '未確認の得点ルールです。',
             reference_kind: 'mentions',
             verification_status: 'unknown',
+            source_url: 'https://example.com/unverified-source',
           },
           {
             rule_id: 'rule-verified',
@@ -163,6 +164,9 @@ test('未確認の関連ルールは表示せず、確認済みの参照だけ�
             normalized_statement: '確認済みの得点ルールです。',
             reference_kind: 'defines',
             verification_status: 'verified',
+            rule_set_id: 'ruleset-current',
+            source_url: 'https://example.com/official-rulebook',
+            source_locator: 'rules:scoring',
           },
         ],
       },
@@ -175,6 +179,8 @@ test('未確認の関連ルールは表示せず、確認済みの参照だけ�
 
   await expect(glossary.getByText('確認済みの得点ルールです。', { exact: true })).toBeVisible()
   await expect(glossary.getByText('未確認の得点ルールです。', { exact: true })).toHaveCount(0)
+  await expect(glossary.getByRole('link', { name: '出典を確認', exact: true })).toHaveAttribute('href', 'https://example.com/official-rulebook')
+  await expect(glossary.locator('a[href="https://example.com/unverified-source"]')).toHaveCount(0)
 })
 
 test('関連ルールが未確認だけなら未確認文を隠して状態を明示する', async ({ page }) => {


### PR DESCRIPTION
## 目的
用語集で確認済みの関連ルールを見つけた利用者が、そのRuleNodeに既に登録されている出典を1操作で確認できるようにします。

## Before → After
- Before: 確認済みRuleNodeの文章は表示できるが、登録済み出典へ進めない
- After: `source_bound` / `verified` のRuleNodeだけ、既存 `source_url` への「出典を確認」を表示する

## 実装
- `RuleConceptReference` に既存RuleSet / source provenanceを投影
- active RuleSetの`rule_nodes.source_url` / `source_locator`をGlossary APIへ渡す
- 確認済み参照だけ出典リンクを表示
- 未確認参照の文章・出典は引き続き非表示
- 既存backend test / `canonical_glossary.spec.js`へ回帰条件を統合

## 追加しないもの
- 新しいDB schema / migration
- 新しい検索API / database
- 文字列推測によるRuleNode結合
- legacy `structured_data` fallback

Refs #272 #254