### PR TITLE
Vercel CDNで公開ゲームreadを実際にキャッシュする

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
 
 PUBLIC_GAME_BROWSER_CACHE = "public, max-age=0, must-revalidate"
-PUBLIC_GAME_CDN_CACHE = "public, max-age=60, stale-while-revalidate=300"
+PUBLIC_GAME_VERCEL_CDN_CACHE = "public, max-age=60, stale-while-revalidate=300"
 
 
 def is_public_game_read_path(path: str) -> bool:
@@ -31,7 +31,7 @@ async def cache_public_game_reads(request: Request, call_next):
     response = await call_next(request)
     if request.method == "GET" and response.status_code == 200 and is_public_game_read_path(request.url.path):
         response.headers["Cache-Control"] = PUBLIC_GAME_BROWSER_CACHE
-        response.headers["CDN-Cache-Control"] = PUBLIC_GAME_CDN_CACHE
+        response.headers["Vercel-CDN-Cache-Control"] = PUBLIC_GAME_VERCEL_CDN_CACHE
     return response
 
 

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -183,7 +183,7 @@ def test_directory_query_parameters_are_forwarded(monkeypatch):
     }
 
 
-def test_public_game_reads_use_browser_and_cdn_cache_control(monkeypatch):
+def test_public_game_reads_use_browser_and_vercel_cdn_cache_control(monkeypatch):
     async def fake_directory_query(**kwargs):
         return {
             "data": [{"id": "game-1", "slug": "example", "title": "Example", "work_id": "work-1"}],
@@ -202,7 +202,8 @@ def test_public_game_reads_use_browser_and_cdn_cache_control(monkeypatch):
         for response in (detail, listing):
             assert response.status_code == 200
             assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
-            assert response.headers["cdn-cache-control"] == "public, max-age=60, stale-while-revalidate=300"
+            assert response.headers["vercel-cdn-cache-control"] == "public, max-age=60, stale-while-revalidate=300"
+            assert "cdn-cache-control" not in response.headers
     finally:
         production_app.dependency_overrides.clear()
 
@@ -217,6 +218,7 @@ def test_cache_headers_do_not_apply_to_health_mutation_or_missing_game():
         missing = client.get("/api/games/not-found")
 
         for response in (health, patch, missing):
+            assert "vercel-cdn-cache-control" not in response.headers
             assert "cdn-cache-control" not in response.headers
     finally:
         production_app.dependency_overrides.clear()


### PR DESCRIPTION
Refs #255

## Before → After
- Before: #589で`CDN-Cache-Control`を返すようにしたが、canonical productionの`/api/games/skull-king`を同一URLで連続取得しても`x-vercel-cache: MISS`、`age: 0`のままで成功条件を満たしていない。
- After: Vercel公式のVercel固有ヘッダー`Vercel-CDN-Cache-Control`を使用し、ブラウザ向け`Cache-Control: public, max-age=0, must-revalidate`は維持する。

## 利用者向け成功条件
canonical productionの同じ公開Game APIを連続取得したとき、2回目以降で`x-vercel-cache: HIT`または`STALE`を実測できること。更新系、認証系、404には共有キャッシュを付けないこと。

## 変更
- 既存public game read middlewareの`CDN-Cache-Control`を`Vercel-CDN-Cache-Control`へ置換
- 既存game route testを同じ契約へ更新
- 新しいmiddleware、package、workflow、retry、別cache authorityは追加しない

## 根拠
Vercel公式ドキュメントはVercel CDN専用制御に`Vercel-CDN-Cache-Control`を提供している。productionでHIT/STALEを確認できなければPASS扱いにしない。