### PR TITLE
ルール内検索で正準用語集の別名を使えるようにする

### DIFF
--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
+import { getGlossaryData, glossaryConceptFragment } from './glossaryData'
 
 function normalizeSearchText(value) {
   return String(value || '')
@@ -47,6 +48,17 @@ function projectionRuleDestinations(projection, references) {
   return { destinations, ruleNodes }
 }
 
+function conceptIdFromHash() {
+  if (typeof window === 'undefined') return null
+  const prefix = '#glossary-concept-'
+  if (!window.location.hash.startsWith(prefix)) return null
+  try {
+    return decodeURIComponent(window.location.hash.slice(prefix.length))
+  } catch {
+    return null
+  }
+}
+
 export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
   const [entries, setEntries] = useState([])
   const [query, setQuery] = useState('')
@@ -61,7 +73,7 @@ export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
   useEffect(() => {
     let cancelled = false
 
-    api.get(`/api/games/${slug}/glossary?language_code=ja`)
+    getGlossaryData(slug, 'ja')
       .then((data) => {
         if (cancelled) return
         const available = data?.status === 'available' && data.entries?.length > 0
@@ -159,6 +171,29 @@ export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
     }
   }
 
+  useEffect(() => {
+    if (fetchStatus !== 'available') return undefined
+
+    const selectHashConcept = () => {
+      const conceptId = conceptIdFromHash()
+      if (!conceptId || !entries.some((entry) => entry.concept_id === conceptId)) return
+      if (selectedId !== conceptId) selectConcept(conceptId)
+      window.requestAnimationFrame(() => {
+        const target = document.getElementById(`glossary-concept-${conceptId}`)
+        target?.scrollIntoView({ block: 'center' })
+        target?.focus({ preventScroll: true })
+      })
+    }
+
+    selectHashConcept()
+    window.addEventListener('hashchange', selectHashConcept)
+    window.addEventListener('popstate', selectHashConcept)
+    return () => {
+      window.removeEventListener('hashchange', selectHashConcept)
+      window.removeEventListener('popstate', selectHashConcept)
+    }
+  }, [entries, fetchStatus, selectedId])
+
   if (loadedSlug !== slug) {
     return (
       <div className="pro-card" aria-label="用語集">
@@ -213,11 +248,12 @@ export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
           {filteredEntries.map((entry) => (
             <button
               key={entry.concept_id}
+              id={`glossary-concept-${entry.concept_id}`}
               type="button"
               className="tag-item"
               aria-expanded={selectedId === entry.concept_id}
               onClick={() => selectConcept(entry.concept_id)}
-              style={{ cursor: 'pointer', font: 'inherit' }}
+              style={{ cursor: 'pointer', font: 'inherit', scrollMarginTop: '1rem' }}
             >
               {entry.label}
             </button>

--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
-import { getGlossaryData, glossaryConceptFragment } from './glossaryData'
+import { getGlossaryData } from './glossaryData'
 
 function normalizeSearchText(value) {
   return String(value || '')

--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
+import { getGlossaryData, glossaryConceptFragment } from './glossaryData'
 
 function headingLabel(markdownText) {
   return markdownText
@@ -123,6 +125,17 @@ function searchSections(sections, query) {
   return sections.filter((section) => tokens.every((token) => section.searchText.includes(token)))
 }
 
+function searchGlossary(entries, query) {
+  const normalizedQuery = normalizeSearchText(query)
+  if (!normalizedQuery) return []
+
+  const tokens = normalizedQuery.split(' ').filter(Boolean)
+  return entries.filter((entry) => {
+    const searchable = normalizeSearchText([entry.label, ...(entry.aliases || [])].join(' '))
+    return tokens.every((token) => searchable.includes(token))
+  })
+}
+
 function resultSnippet(section, query) {
   if (!section.body) return 'この見出しへ移動します。'
 
@@ -141,11 +154,36 @@ function resultSnippet(section, query) {
 }
 
 function RuleMarkdown({ markdown = '', ruleNodes = [] }) {
+  const { slug } = useParams()
   const [query, setQuery] = useState('')
+  const [glossaryEntries, setGlossaryEntries] = useState([])
+  const [glossaryStatus, setGlossaryStatus] = useState('loading')
   const sections = useMemo(() => getRuleSections(markdown), [markdown])
-  const results = useMemo(() => searchSections(sections, query), [sections, query])
+  const sectionResults = useMemo(() => searchSections(sections, query), [sections, query])
+  const glossaryResults = useMemo(() => searchGlossary(glossaryEntries, query), [glossaryEntries, query])
   const headingComponents = useMemo(() => createHeadingComponents(sections), [sections])
   const hasQuery = normalizeSearchText(query).length > 0
+  const resultCount = sectionResults.length + glossaryResults.length
+
+  useEffect(() => {
+    let cancelled = false
+    setGlossaryStatus('loading')
+
+    getGlossaryData(slug, 'ja')
+      .then((data) => {
+        if (cancelled) return
+        const available = data?.status === 'available' && data.entries?.length > 0
+        setGlossaryEntries(available ? data.entries : [])
+        setGlossaryStatus(available ? 'available' : 'unavailable')
+      })
+      .catch(() => {
+        if (cancelled) return
+        setGlossaryEntries([])
+        setGlossaryStatus('error')
+      })
+
+    return () => { cancelled = true }
+  }, [slug])
 
   useEffect(() => {
     const focusCurrentSection = () => {
@@ -204,24 +242,41 @@ function RuleMarkdown({ markdown = '', ruleNodes = [] }) {
               type="search"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="例: 得点、2人、Mermaid"
+              placeholder="例: 得点、2人、Mermaid、Bid"
               autoComplete="off"
               style={{ width: '100%', maxWidth: '36rem' }}
             />
             {hasQuery && (
               <div style={{ marginTop: '0.75rem' }}>
                 <div role="status" aria-live="polite" style={{ marginBottom: '0.5rem' }}>
-                  {results.length > 0 ? `${results.length}件見つかりました` : '該当するルールは見つかりませんでした'}
+                  {resultCount > 0 ? `${resultCount}件見つかりました` : '該当するルールや用語は見つかりませんでした'}
                 </div>
-                {results.length > 0 && (
+                {sectionResults.length > 0 && (
                   <ul style={{ margin: 0, paddingInlineStart: '1.25rem' }}>
-                    {results.map((section) => (
+                    {sectionResults.map((section) => (
                       <li key={section.id} style={{ marginBlock: '0.6rem' }}>
                         <a href={`#${section.id}`}><strong>{section.label}</strong></a>
                         <div style={{ marginTop: '0.2rem' }}>{resultSnippet(section, query)}</div>
                       </li>
                     ))}
                   </ul>
+                )}
+                {glossaryResults.length > 0 && (
+                  <ul aria-label="用語集の検索結果" style={{ margin: '0.75rem 0 0', paddingInlineStart: '1.25rem' }}>
+                    {glossaryResults.map((entry) => (
+                      <li key={entry.concept_id} style={{ marginBlock: '0.6rem' }}>
+                        <a href={glossaryConceptFragment(entry.concept_id)}><strong>{entry.label}</strong></a>
+                        {entry.aliases?.length > 0 && (
+                          <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>別名: {entry.aliases.join(' / ')}</div>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+                {glossaryStatus === 'error' && (
+                  <div className="game-empty-note" role="alert" style={{ marginTop: '0.75rem' }}>
+                    用語集の正準データを取得できないため、本文だけを検索しています。
+                  </div>
                 )}
               </div>
             )}

--- a/frontend/src/components/game/glossaryData.js
+++ b/frontend/src/components/game/glossaryData.js
@@ -1,0 +1,24 @@
+import { api } from '../../lib/api'
+
+const glossaryRequests = new Map()
+
+export function getGlossaryData(slug, languageCode = 'ja') {
+  if (!slug) return Promise.resolve({ status: 'not_available', entries: [] })
+
+  const key = `${slug}:${languageCode}`
+  if (!glossaryRequests.has(key)) {
+    glossaryRequests.set(
+      key,
+      api.get(`/api/games/${slug}/glossary?language_code=${encodeURIComponent(languageCode)}`)
+        .catch((error) => {
+          glossaryRequests.delete(key)
+          throw error
+        }),
+    )
+  }
+  return glossaryRequests.get(key)
+}
+
+export function glossaryConceptFragment(conceptId) {
+  return `#glossary-concept-${encodeURIComponent(conceptId)}`
+}

--- a/frontend/tests/rule_lookup_glossary_alias.spec.js
+++ b/frontend/tests/rule_lookup_glossary_alias.spec.js
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 902,
+  slug: 'rule-lookup-alias-test',
+  title: 'Rule Lookup Alias Test',
+  title_ja: 'ルール検索別名テスト',
+  min_players: 2,
+  max_players: 8,
+  play_time: 45,
+  min_age: 8,
+  published_year: 2026,
+  summary: '正準用語集の別名から確認済みルールへ移動するテスト。',
+  source_url: 'https://example.com/source',
+  source_trust: 'official_publisher',
+  content_review_status: 'human_reviewed',
+  rules_content: '# Rules\n\n## 得点\n\n0を宣言した場合の得点を計算します。',
+  structured_data: {},
+}
+
+const glossary = {
+  status: 'available',
+  entries: [
+    {
+      concept_id: 'player-action.bid',
+      label: 'ビッド',
+      definition: '獲得するトリック数の宣言です。',
+      aliases: ['Bid'],
+      rule_references: [
+        {
+          rule_id: 'scoring.bid-one-plus',
+          rule_set_id: 'ruleset-current',
+          normalized_statement: '1以上をビッドした場合の得点を計算します。',
+          reference_kind: 'defines',
+          verification_status: 'source_bound',
+          source_url: 'https://example.com/official-rulebook',
+        },
+      ],
+    },
+  ],
+}
+
+test('ルール内検索で正準用語集の英語別名から同じConceptと確認済みRuleNodeへ到達する', async ({ page }) => {
+  let glossaryRequests = 0
+
+  await page.route('**/api/**', async route => {
+    const url = new URL(route.request().url())
+
+    if (url.pathname === '/api/games/rule-lookup-alias-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === '/api/games/rule-lookup-alias-test/glossary') {
+      glossaryRequests += 1
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(glossary) })
+      return
+    }
+    if (url.pathname === '/api/games/rule-lookup-alias-test/presentation') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'available',
+          rule_set_id: 'ruleset-current',
+          setup: { status: 'not_available', items: [] },
+          game_flow: { status: 'not_available', items: [] },
+          end_condition: { status: 'not_available', items: [] },
+          scoring: {
+            status: 'available',
+            items: [{ rule_id: 'scoring.bid-one-plus', text: '1以上をビッドした場合の得点を計算します。' }],
+          },
+        }),
+      })
+      return
+    }
+    if (url.pathname === '/api/concepts/player-action.bid') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ concept_id: 'player-action.bid', game_backlinks: [] }) })
+      return
+    }
+    if (url.pathname.endsWith('/connections')) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ status: 'not_available', connections: [] }) })
+      return
+    }
+
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+
+  await page.goto('/games/rule-lookup-alias-test#rules')
+
+  const ruleSearch = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  await ruleSearch.fill('Bid')
+  await expect(page.getByRole('link', { name: 'ビッド', exact: true })).toBeVisible()
+  await page.getByRole('link', { name: 'ビッド', exact: true }).click()
+
+  const glossaryPanel = page.locator('[aria-label="用語集"]')
+  await expect(glossaryPanel.getByRole('button', { name: 'ビッド', exact: true })).toHaveAttribute('aria-expanded', 'true')
+  await expect(glossaryPanel.getByText('1以上をビッドした場合の得点を計算します。', { exact: true })).toBeVisible()
+  await expect(glossaryPanel.getByRole('link', { name: '詳しいルールで確認', exact: true })).toHaveAttribute('href', '#rule-node-scoring.bid-one-plus')
+
+  await glossaryPanel.getByRole('link', { name: '詳しいルールで確認', exact: true }).click()
+  await expect(page.locator('#rule-node-scoring\\.bid-one-plus')).toContainText('1以上をビッドした場合の得点を計算します。')
+  expect(glossaryRequests).toBe(1)
+})


### PR DESCRIPTION
## 変更内容

Issue #272 のルール内検索を、既存の正準用語集へ接続します。

- ルール本文検索で日本語名・英語別名を含む正準Glossaryを検索
- `Bid` などの別名から同じConceptへ移動
- Conceptから既存の確認済みRuleNode / 出典導線を利用
- RuleMarkdownとConceptGlossaryのGlossary取得を1つの共有Promiseへ統合し、同一GamePageで重複API取得しない
- 新しい検索サービス、別のルール本文、ゲーム専用辞書は追加しない

## プレイヤー向け成功条件

`Bid` を「ルール内を検索」へ入力し、「ビッド」Conceptを選び、同じcurrent RuleSetの確認済みRuleNodeへ到達できること。

## 検証

Playwrightで以下を追加しました。

1. 英語別名 `Bid` で正準Glossaryの「ビッド」が検索結果に出る
2. 検索結果からGlossary Conceptを開ける
3. source-bound RuleNodeへのリンクが出る
4. RuleNodeへ移動できる
5. Glossary API取得が同一ページで1回だけである

#599はPR作成後の追加修正がheadへ反映されなかったため未mergeで閉じ、このPRで最新SHAをexact-head検証します。