### PR TITLE
Skull KingのGlossaryに人数条件を明示する

### DIFF
--- a/backend/app/models/concept_taxonomy.py
+++ b/backend/app/models/concept_taxonomy.py
@@ -141,6 +141,7 @@ class RuleConceptReference(TaxonomyModel):
     reference_kind: RuleConceptReferenceKind
     verification_status: ConceptVerificationStatus = ConceptVerificationStatus.UNKNOWN
     rule_set_id: str | None = None
+    player_count: int | None = Field(default=None, ge=1)
     source_url: str | None = None
     source_locator: str | None = None
 

--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -244,7 +244,7 @@ class ConceptTaxonomyService:
         for link in links:
             nodes = (
                 client.table("rule_nodes")
-                .select("rule_id,node_type,normalized_statement,source_url,source_locator")
+                .select("rule_id,node_type,normalized_statement,source_url,source_locator,metadata")
                 .eq("rule_set_id", rule_set_id)
                 .eq("rule_id", link["rule_id"])
                 .limit(1)
@@ -254,6 +254,9 @@ class ConceptTaxonomyService:
             if not nodes:
                 continue
             node = nodes[0]
+            metadata = node.get("metadata") or {}
+            condition = metadata.get("condition") if isinstance(metadata, dict) else None
+            player_count = condition.get("player_count") if isinstance(condition, dict) else None
             references.append(
                 RuleConceptReference(
                     rule_id=node["rule_id"],
@@ -262,6 +265,7 @@ class ConceptTaxonomyService:
                     reference_kind=link["reference_kind"],
                     verification_status=link.get("verification_status", "unknown"),
                     rule_set_id=str(rule_set_id),
+                    player_count=player_count if isinstance(player_count, int) and not isinstance(player_count, bool) else None,
                     source_url=node.get("source_url"),
                     source_locator=node.get("source_locator"),
                 )

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -178,6 +178,9 @@ export function ConceptGlossary({ slug }) {
               <strong style={{ fontSize: '0.78rem' }}>このゲームでは</strong>
               {verifiedRuleReferences.map((reference) => (
                 <div key={`${reference.rule_id}-${reference.reference_kind}`} className="game-empty-note" style={{ marginTop: '6px' }}>
+                  {reference.player_count && (
+                    <div style={{ fontWeight: 700, marginBottom: '2px' }}>{reference.player_count}人用</div>
+                  )}
                   <div>{reference.normalized_statement}</div>
                   {reference.source_url && (
                     <a href={reference.source_url} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: '4px' }}>

--- a/frontend/tests/glossary_player_count.spec.js
+++ b/frontend/tests/glossary_player_count.spec.js
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 902,
+  slug: 'glossary-player-count-test',
+  title: 'Glossary Player Count Test',
+  title_ja: '用語集人数条件テスト',
+  min_players: 2,
+  max_players: 8,
+  play_time: 30,
+  min_age: 8,
+  published_year: 2026,
+  summary: '用語集の人数条件表示を確認するテスト用ゲーム。',
+  source_url: 'https://example.com/source',
+  source_trust: 'official_publisher',
+  content_review_status: 'review_required',
+  rules_content: '# Rules\n\n## 特殊カード\n\n特殊カードのルールです。',
+  structured_data: {},
+}
+
+test('確認済みRuleReferenceの人数条件を明示し、条件なしを一般人数として推測しない', async ({ page }) => {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/glossary-player-count-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === '/api/games/glossary-player-count-test/glossary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'available',
+          entries: [{
+            concept_id: 'component.special-card',
+            label: '特殊カード',
+            definition: '特殊な効果を持つカードです。',
+            aliases: [],
+            rule_references: [
+              {
+                rule_id: 'two-player.tigress',
+                node_type: 'exception',
+                normalized_statement: 'GraybeardがTigressを出した場合はEscapeとして扱う。',
+                reference_kind: 'mentions',
+                verification_status: 'source_bound',
+                rule_set_id: 'ruleset-current',
+                player_count: 2,
+                source_url: 'https://example.com/official-faq',
+              },
+              {
+                rule_id: 'turn.follow-suit',
+                node_type: 'condition',
+                normalized_statement: '特殊カードはリードスートに関係なく出せる。',
+                reference_kind: 'mentions',
+                verification_status: 'source_bound',
+                rule_set_id: 'ruleset-current',
+                player_count: null,
+                source_url: 'https://example.com/official-rulebook',
+              },
+            ],
+          }],
+        }),
+      })
+      return
+    }
+    if (url.pathname.startsWith('/api/concepts/')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game_backlinks: [] }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+
+  await page.goto('/games/glossary-player-count-test#rules')
+  const glossary = page.locator('[aria-label="用語集"]')
+  await glossary.getByRole('button', { name: '特殊カード', exact: true }).click()
+
+  await expect(glossary.getByText('2人用', { exact: true })).toBeVisible()
+  await expect(glossary.getByText('GraybeardがTigressを出した場合はEscapeとして扱う。', { exact: true })).toBeVisible()
+  await expect(glossary.getByText('特殊カードはリードスートに関係なく出せる。', { exact: true })).toBeVisible()
+  await expect(glossary.getByText('4人用', { exact: true })).toHaveCount(0)
+})


### PR DESCRIPTION
Closes #209 の残件のうち、公開画面で人数条件を誤解なく投影する部分を進めます。

## Before → After
- Before: 正準RuleNodeに `condition.player_count = 2` があってもGlossary API/UIで失われ、確認済み関連ルールの適用人数を構造化表示できない。
- After: RuleNodeの既存 `player_count` 条件だけをGlossaryへ投影し、2人用ルールは「2人用」と明示する。条件がないルールを一般人数として推測しない。

## 成功条件
productionのSkull King Glossaryで `two-player.tigress` が `player_count: 2` を返し、公開UIで「2人用」と確認できること。

## 根拠
production DBのactive RuleSetで `two-player.tigress` は `metadata.condition.player_count = 2`、通常ルールは同条件なし。公式FAQでもGraybeardがTigressを出した場合はEscapeとして扱う裁定を確認。

## 変更
- RuleConceptReferenceへ既存 `player_count` を投影
- ConceptGlossaryで人数条件を明示
- Playwright回帰テストを追加

新しいRuleSet、ルール本文、fallback、workflowは追加しません。