### PR TITLE
ルール内検索で0 bidを正準Conceptへ解決する

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -131,7 +131,16 @@ function searchGlossary(entries, query) {
 
   const tokens = normalizedQuery.split(' ').filter(Boolean)
   return entries.filter((entry) => {
-    const searchable = normalizeSearchText([entry.label, ...(entry.aliases || [])].join(' '))
+    const verifiedRuleText = (entry.rule_references || [])
+      .filter((reference) => ['verified', 'source_bound'].includes(reference.verification_status))
+      .map((reference) => reference.normalized_statement)
+      .filter(Boolean)
+    const searchable = normalizeSearchText([
+      entry.label,
+      ...(entry.aliases || []),
+      entry.definition,
+      ...verifiedRuleText,
+    ].filter(Boolean).join(' '))
     return tokens.every((token) => searchable.includes(token))
   })
 }

--- a/frontend/tests/rule_lookup_glossary_alias.spec.js
+++ b/frontend/tests/rule_lookup_glossary_alias.spec.js
@@ -35,12 +35,20 @@ const glossary = {
           verification_status: 'source_bound',
           source_url: 'https://example.com/official-rulebook',
         },
+        {
+          rule_id: 'scoring.bid-zero',
+          rule_set_id: 'ruleset-current',
+          normalized_statement: '0ビッドを宣言した場合は、0ビッド用の得点計算を行います。',
+          reference_kind: 'mentions',
+          verification_status: 'source_bound',
+          source_url: 'https://example.com/official-rulebook',
+        },
       ],
     },
   ],
 }
 
-test('ルール内検索で正準用語集の英語別名から同じConceptと確認済みRuleNodeへ到達する', async ({ page }) => {
+test('ルール内検索で正準用語集の英語別名と確認済みRuleNodeから同じConceptへ到達する', async ({ page }) => {
   let glossaryRequests = 0
 
   await page.route('**/api/**', async route => {
@@ -67,7 +75,10 @@ test('ルール内検索で正準用語集の英語別名から同じConceptと�
           end_condition: { status: 'not_available', items: [] },
           scoring: {
             status: 'available',
-            items: [{ rule_id: 'scoring.bid-one-plus', text: '1以上をビッドした場合の得点を計算します。' }],
+            items: [
+              { rule_id: 'scoring.bid-one-plus', text: '1以上をビッドした場合の得点を計算します。' },
+              { rule_id: 'scoring.bid-zero', text: '0ビッドを宣言した場合は、0ビッド用の得点計算を行います。' },
+            ],
           },
         }),
       })
@@ -88,6 +99,9 @@ test('ルール内検索で正準用語集の英語別名から同じConceptと�
   await page.goto('/games/rule-lookup-alias-test#rules')
 
   const ruleSearch = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  await ruleSearch.fill('0 bid')
+  await expect(page.getByRole('link', { name: 'ビッド', exact: true })).toBeVisible()
+
   await ruleSearch.fill('Bid')
   await expect(page.getByRole('link', { name: 'ビッド', exact: true })).toBeVisible()
   await page.getByRole('link', { name: 'ビッド', exact: true }).click()
@@ -95,9 +109,10 @@ test('ルール内検索で正準用語集の英語別名から同じConceptと�
   const glossaryPanel = page.locator('[aria-label="用語集"]')
   await expect(glossaryPanel.getByRole('button', { name: 'ビッド', exact: true })).toHaveAttribute('aria-expanded', 'true')
   await expect(glossaryPanel.getByText('1以上をビッドした場合の得点を計算します。', { exact: true })).toBeVisible()
-  await expect(glossaryPanel.getByRole('link', { name: '詳しいルールで確認', exact: true })).toHaveAttribute('href', '#rule-node-scoring.bid-one-plus')
+  await expect(glossaryPanel.getByText('0ビッドを宣言した場合は、0ビッド用の得点計算を行います。', { exact: true })).toBeVisible()
+  await expect(glossaryPanel.getByRole('link', { name: '詳しいルールで確認', exact: true }).first()).toHaveAttribute('href', '#rule-node-scoring.bid-one-plus')
 
-  await glossaryPanel.getByRole('link', { name: '詳しいルールで確認', exact: true }).click()
+  await glossaryPanel.getByRole('link', { name: '詳しいルールで確認', exact: true }).first().click()
   await expect(page.locator('#rule-node-scoring\\.bid-one-plus')).toContainText('1以上をビッドした場合の得点を計算します。')
   expect(glossaryRequests).toBe(1)
 })


### PR DESCRIPTION
## Before→After

Before: ルール内検索は本文と用語名・別名を別々にAND検索していたため、正準用語集が `Bid`、確認済みRuleNodeが `0ビッド` を持つ場合でも `0 bid` から同じConceptへ到達できませんでした。

After: 同じ正準Glossary entryに結合済みの `verified` / `source_bound` RuleNode文言を検索対象へ含めます。新しい辞書や検索データは作りません。

## Observable success condition

`0 bid` を入力すると、`Bid` 別名と確認済み `0ビッド` RuleNodeを持つ同じ「ビッド」Conceptが1件以上見つかること。

## Trust boundary

- `verified` / `source_bound` のRuleNodeだけ検索対象にする
- unverified RuleNodeは検索対象へ入れない
- selected canonical Glossary dataを再利用する
- 外部検索サービス、vector DB、LLM検索を追加しない

## Tests

既存 `rule_lookup_glossary_alias.spec.js` を拡張し、`0 bid` → 「ビッド」Conceptを固定します。

Related: #272