### PR TITLE
Glossaryから確認済みルールの該当sectionへ直接移動する

### DIFF
--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -2,6 +2,13 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
 
+const PRESENTATION_SECTION_HASHES = {
+  setup: '#rule-セットアップ',
+  game_flow: '#rule-ゲーム進行',
+  end_condition: '#rule-終了条件勝利',
+  scoring: '#rule-得点',
+}
+
 function normalizeSearchText(value) {
   return String(value || '')
     .normalize('NFKC')
@@ -14,6 +21,20 @@ function isVerifiedRuleReference(reference) {
   return reference?.verification_status === 'source_bound' || reference?.verification_status === 'verified'
 }
 
+function projectionRuleDestinations(projection) {
+  if (projection?.status !== 'available') return {}
+
+  const destinations = {}
+  Object.entries(PRESENTATION_SECTION_HASHES).forEach(([sectionKey, hash]) => {
+    const section = projection?.[sectionKey]
+    if (section?.status !== 'available') return
+    ;(section.items || []).forEach((item) => {
+      if (item?.rule_id) destinations[`${projection.rule_set_id}:${item.rule_id}`] = hash
+    })
+  })
+  return destinations
+}
+
 export function ConceptGlossary({ slug }) {
   const [entries, setEntries] = useState([])
   const [query, setQuery] = useState('')
@@ -22,6 +43,8 @@ export function ConceptGlossary({ slug }) {
   const [fetchStatus, setFetchStatus] = useState('loading')
   const [loadedSlug, setLoadedSlug] = useState(null)
   const [detailError, setDetailError] = useState(false)
+  const [ruleDestinations, setRuleDestinations] = useState({})
+  const [presentationError, setPresentationError] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -66,16 +89,48 @@ export function ConceptGlossary({ slug }) {
     [selected],
   )
 
+  const loadRuleDestinations = async (entry) => {
+    const ruleSetIds = [
+      ...new Set(
+        (entry?.rule_references || [])
+          .filter(isVerifiedRuleReference)
+          .map((reference) => reference.rule_set_id)
+          .filter(Boolean),
+      ),
+    ]
+    if (ruleSetIds.length === 0) return
+
+    try {
+      const projections = await Promise.all(
+        ruleSetIds.map((ruleSetId) => api.get(
+          `/api/games/${slug}/presentation?rule_set_id=${encodeURIComponent(ruleSetId)}&language_code=ja`,
+        )),
+      )
+      setRuleDestinations(Object.assign({}, ...projections.map(projectionRuleDestinations)))
+    } catch {
+      setRuleDestinations({})
+      setPresentationError(true)
+    }
+  }
+
   const selectConcept = async (conceptId) => {
     if (selectedId === conceptId) {
       setSelectedId(null)
       setDetail(null)
       setDetailError(false)
+      setRuleDestinations({})
+      setPresentationError(false)
       return
     }
     setSelectedId(conceptId)
     setDetail(null)
     setDetailError(false)
+    setRuleDestinations({})
+    setPresentationError(false)
+
+    const entry = entries.find((item) => item.concept_id === conceptId)
+    await loadRuleDestinations(entry)
+
     try {
       const response = await api.get(`/api/concepts/${encodeURIComponent(conceptId)}`)
       setDetail(response)
@@ -176,24 +231,41 @@ export function ConceptGlossary({ slug }) {
           {verifiedRuleReferences.length > 0 && (
             <div style={{ marginTop: '0.75rem' }}>
               <strong style={{ fontSize: '0.78rem' }}>このゲームでは</strong>
-              {verifiedRuleReferences.map((reference) => (
-                <div key={`${reference.rule_id}-${reference.reference_kind}`} className="game-empty-note" style={{ marginTop: '6px' }}>
-                  {reference.player_count && (
-                    <div style={{ fontWeight: 700, marginBottom: '2px' }}>{reference.player_count}人用</div>
-                  )}
-                  <div>{reference.normalized_statement}</div>
-                  {reference.source_url && (
-                    <a href={reference.source_url} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: '4px' }}>
-                      出典を確認
-                    </a>
-                  )}
-                </div>
-              ))}
+              {verifiedRuleReferences.map((reference) => {
+                const destination = ruleDestinations[`${reference.rule_set_id}:${reference.rule_id}`]
+                return (
+                  <div key={`${reference.rule_id}-${reference.reference_kind}`} className="game-empty-note" style={{ marginTop: '6px' }}>
+                    {reference.player_count && (
+                      <div style={{ fontWeight: 700, marginBottom: '2px' }}>{reference.player_count}人用</div>
+                    )}
+                    <div>{reference.normalized_statement}</div>
+                    {destination ? (
+                      <a href={destination} style={{ display: 'inline-block', marginTop: '4px', marginRight: '0.75rem' }}>
+                        詳しいルールで確認
+                      </a>
+                    ) : (
+                      <div className="game-empty-note" style={{ marginTop: '4px' }}>
+                        詳しいルール内の移動先は未確認です。
+                      </div>
+                    )}
+                    {reference.source_url && (
+                      <a href={reference.source_url} target="_blank" rel="noreferrer" style={{ display: 'inline-block', marginTop: '4px' }}>
+                        出典を確認
+                      </a>
+                    )}
+                  </div>
+                )
+              })}
             </div>
           )}
           {selected.rule_references?.length > 0 && verifiedRuleReferences.length === 0 && (
             <div className="game-empty-note" style={{ marginTop: '0.75rem' }}>
               確認済みの関連ルールはありません。
+            </div>
+          )}
+          {presentationError && (
+            <div className="game-empty-note" role="alert" style={{ marginTop: '0.75rem' }}>
+              詳しいルール内の移動先を取得できませんでした。
             </div>
           )}
           {detailError && (

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -212,3 +212,71 @@ test('関連ルールが未確認だけなら未確認文を隠して状態を�
   await expect(glossary.getByText('未確認の得点ルールです。', { exact: true })).toHaveCount(0)
   await expect(glossary.getByText('確認済みの関連ルールはありません。', { exact: true })).toBeVisible()
 })
+
+test('確認済みRuleNodeを同じRuleSetの正準Presentation Projectionから詳細ルールsectionへ移動できる', async ({ page }) => {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/glossary-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === '/api/games/glossary-test/glossary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'available',
+          entries: [{
+            concept_id: 'scoring',
+            label: '得点',
+            definition: 'ゲームの得点に関する用語です。',
+            aliases: [],
+            rule_references: [{
+              rule_id: 'rule-verified',
+              node_type: 'scoring',
+              normalized_statement: '確認済みの得点ルールです。',
+              reference_kind: 'defines',
+              verification_status: 'source_bound',
+              rule_set_id: 'ruleset-current',
+              source_url: 'https://example.com/official-rulebook',
+            }],
+          }],
+        }),
+      })
+      return
+    }
+    if (url.pathname === '/api/games/glossary-test/presentation') {
+      expect(url.searchParams.get('rule_set_id')).toBe('ruleset-current')
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'available',
+          rule_set_id: 'ruleset-current',
+          setup: { status: 'not_available', items: [] },
+          game_flow: { status: 'not_available', items: [] },
+          end_condition: { status: 'not_available', items: [] },
+          scoring: { status: 'available', items: [{ rule_id: 'rule-verified', text: '確認済みの得点ルールです。' }] },
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+  await page.route('**/api/concepts/**', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ concept: {}, game_backlinks: [] }),
+  }))
+
+  await page.goto('/games/glossary-test#rules')
+  const glossary = page.locator('[aria-label="用語集"]')
+  await glossary.getByRole('button', { name: '得点', exact: true }).click()
+
+  const localLink = glossary.getByRole('link', { name: '詳しいルールで確認', exact: true })
+  await expect(localLink).toHaveAttribute('href', '#rule-得点')
+  await localLink.click()
+
+  await expect(page).toHaveURL(/#rule-%E5%BE%97%E7%82%B9$/)
+  await expect(page.getByRole('heading', { name: '得点', exact: true })).toBeFocused()
+})


### PR DESCRIPTION
## 目的
Glossaryの確認済みRuleReferenceから、同じRuleSetのcanonical Presentation Projectionに含まれるRuleNodeだけを詳細ルールの該当sectionへ直接移動できるようにします。

## プレイヤー向け完了条件
Glossaryで確認済み関連ルールを選び「詳しいルールで確認」を押すと、同じRuleSetのPresentation Projectionで同じrule_idが確認できた場合だけ、GamePageの該当ルールsectionへ移動して見出しへフォーカスする。

## 実装
- 既存 `/api/games/{slug}/presentation` を選択時だけ取得
- `rule_set_id + rule_id` の完全一致だけで移動先を決定
- normalized_statementの文字列類似やlegacy dataは使わない
- projection取得失敗は明示し、別データへfallbackしない
- 既存 `canonical_glossary.spec.js` に回帰テストを統合

Refs #272