### PR TITLE
Glossaryから確認済みRuleNodeへ直接移動する

### DIFF
--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -2,13 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
 
-const PRESENTATION_SECTION_HASHES = {
-  setup: '#rule-セットアップ',
-  game_flow: '#rule-ゲーム進行',
-  end_condition: '#rule-終了条件勝利',
-  scoring: '#rule-得点',
-}
-
 function normalizeSearchText(value) {
   return String(value || '')
     .normalize('NFKC')
@@ -21,21 +14,40 @@ function isVerifiedRuleReference(reference) {
   return reference?.verification_status === 'source_bound' || reference?.verification_status === 'verified'
 }
 
-function projectionRuleDestinations(projection) {
-  if (projection?.status !== 'available') return {}
+function ruleNodeFragment(ruleId) {
+  return `#rule-node-${encodeURIComponent(ruleId)}`
+}
 
+function projectionRuleDestinations(projection, references) {
+  if (projection?.status !== 'available') return { destinations: {}, ruleNodes: [] }
+
+  const referenceKeys = new Set(
+    references.map((reference) => `${reference.rule_set_id}:${reference.rule_id}`),
+  )
   const destinations = {}
-  Object.entries(PRESENTATION_SECTION_HASHES).forEach(([sectionKey, hash]) => {
+  const ruleNodes = []
+
+  ;['setup', 'game_flow', 'end_condition', 'scoring'].forEach((sectionKey) => {
     const section = projection?.[sectionKey]
     if (section?.status !== 'available') return
     ;(section.items || []).forEach((item) => {
-      if (item?.rule_id) destinations[`${projection.rule_set_id}:${item.rule_id}`] = hash
+      if (!item?.rule_id) return
+      const key = `${projection.rule_set_id}:${item.rule_id}`
+      if (!referenceKeys.has(key)) return
+      destinations[key] = ruleNodeFragment(item.rule_id)
+      ruleNodes.push({
+        rule_set_id: projection.rule_set_id,
+        rule_id: item.rule_id,
+        text: item.text,
+        section_key: sectionKey,
+      })
     })
   })
-  return destinations
+
+  return { destinations, ruleNodes }
 }
 
-export function ConceptGlossary({ slug }) {
+export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
   const [entries, setEntries] = useState([])
   const [query, setQuery] = useState('')
   const [selectedId, setSelectedId] = useState(null)
@@ -90,15 +102,18 @@ export function ConceptGlossary({ slug }) {
   )
 
   const loadRuleDestinations = async (entry) => {
+    const references = (entry?.rule_references || []).filter(isVerifiedRuleReference)
     const ruleSetIds = [
       ...new Set(
-        (entry?.rule_references || [])
-          .filter(isVerifiedRuleReference)
+        references
           .map((reference) => reference.rule_set_id)
           .filter(Boolean),
       ),
     ]
-    if (ruleSetIds.length === 0) return
+    if (ruleSetIds.length === 0) {
+      onRuleNodesLoaded?.([])
+      return
+    }
 
     try {
       const projections = await Promise.all(
@@ -106,10 +121,13 @@ export function ConceptGlossary({ slug }) {
           `/api/games/${slug}/presentation?rule_set_id=${encodeURIComponent(ruleSetId)}&language_code=ja`,
         )),
       )
-      setRuleDestinations(Object.assign({}, ...projections.map(projectionRuleDestinations)))
+      const resolved = projections.map((projection) => projectionRuleDestinations(projection, references))
+      setRuleDestinations(Object.assign({}, ...resolved.map((item) => item.destinations)))
+      onRuleNodesLoaded?.(resolved.flatMap((item) => item.ruleNodes))
     } catch {
       setRuleDestinations({})
       setPresentationError(true)
+      onRuleNodesLoaded?.([])
     }
   }
 
@@ -120,6 +138,7 @@ export function ConceptGlossary({ slug }) {
       setDetailError(false)
       setRuleDestinations({})
       setPresentationError(false)
+      onRuleNodesLoaded?.([])
       return
     }
     setSelectedId(conceptId)
@@ -127,6 +146,7 @@ export function ConceptGlossary({ slug }) {
     setDetailError(false)
     setRuleDestinations({})
     setPresentationError(false)
+    onRuleNodesLoaded?.([])
 
     const entry = entries.find((item) => item.concept_id === conceptId)
     await loadRuleDestinations(entry)

--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -41,6 +41,10 @@ function sectionId(label, occurrence = 1) {
   return occurrence === 1 ? base : `${base}-${occurrence}`
 }
 
+function ruleNodeId(ruleId) {
+  return `rule-node-${ruleId}`
+}
+
 function getRuleSections(markdown = '') {
   const lines = markdown.split('\n')
   const occurrences = new Map()
@@ -136,7 +140,7 @@ function resultSnippet(section, query) {
   return section.body.length > 140 ? `${section.body.slice(0, 140)}…` : section.body
 }
 
-function RuleMarkdown({ markdown = '' }) {
+function RuleMarkdown({ markdown = '', ruleNodes = [] }) {
   const [query, setQuery] = useState('')
   const sections = useMemo(() => getRuleSections(markdown), [markdown])
   const results = useMemo(() => searchSections(sections, query), [sections, query])
@@ -163,10 +167,31 @@ function RuleMarkdown({ markdown = '' }) {
       window.removeEventListener('hashchange', focusCurrentSection)
       window.removeEventListener('popstate', focusCurrentSection)
     }
-  }, [markdown])
+  }, [markdown, ruleNodes])
 
   return (
     <>
+      {ruleNodes.length > 0 && (
+        <section className="pro-card" aria-labelledby="canonical-rule-nodes-title" style={{ marginBottom: '1rem' }}>
+          <div id="canonical-rule-nodes-title" className="pro-card-title">確認済みルール</div>
+          <div className="game-empty-note" style={{ marginBottom: '0.6rem' }}>
+            選択した用語に関連する、現在のRuleSetの確認済みルールです。
+          </div>
+          <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
+            {ruleNodes.map((ruleNode) => (
+              <li
+                key={`${ruleNode.rule_set_id}:${ruleNode.rule_id}`}
+                id={ruleNodeId(ruleNode.rule_id)}
+                tabIndex={-1}
+                style={{ marginBlock: '0.6rem', scrollMarginTop: '1rem' }}
+              >
+                <div>{ruleNode.text}</div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       {sections.length > 0 && (
         <>
           <section className="pro-card" aria-labelledby="rule-lookup-title" style={{ marginBottom: '1rem' }}>

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -67,6 +67,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const [connections, setConnections] = useState(null)
   const [connectionsLoading, setConnectionsLoading] = useState(false)
   const [connectionsError, setConnectionsError] = useState(false)
+  const [ruleNodes, setRuleNodes] = useState([])
 
   const BASE_URL = 'https://bodoge-no-mikata.vercel.app'
   const infographicsSourceUrl = game?.infographics_source_url || game?.source_url || null
@@ -99,6 +100,10 @@ export default function GamePage({ slug: propSlug, initialGame }) {
     }
     fetchData()
   }, [slug, initialGame])
+
+  useEffect(() => {
+    setRuleNodes([])
+  }, [slug])
 
   useEffect(() => {
     if (!game || typeof window === 'undefined') return undefined
@@ -264,7 +269,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
 
           <div className="pro-main-col">
-            {activeTab === 'rules' && <RuleMarkdown markdown={rules} />}
+            {activeTab === 'rules' && <RuleMarkdown markdown={rules} ruleNodes={ruleNodes} />}
 
             {activeTab === 'coach' && (
               <div className="coach-mode">
@@ -389,7 +394,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
             <div className="game-empty-note">{reviewLabel}</div>
           </div>
 
-          <ConceptGlossary slug={slug} />
+          <ConceptGlossary slug={slug} onRuleNodesLoaded={setRuleNodes} />
 
           <div className="pro-card">
             <div className="pro-card-title">LINKS</div>

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -213,7 +213,7 @@ test('関連ルールが未確認だけなら未確認文を隠して状態を�
   await expect(glossary.getByText('確認済みの関連ルールはありません。', { exact: true })).toBeVisible()
 })
 
-test('確認済みRuleNodeを同じRuleSetの正準Presentation Projectionから詳細ルールsectionへ移動できる', async ({ page }) => {
+test('確認済みRuleNodeを同じRuleSetの正準Presentation ProjectionからRuleNode単位で直接確認できる', async ({ page }) => {
   await page.route('**/api/games**', async route => {
     const url = new URL(route.request().url())
     if (url.pathname === '/api/games/glossary-test') {
@@ -274,9 +274,11 @@ test('確認済みRuleNodeを同じRuleSetの正準Presentation Projectionから
   await glossary.getByRole('button', { name: '得点', exact: true }).click()
 
   const localLink = glossary.getByRole('link', { name: '詳しいルールで確認', exact: true })
-  await expect(localLink).toHaveAttribute('href', '#rule-得点')
+  await expect(localLink).toHaveAttribute('href', '#rule-node-rule-verified')
   await localLink.click()
 
-  await expect(page).toHaveURL(/#rule-%E5%BE%97%E7%82%B9$/)
-  await expect(page.getByRole('heading', { name: '得点', exact: true })).toBeFocused()
+  await expect(page).toHaveURL(/#rule-node-rule-verified$/)
+  const ruleNode = page.locator('#rule-node-rule-verified')
+  await expect(ruleNode).toContainText('確認済みの得点ルールです。')
+  await expect(ruleNode).toBeFocused()
 })


### PR DESCRIPTION
## 変更
- Glossaryの確認済み`rule_id`と同じRuleSetのPresentation Projectionを完全一致で照合
- section単位ではなく`#rule-node-{rule_id}`へstable fragmentを付与
- 詳細ルール表示に、選択した用語に対応する確認済みRuleNodeだけを正準Projection由来で表示
- 文字列類似・legacy structured_data・新しい検索データは使わない
- 既存Playwright回帰をRuleNode単位のfocusまで更新

## 成功条件
Glossaryの確認済み関連ルールから「詳しいルールで確認」を押すと、同じRuleSetの同じ`rule_id`を持つRuleNodeへ移動し、そのRuleNodeにkeyboard focusが当たること。

Refs #272