### PR TITLE
production Glossary検証を実API構造に合わせる

### DIFF
--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -46,15 +46,15 @@ def validate_source_bound_glossary_payload(payload: Any) -> int:
     if payload.get("status") != "available":
         raise ValueError(f"unexpected glossary status: {payload.get('status')!r}; expected 'available'")
 
-    concepts = payload.get("concepts")
-    if not isinstance(concepts, list):
-        raise ValueError("glossary concepts must be a JSON array")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("glossary entries must be a JSON array")
 
     source_bound_references: list[dict[str, Any]] = []
-    for concept in concepts:
-        if not isinstance(concept, dict):
-            raise ValueError("glossary concepts must contain JSON objects")
-        references = concept.get("rule_references")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("glossary entries must contain JSON objects")
+        references = entry.get("rule_references")
         if not isinstance(references, list):
             raise ValueError("glossary rule_references must be a JSON array")
         for reference in references:

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -64,9 +64,9 @@ def test_validate_mechanical_dna_payload_fails_closed(field, value):
 def test_validate_source_bound_glossary_payload_accepts_canonical_rule_reference():
     payload = {
         "status": "available",
-        "concepts": [
+        "entries": [
             {
-                "display_label": "ビッド",
+                "label": "ビッド",
                 "rule_references": [
                     {
                         "verification_status": "source_bound",
@@ -84,7 +84,7 @@ def test_validate_source_bound_glossary_payload_accepts_canonical_rule_reference
 def test_validate_source_bound_glossary_payload_fails_when_rule_links_are_missing():
     payload = {
         "status": "available",
-        "concepts": [{"display_label": "ビッド", "rule_references": []}],
+        "entries": [{"label": "ビッド", "rule_references": []}],
     }
 
     with pytest.raises(ValueError, match="no source-bound rule references"):
@@ -101,7 +101,7 @@ def test_validate_source_bound_glossary_payload_requires_current_ruleset_and_sou
     reference[missing_field] = ""
     payload = {
         "status": "available",
-        "concepts": [{"display_label": "ビッド", "rule_references": [reference]}],
+        "entries": [{"label": "ビッド", "rule_references": [reference]}],
     }
 
     with pytest.raises(ValueError, match=missing_field):


### PR DESCRIPTION
## 目的
#586で追加したproduction Glossary検証を、canonical production APIの実レスポンス構造へ合わせます。

## 実データで確認した差
canonical production `/api/games/skull-king/glossary?language_code=ja` は用語配列を`entries`で返しています。#586は誤って`concepts`を期待していたため、そのままでは正しい本番データでもrelease検証が失敗します。

## 変更
- `concepts`ではなく実APIと同じ`entries`を検証
- test fixtureも実API field名の`entries` / `label`へ合わせる
- source_bound関連ルール、`rule_set_id`、`source_url`のfail-closed条件は維持

新しいfallback、workflow、schemaは追加しません。