### PR TITLE
productionで公開ゲームAPIのCDNキャッシュを検証する

### DIFF
--- a/backend/app/scripts/verify_production_contract.py
+++ b/backend/app/scripts/verify_production_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import uuid
 import xml.etree.ElementTree as ET
 from collections import Counter
 from pathlib import Path
@@ -11,6 +12,7 @@ from urllib.request import Request, urlopen
 
 MECHANICAL_DNA_PATH = "/api/games/skull-king/connections?limit=8"
 SOURCE_BOUND_GLOSSARY_PATH = "/api/games/skull-king/glossary?language_code=ja"
+PUBLIC_GAME_CACHE_PATH = "/api/games/skull-king"
 CATALOG_AUTH_PATH = "/api/games/splendor"
 PUBLIC_GAMES_PAGE_SIZE = 100
 SITEMAP_PATH = "/sitemap.xml"
@@ -76,6 +78,27 @@ def validate_source_bound_glossary_payload(payload: Any) -> int:
             raise ValueError("source-bound glossary rule reference is missing source_url")
 
     return len(source_bound_references)
+
+
+def validate_public_cache_observation(
+    first_status: int,
+    second_status: int,
+    first_body: bytes,
+    second_body: bytes,
+    second_cache_status: str | None,
+) -> None:
+    if first_status != 200 or second_status != 200:
+        raise ValueError(
+            "public game cache probe must return HTTP 200 twice; "
+            f"received first={first_status}, second={second_status}"
+        )
+    if first_body != second_body:
+        raise ValueError("public game cache probe returned different response bodies")
+    if second_cache_status != "HIT":
+        raise ValueError(
+            "public game cache probe did not hit Vercel CDN on the second request; "
+            f"x-vercel-cache={second_cache_status!r}"
+        )
 
 
 def validate_anonymous_catalog_patch_status(status_code: int) -> None:
@@ -264,6 +287,43 @@ def verify_anonymous_catalog_patch(base_url: str, timeout_seconds: float = 20.0)
     return status_code
 
 
+def verify_public_game_cache(base_url: str, timeout_seconds: float = 20.0) -> str:
+    probe = uuid.uuid4().hex
+    url = f"{base_url.rstrip('/')}{PUBLIC_GAME_CACHE_PATH}?cache_probe={probe}"
+    observations: list[tuple[int, bytes, str | None]] = []
+
+    for _ in range(2):
+        request = Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "rule-scribe-games-production-contract/1.0",
+            },
+        )
+        try:
+            with urlopen(request, timeout=timeout_seconds) as response:  # noqa: S310
+                observations.append(
+                    (
+                        response.status,
+                        response.read(),
+                        response.headers.get("X-Vercel-Cache"),
+                    )
+                )
+        except HTTPError as exc:
+            observations.append((exc.code, exc.read(), exc.headers.get("X-Vercel-Cache")))
+
+    first_status, first_body, _ = observations[0]
+    second_status, second_body, second_cache_status = observations[1]
+    validate_public_cache_observation(
+        first_status,
+        second_status,
+        first_body,
+        second_body,
+        second_cache_status,
+    )
+    return str(second_cache_status)
+
+
 def verify_search_indexability(base_url: str, timeout_seconds: float = 20.0) -> tuple[dict[str, Any], list[str]]:
     games = fetch_public_games(base_url, timeout_seconds)
 
@@ -330,6 +390,7 @@ def main() -> None:
 
     connection_count = verify_production(args.base_url, args.timeout_seconds)
     source_bound_glossary_references = verify_source_bound_glossary(args.base_url, args.timeout_seconds)
+    public_game_cache = verify_public_game_cache(args.base_url, args.timeout_seconds)
     auth_status = verify_anonymous_catalog_patch(args.base_url, args.timeout_seconds)
     indexability, current_slugs = verify_search_indexability(args.base_url, args.timeout_seconds)
     indexability.update(compare_indexability_state(current_slugs, args.previous_indexability_state))
@@ -341,6 +402,7 @@ def main() -> None:
         "Production API contracts: OK "
         f"(mechanical_dna_connections={connection_count}, "
         f"source_bound_glossary_references={source_bound_glossary_references}, "
+        f"public_game_cache={public_game_cache}, "
         f"anonymous_catalog_patch={auth_status})"
     )
     print(json.dumps({"search_indexability": indexability}, ensure_ascii=False, sort_keys=True))

--- a/backend/tests/test_production_contract.py
+++ b/backend/tests/test_production_contract.py
@@ -9,6 +9,7 @@ from app.scripts.verify_production_contract import (
     indexability_reasons,
     validate_anonymous_catalog_patch_status,
     validate_mechanical_dna_payload,
+    validate_public_cache_observation,
     validate_source_bound_glossary_payload,
 )
 
@@ -106,6 +107,21 @@ def test_validate_source_bound_glossary_payload_requires_current_ruleset_and_sou
 
     with pytest.raises(ValueError, match=missing_field):
         validate_source_bound_glossary_payload(payload)
+
+
+def test_validate_public_cache_observation_accepts_second_request_hit():
+    validate_public_cache_observation(200, 200, b'{"slug":"skull-king"}', b'{"slug":"skull-king"}', "HIT")
+
+
+@pytest.mark.parametrize("cache_status", [None, "MISS", "BYPASS", "STALE"])
+def test_validate_public_cache_observation_requires_actual_second_request_hit(cache_status):
+    with pytest.raises(ValueError, match="did not hit Vercel CDN"):
+        validate_public_cache_observation(200, 200, b"same", b"same", cache_status)
+
+
+def test_validate_public_cache_observation_rejects_changed_body():
+    with pytest.raises(ValueError, match="different response bodies"):
+        validate_public_cache_observation(200, 200, b"first", b"second", "HIT")
 
 
 @pytest.mark.parametrize("status_code", [401, 403])


### PR DESCRIPTION
## 変更前
公開ゲームreadへキャッシュ指示を追加しても、release時に実際のVercel CDN HITを確認していなかった。コード上のheaderだけが正しくても、origin / Supabase readが毎回発生する状態をproduction PASSにできた。

## 変更
- 既存 `verify_production_contract.py` に公開ゲームAPIの実CDN検証を統合
- 一意なqueryを付けた同一URLを2回取得し、2回目の `X-Vercel-Cache` が `HIT` でなければfail loudly
- 2回のHTTP 200とresponse body一致も必須
- 既存 `test_production_contract.py` に判定契約を追加
- 新workflow・新scriptは追加しない

## プレイヤー向け成功条件
canonical productionの同一公開ゲームAPIを連続取得したとき、2回目がVercel CDN HITとなり、同じゲーム内容を返したままserverless function / Supabaseへの重複readを減らせること。

Related: #255