### PR TITLE
Concept taxonomyのread失敗を未整備扱いにしない

### DIFF
--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -19,6 +19,10 @@ from app.models.concept_taxonomy import (
 logger = logging.getLogger("services.concept_taxonomy")
 
 
+class ConceptTaxonomyReadError(RuntimeError):
+    """Raised when canonical concept taxonomy data cannot be read safely."""
+
+
 class ConceptTaxonomyService:
     async def get_concept(self, concept_id: str) -> ConceptDetailResponse | None:
         if supabase.is_local():
@@ -26,8 +30,8 @@ class ConceptTaxonomyService:
         try:
             return await anyio.to_thread.run_sync(self._load_concept, concept_id)
         except Exception as exc:
-            logger.warning("Concept taxonomy unavailable for %s: %s", concept_id, exc)
-            return None
+            logger.exception("Concept taxonomy read failed for %s", concept_id)
+            raise ConceptTaxonomyReadError(f"concept taxonomy backend failure for {concept_id}") from exc
 
     async def get_by_game_slug(self, slug: str) -> GameConceptsReadResponse | None:
         game = await supabase.get_by_slug(slug)
@@ -39,8 +43,8 @@ class ConceptTaxonomyService:
         try:
             return await anyio.to_thread.run_sync(self._load_game_concepts, game, base)
         except Exception as exc:
-            logger.warning("Concept projection unavailable for %s: %s", slug, exc)
-            return GameConceptsReadResponse(status="not_available", **base)
+            logger.exception("Concept projection read failed for %s", slug)
+            raise ConceptTaxonomyReadError(f"concept projection backend failure for {slug}") from exc
 
     async def get_glossary_by_game_slug(self, slug: str, language_code: str = "ja") -> GameGlossaryReadResponse | None:
         game = await supabase.get_by_slug(slug)
@@ -60,8 +64,8 @@ class ConceptTaxonomyService:
                 {"game_id": base["game_id"], "slug": base["slug"]},
             )
         except Exception as exc:
-            logger.warning("Glossary projection unavailable for %s: %s", slug, exc)
-            return GameGlossaryReadResponse(status="not_available", **base)
+            logger.exception("Glossary projection read failed for %s", slug)
+            raise ConceptTaxonomyReadError(f"glossary projection backend failure for {slug}") from exc
 
         entries: list[GlossaryEntry] = []
         for reference in concepts.concepts:

--- a/backend/tests/test_concept_taxonomy.py
+++ b/backend/tests/test_concept_taxonomy.py
@@ -21,6 +21,7 @@ from app.models.concept_taxonomy import (
     validate_relation_set,
 )
 from app.routers import games
+from app.services.concept_taxonomy import ConceptTaxonomyReadError, ConceptTaxonomyService
 
 
 def concept(concept_id: str, labels: list[ConceptLabel], **kwargs) -> Concept:
@@ -175,6 +176,28 @@ def test_migration_declares_rule_node_concept_backlinks():
     assert "CREATE TABLE IF NOT EXISTS public.rule_node_concepts" in sql
     assert "FOREIGN KEY (rule_set_id, rule_id)" in sql
     assert "concept_labels_unique_normalized_per_language" in sql
+
+
+@pytest.mark.anyio
+async def test_concept_taxonomy_backend_failure_is_not_reported_as_missing_or_not_available(monkeypatch):
+    async def get_game(slug):
+        return {"id": "game-1", "slug": slug}
+
+    def fail_read(*args, **kwargs):
+        raise RuntimeError("backend disconnected")
+
+    monkeypatch.setattr("app.services.concept_taxonomy.supabase.get_by_slug", get_game)
+    monkeypatch.setattr("app.services.concept_taxonomy.supabase.is_local", lambda: False)
+    monkeypatch.setattr(ConceptTaxonomyService, "_load_concept", fail_read)
+    monkeypatch.setattr(ConceptTaxonomyService, "_load_game_concepts", fail_read)
+
+    service = ConceptTaxonomyService()
+    with pytest.raises(ConceptTaxonomyReadError, match="concept taxonomy backend failure"):
+        await service.get_concept("fixture.mechanic.trick")
+    with pytest.raises(ConceptTaxonomyReadError, match="concept projection backend failure"):
+        await service.get_by_game_slug("example")
+    with pytest.raises(ConceptTaxonomyReadError, match="glossary projection backend failure"):
+        await service.get_glossary_by_game_slug("example", language_code="ja")
 
 
 class FakeConceptService:


### PR DESCRIPTION
## 変更
- Concept detail / game concepts / Glossaryのbackend read例外を`None`や`not_available`へ変換しない
- 既存Presentation Projectionと同じくtyped read errorでfail loudlyする
- 実データが本当に存在しない場合と、Supabase等のread失敗を分離する
- 既存Concept taxonomyテストへ3経路の回帰を統合

## productionで確認した症状
Skull King Glossaryが一時的なbackend切断時にHTTP 200 `not_available`を返し、直後には同じ正準データが`available`へ戻った。データ欠落ではなくread失敗を未整備として隠していた。

## 成功条件
backend readが失敗したとき、Concept taxonomy公開readが404/`not_available`を返さず5xxへ失敗すること。本当に未整備の正準データだけが`not_available`になること。

Refs #272