### PR TITLE
Vercel FunctionのCDNキャッシュ指示をs-maxageへ合わせる

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
 
 PUBLIC_GAME_BROWSER_CACHE = "public, max-age=0, must-revalidate"
-PUBLIC_GAME_VERCEL_CDN_CACHE = "public, max-age=60, stale-while-revalidate=300"
+PUBLIC_GAME_VERCEL_CDN_CACHE = "public, s-maxage=60, stale-while-revalidate=300"
 
 
 def is_public_game_read_path(path: str) -> bool:

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -202,7 +202,7 @@ def test_public_game_reads_use_browser_and_vercel_cdn_cache_control(monkeypatch)
         for response in (detail, listing):
             assert response.status_code == 200
             assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
-            assert response.headers["vercel-cdn-cache-control"] == "public, max-age=60, stale-while-revalidate=300"
+            assert response.headers["vercel-cdn-cache-control"] == "public, s-maxage=60, stale-while-revalidate=300"
             assert "cdn-cache-control" not in response.headers
     finally:
         production_app.dependency_overrides.clear()


### PR DESCRIPTION
Refs #255

## Before → After
- Before: #590をexact mainへproduction deployした後も、canonical `/api/games/skull-king` の連続取得は `x-vercel-cache: MISS` / `age: 0` のままだった。
- After: Vercel公式のFunctions向け要件どおり、Vercel CDN専用ヘッダーを `s-maxage=60, stale-while-revalidate=300` にする。ブラウザ向け `Cache-Control: public, max-age=0, must-revalidate` は維持する。

## 利用者向け成功条件
canonical productionの同じ公開Game APIを連続取得したとき、2回目以降で `x-vercel-cache: HIT` または `STALE` を確認できること。

## 変更
- `Vercel-CDN-Cache-Control` の `max-age=60` を `s-maxage=60` へ置換
- 既存game route testを同じ契約へ更新
- 新しいmiddleware、workflow、retry、fallbackは追加しない

## 根拠
Vercel公式「Vercel CDN Cache」はFunction responseのCDNキャッシュに `s-maxage` を含むCache-Control directiveを要求している。production実測が成功するまでPASS扱いにしない。