### PR TITLE
公開ゲームreadの共有キャッシュをVercel Function仕様へ合わせる

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,8 +12,7 @@ from app.services.sitemap import get_sitemap_xml
 setup_logging()
 app = FastAPI(title="RuleScribe Minimal", version="1.0.0")
 
-PUBLIC_GAME_BROWSER_CACHE = "public, max-age=0, must-revalidate"
-PUBLIC_GAME_VERCEL_CDN_CACHE = "public, s-maxage=60, stale-while-revalidate=300"
+PUBLIC_GAME_CACHE_CONTROL = "public, max-age=0, s-maxage=60, stale-while-revalidate=300"
 
 
 def is_public_game_read_path(path: str) -> bool:
@@ -30,8 +29,7 @@ def is_public_game_read_path(path: str) -> bool:
 async def cache_public_game_reads(request: Request, call_next):
     response = await call_next(request)
     if request.method == "GET" and response.status_code == 200 and is_public_game_read_path(request.url.path):
-        response.headers["Cache-Control"] = PUBLIC_GAME_BROWSER_CACHE
-        response.headers["Vercel-CDN-Cache-Control"] = PUBLIC_GAME_VERCEL_CDN_CACHE
+        response.headers["Cache-Control"] = PUBLIC_GAME_CACHE_CONTROL
     return response
 
 

--- a/backend/tests/test_games_router.py
+++ b/backend/tests/test_games_router.py
@@ -183,7 +183,7 @@ def test_directory_query_parameters_are_forwarded(monkeypatch):
     }
 
 
-def test_public_game_reads_use_browser_and_vercel_cdn_cache_control(monkeypatch):
+def test_public_game_reads_use_browser_and_shared_cdn_cache_control(monkeypatch):
     async def fake_directory_query(**kwargs):
         return {
             "data": [{"id": "game-1", "slug": "example", "title": "Example", "work_id": "work-1"}],
@@ -201,8 +201,10 @@ def test_public_game_reads_use_browser_and_vercel_cdn_cache_control(monkeypatch)
 
         for response in (detail, listing):
             assert response.status_code == 200
-            assert response.headers["cache-control"] == "public, max-age=0, must-revalidate"
-            assert response.headers["vercel-cdn-cache-control"] == "public, s-maxage=60, stale-while-revalidate=300"
+            assert response.headers["cache-control"] == (
+                "public, max-age=0, s-maxage=60, stale-while-revalidate=300"
+            )
+            assert "vercel-cdn-cache-control" not in response.headers
             assert "cdn-cache-control" not in response.headers
     finally:
         production_app.dependency_overrides.clear()


### PR DESCRIPTION
## 変更前
productionで `/api/games/skull-king` を連続取得しても `x-vercel-cache: MISS` / `age: 0` のままで、実際にserverless functionとSupabaseへ到達していた。

## 変更
- 公開ゲームreadのキャッシュ指定を `Cache-Control: public, max-age=0, s-maxage=60, stale-while-revalidate=300` の1本へ統合
- `Vercel-CDN-Cache-Control` の重複authorityを削除
- 既存route testへ同じ契約を統合

Vercelの標準Function向け公式仕様は `Cache-Control` の `s-maxage` でCDN TTLを指定する。

## プレイヤー向け成功条件
同じ公開ゲームAPIを短時間に連続取得したとき、2回目以降がVercel CDNから返り、ゲーム内容は同じままorigin/Supabase readを削減できること。

## production確認
merge後にexact main deploymentを確認し、canonical productionで `x-vercel-cache` / `age` とruntime invocationを実測する。HITが成立しなければproduction PASSにしない。

Related: #255