### PR TITLE
本番用語集の正準データ欠落をproduction検証で止める

### DIFF
--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -10,6 +10,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 MECHANICAL_DNA_PATH = "/api/games/skull-king/connections?limit=8"
+SOURCE_BOUND_GLOSSARY_PATH = "/api/games/skull-king/glossary?language_code=ja"
 CATALOG_AUTH_PATH = "/api/games/splendor"
 PUBLIC_GAMES_PAGE_SIZE = 100
 SITEMAP_PATH = "/sitemap.xml"
@@ -37,6 +38,44 @@ def validate_mechanical_dna_payload(payload: Any) -> int:
         raise ValueError("connections must be a JSON array")
 
     return len(connections)
+
+
+def validate_source_bound_glossary_payload(payload: Any) -> int:
+    if not isinstance(payload, dict):
+        raise ValueError("Glossary response must be a JSON object")
+    if payload.get("status") != "available":
+        raise ValueError(f"unexpected glossary status: {payload.get('status')!r}; expected 'available'")
+
+    concepts = payload.get("concepts")
+    if not isinstance(concepts, list):
+        raise ValueError("glossary concepts must be a JSON array")
+
+    source_bound_references: list[dict[str, Any]] = []
+    for concept in concepts:
+        if not isinstance(concept, dict):
+            raise ValueError("glossary concepts must contain JSON objects")
+        references = concept.get("rule_references")
+        if not isinstance(references, list):
+            raise ValueError("glossary rule_references must be a JSON array")
+        for reference in references:
+            if not isinstance(reference, dict):
+                raise ValueError("glossary rule_references must contain JSON objects")
+            if reference.get("verification_status") == "source_bound":
+                source_bound_references.append(reference)
+
+    if not source_bound_references:
+        raise ValueError(
+            "production glossary has no source-bound rule references; "
+            "canonical RuleSet data may be missing or migrations may not be applied"
+        )
+
+    for reference in source_bound_references:
+        if not str(reference.get("rule_set_id") or "").strip():
+            raise ValueError("source-bound glossary rule reference is missing rule_set_id")
+        if not str(reference.get("source_url") or "").strip():
+            raise ValueError("source-bound glossary rule reference is missing source_url")
+
+    return len(source_bound_references)
 
 
 def validate_anonymous_catalog_patch_status(status_code: int) -> None:
@@ -270,6 +309,13 @@ def verify_production(base_url: str, timeout_seconds: float = 20.0) -> int:
     return validate_mechanical_dna_payload(payload)
 
 
+def verify_source_bound_glossary(base_url: str, timeout_seconds: float = 20.0) -> int:
+    status, body = _request(base_url, SOURCE_BOUND_GLOSSARY_PATH, timeout_seconds, "application/json")
+    if status != 200:
+        raise RuntimeError(f"source-bound glossary endpoint returned HTTP {status}")
+    return validate_source_bound_glossary_payload(json.loads(body))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Verify canonical production API contracts")
     parser.add_argument(
@@ -283,6 +329,7 @@ def main() -> None:
     args = parser.parse_args()
 
     connection_count = verify_production(args.base_url, args.timeout_seconds)
+    source_bound_glossary_references = verify_source_bound_glossary(args.base_url, args.timeout_seconds)
     auth_status = verify_anonymous_catalog_patch(args.base_url, args.timeout_seconds)
     indexability, current_slugs = verify_search_indexability(args.base_url, args.timeout_seconds)
     indexability.update(compare_indexability_state(current_slugs, args.previous_indexability_state))
@@ -292,7 +339,9 @@ def main() -> None:
 
     print(
         "Production API contracts: OK "
-        f"(mechanical_dna_connections={connection_count}, anonymous_catalog_patch={auth_status})"
+        f"(mechanical_dna_connections={connection_count}, "
+        f"source_bound_glossary_references={source_bound_glossary_references}, "
+        f"anonymous_catalog_patch={auth_status})"
     )
     print(json.dumps({"search_indexability": indexability}, ensure_ascii=False, sort_keys=True))
 

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -9,6 +9,7 @@ from app.scripts.verify_production_contract import (
     indexability_reasons,
     validate_anonymous_catalog_patch_status,
     validate_mechanical_dna_payload,
+    validate_source_bound_glossary_payload,
 )
 
 
@@ -58,6 +59,53 @@ def test_validate_mechanical_dna_payload_fails_closed(field, value):
 
     with pytest.raises(ValueError):
         validate_mechanical_dna_payload(payload)
+
+
+def test_validate_source_bound_glossary_payload_accepts_canonical_rule_reference():
+    payload = {
+        "status": "available",
+        "concepts": [
+            {
+                "display_label": "ビッド",
+                "rule_references": [
+                    {
+                        "verification_status": "source_bound",
+                        "rule_set_id": "current-rule-set",
+                        "source_url": "https://example.com/official-rules",
+                    }
+                ],
+            }
+        ],
+    }
+
+    assert validate_source_bound_glossary_payload(payload) == 1
+
+
+def test_validate_source_bound_glossary_payload_fails_when_rule_links_are_missing():
+    payload = {
+        "status": "available",
+        "concepts": [{"display_label": "ビッド", "rule_references": []}],
+    }
+
+    with pytest.raises(ValueError, match="no source-bound rule references"):
+        validate_source_bound_glossary_payload(payload)
+
+
+@pytest.mark.parametrize("missing_field", ["rule_set_id", "source_url"])
+def test_validate_source_bound_glossary_payload_requires_current_ruleset_and_source(missing_field):
+    reference = {
+        "verification_status": "source_bound",
+        "rule_set_id": "current-rule-set",
+        "source_url": "https://example.com/official-rules",
+    }
+    reference[missing_field] = ""
+    payload = {
+        "status": "available",
+        "concepts": [{"display_label": "ビッド", "rule_references": [reference]}],
+    }
+
+    with pytest.raises(ValueError, match=missing_field):
+        validate_source_bound_glossary_payload(payload)
 
 
 @pytest.mark.parametrize("status_code", [401, 403])


### PR DESCRIPTION
## 目的
Vercelのdeploymentが成功していても、本番Supabaseへ必要なデータ変更が反映されず、プレイヤー向け用語集の確認済み関連ルールが0件になる再発を止めます。

## プレイヤー向け完了条件
公開後のSkull King用語集に、現行RuleSetへ結び付いた`source_bound`の関連ルールが1件以上存在し、その関連ルールから公式出典URLを取得できること。

## 変更
- 既存`verify_production_contract.py`へcanonical Glossary APIの検証を統合
- `source_bound`関連ルールが0件ならfail loudly
- `source_bound`なのに`rule_set_id`または`source_url`が欠けていてもfail loudly
- 既存`test_production_contract.py`へ成功・欠落・不完全出典の回帰テストを追加

新しいworkflow、DB schema、retry、fallback、ゲーム専用scriptは追加しません。productionの実ユーザー向けデータを既存release検証で読むことで、CI greenとproduction data PASSを分離します。