### PR TITLE
ルール検索でFAQ・ルールブック・人数条件を区別する

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import ReactMarkdown from 'react-markdown'
-import { getGlossaryData, glossaryConceptFragment } from './glossaryData'
+import { getGlossaryData, glossaryConceptFragment, ruleReferenceSourceLabel } from './glossaryData'
 
 function headingLabel(markdownText) {
   return markdownText
@@ -125,15 +125,23 @@ function searchSections(sections, query) {
   return sections.filter((section) => tokens.every((token) => section.searchText.includes(token)))
 }
 
+function trustedRuleReferences(entry) {
+  return (entry.rule_references || [])
+    .filter((reference) => ['verified', 'source_bound'].includes(reference.verification_status))
+}
+
 function searchGlossary(entries, query) {
   const normalizedQuery = normalizeSearchText(query)
   if (!normalizedQuery) return []
 
   const tokens = normalizedQuery.split(' ').filter(Boolean)
   return entries.filter((entry) => {
-    const verifiedRuleText = (entry.rule_references || [])
-      .filter((reference) => ['verified', 'source_bound'].includes(reference.verification_status))
-      .map((reference) => reference.normalized_statement)
+    const verifiedRuleText = trustedRuleReferences(entry)
+      .flatMap((reference) => [
+        reference.normalized_statement,
+        reference.player_count ? `${reference.player_count}人` : null,
+        ruleReferenceSourceLabel(reference),
+      ])
       .filter(Boolean)
     const searchable = normalizeSearchText([
       entry.label,
@@ -143,6 +151,16 @@ function searchGlossary(entries, query) {
     ].filter(Boolean).join(' '))
     return tokens.every((token) => searchable.includes(token))
   })
+}
+
+function glossaryResultContext(entry) {
+  const references = trustedRuleReferences(entry)
+  const sourceLabels = [...new Set(references.map(ruleReferenceSourceLabel).filter(Boolean))]
+  const playerCounts = [...new Set(references.map((reference) => reference.player_count).filter(Boolean))]
+  return {
+    sourceLabels,
+    playerCounts,
+  }
 }
 
 function resultSnippet(section, query) {
@@ -275,14 +293,27 @@ function RuleMarkdown({ markdown = '', ruleNodes = [] }) {
                 )}
                 {glossaryResults.length > 0 && (
                   <ul aria-label="用語集の検索結果" style={{ margin: '0.75rem 0 0', paddingInlineStart: '1.25rem' }}>
-                    {glossaryResults.map((entry) => (
-                      <li key={entry.concept_id} style={{ marginBlock: '0.6rem' }}>
-                        <a href={glossaryConceptFragment(entry.concept_id)}><strong>{entry.label}</strong></a>
-                        {entry.aliases?.length > 0 && (
-                          <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>別名: {entry.aliases.join(' / ')}</div>
-                        )}
-                      </li>
-                    ))}
+                    {glossaryResults.map((entry) => {
+                      const context = glossaryResultContext(entry)
+                      return (
+                        <li key={entry.concept_id} style={{ marginBlock: '0.6rem' }}>
+                          <a href={glossaryConceptFragment(entry.concept_id)}><strong>{entry.label}</strong></a>
+                          {entry.aliases?.length > 0 && (
+                            <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>別名: {entry.aliases.join(' / ')}</div>
+                          )}
+                          {context.sourceLabels.length > 0 && (
+                            <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>
+                              出典: {context.sourceLabels.join(' / ')}
+                            </div>
+                          )}
+                          {context.playerCounts.length > 0 && (
+                            <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>
+                              人数条件: {context.playerCounts.map((count) => `${count}人`).join(' / ')}
+                            </div>
+                          )}
+                        </li>
+                      )
+                    })}
                   </ul>
                 )}
                 {glossarySlug === slug && glossaryStatus === 'error' && (

--- a/frontend/src/components/game/glossaryData.js
+++ b/frontend/src/components/game/glossaryData.js
@@ -2,10 +2,6 @@ import { api } from '../../lib/api'
 
 const glossaryRequests = new Map()
 
-export function isVerifiedRuleReference(reference) {
-  return reference?.verification_status === 'source_bound' || reference?.verification_status === 'verified'
-}
-
 export function ruleReferenceSourceLabel(reference) {
   const locator = String(reference?.source_locator || '')
   if (locator.includes(':rulebook:')) return 'ルールブック'

--- a/frontend/src/components/game/glossaryData.js
+++ b/frontend/src/components/game/glossaryData.js
@@ -2,6 +2,17 @@ import { api } from '../../lib/api'
 
 const glossaryRequests = new Map()
 
+export function isVerifiedRuleReference(reference) {
+  return reference?.verification_status === 'source_bound' || reference?.verification_status === 'verified'
+}
+
+export function ruleReferenceSourceLabel(reference) {
+  const locator = String(reference?.source_locator || '')
+  if (locator.includes(':rulebook:')) return 'ルールブック'
+  if (locator.includes(':faq:')) return 'FAQ'
+  return null
+}
+
 export function getGlossaryData(slug, languageCode = 'ja') {
   if (!slug) return Promise.resolve({ status: 'not_available', entries: [] })
 

--- a/frontend/tests/rule_lookup_evidence.spec.js
+++ b/frontend/tests/rule_lookup_evidence.spec.js
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 902,
+  slug: 'source-search-test',
+  title: 'Source Search Test',
+  title_ja: '出典検索テスト',
+  min_players: 2,
+  max_players: 4,
+  play_time: 30,
+  min_age: 10,
+  published_year: 2026,
+  summary: 'ルール検索の出典表示を確認するテスト用ゲーム。',
+  source_url: 'https://example.com/source',
+  source_trust: 'official_publisher',
+  content_review_status: 'review_required',
+  rules_content: '# Rules\n\n## 進行\n\n通常の進行です。',
+  structured_data: {},
+}
+
+async function mockData(page) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === '/api/games/source-search-test') {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === '/api/games/source-search-test/glossary') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          status: 'available',
+          entries: [
+            {
+              concept_id: 'faq-ruling',
+              label: '特殊カードの裁定',
+              definition: '特殊カードが同時に出た場合の裁定です。',
+              aliases: ['Mermaid'],
+              rule_references: [{
+                rule_id: 'resolution.mermaid-triad',
+                normalized_statement: 'Mermaidがそのトリックに勝ちます。',
+                verification_status: 'source_bound',
+                rule_set_id: 'current-rules',
+                source_url: 'https://example.com/faq',
+                source_locator: 'game:faq:mermaid-triad',
+              }],
+            },
+            {
+              concept_id: 'rulebook-rule',
+              label: 'ビッド',
+              definition: '獲得するトリック数を宣言します。',
+              aliases: ['Bid'],
+              rule_references: [{
+                rule_id: 'round.bid',
+                normalized_statement: '全員が同時にビッドを公開します。',
+                verification_status: 'source_bound',
+                rule_set_id: 'current-rules',
+                source_url: 'https://example.com/rulebook',
+                source_locator: 'game:rulebook:bidding',
+              }],
+            },
+            {
+              concept_id: 'two-player-ruling',
+              label: '2人用の裁定',
+              definition: '2人のときだけ適用する裁定です。',
+              aliases: [],
+              rule_references: [{
+                rule_id: 'two-player.rule',
+                normalized_statement: 'この裁定は該当する2人戦で適用します。',
+                verification_status: 'source_bound',
+                rule_set_id: 'current-rules',
+                player_count: 2,
+                source_url: 'https://example.com/faq-two-player',
+                source_locator: 'game:faq:two-player',
+              }],
+            },
+            {
+              concept_id: 'unverified-faq',
+              label: '未確認裁定',
+              definition: '未確認です。',
+              aliases: [],
+              rule_references: [{
+                rule_id: 'unverified.rule',
+                normalized_statement: '未確認のFAQ記述です。',
+                verification_status: 'unknown',
+                source_locator: 'game:faq:unverified',
+              }],
+            },
+          ],
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+}
+
+test('確認済みのFAQ・ルールブック・人数条件を同じ検索面で区別する', async ({ page }) => {
+  await mockData(page)
+  await page.goto('/games/source-search-test#rules')
+
+  const search = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  const results = page.getByRole('list', { name: '用語集の検索結果' })
+
+  await search.fill('FAQ Mermaid')
+  await expect(results.getByRole('link', { name: '特殊カードの裁定' })).toBeVisible()
+  await expect(results.getByText('出典: FAQ', { exact: true })).toBeVisible()
+  await expect(results.getByRole('link', { name: 'ビッド' })).toHaveCount(0)
+  await expect(results.getByRole('link', { name: '未確認裁定' })).toHaveCount(0)
+
+  await search.fill('ルールブック Bid')
+  await expect(results.getByRole('link', { name: 'ビッド' })).toBeVisible()
+  await expect(results.getByText('出典: ルールブック', { exact: true })).toBeVisible()
+  await expect(results.getByRole('link', { name: '特殊カードの裁定' })).toHaveCount(0)
+
+  await search.fill('FAQ 2人')
+  await expect(results.getByRole('link', { name: '2人用の裁定' })).toBeVisible()
+  await expect(results.getByText('人数条件: 2人', { exact: true })).toBeVisible()
+  await expect(results.getByText('出典: FAQ', { exact: true })).toBeVisible()
+})


### PR DESCRIPTION
Closes part of #272.

## プレイヤー向け完了条件
- 確認済みの正準Glossaryだけを使い、`FAQ Mermaid` でFAQ由来の裁定、`ルールブック Bid` でルールブック由来のルール、`FAQ 2人` で2人用裁定を検索できる。
- 検索結果に、既存 `source_locator` から得られる「FAQ / ルールブック」と既存 `player_count` を表示する。
- `unknown` の参照は検索・表示に使わない。

## 変更
- 既存 `source_locator` の `:faq:` / `:rulebook:` を平易な表示へ変換するhelperを既存Glossary取得moduleに追加。
- ルール内検索で確認済みRuleNodeの出典区分と人数条件を検索対象・結果表示に追加。
- Playwrightで上記3経路と未確認参照の除外を固定。

新しい検索index、辞書、API、workflow、データ分類は追加していません。