### PR TITLE
0ビッド得点を正準ビッドConceptへ接続する

### DIFF
--- a/backend/app/db/migrations/123_link_skull_king_zero_bid_concept.sql
+++ b/backend/app/db/migrations/123_link_skull_king_zero_bid_concept.sql
@@ -2,6 +2,7 @@ BEGIN;
 
 -- 現行Skull King RuleSetの0ビッド得点を、既存の正準Concept「ビッド」へ結ぶ。
 -- RuleNode、Claim、Evidenceがすべて確認済みの場合だけ追加する。
+-- RuleNodeの出典状態はmetadataで保持し、このConcept関連自体は明示確認済みとしてverifiedにする。
 
 DO $$
 DECLARE
@@ -63,12 +64,13 @@ BEGIN
     rn.rule_id,
     'player-action.bid',
     'mentions',
-    rn.verification_status,
+    'verified',
     rn.source_url,
     rn.source_locator,
     jsonb_build_object(
       'source_claim_ref', rn.source_claim_ref,
       'evidence_ref', rn.evidence_ref,
+      'source_rule_verification_status', rn.verification_status,
       'scope', COALESCE(rn.metadata->>'scope', 'base'),
       'condition', COALESCE(rn.metadata->'condition', 'null'::jsonb),
       'migration', '123_link_skull_king_zero_bid_concept'
@@ -101,10 +103,11 @@ BEGIN
       AND rnc.rule_id = 'scoring.zero-bid'
       AND rnc.concept_id = 'player-action.bid'
       AND rnc.reference_kind = 'mentions'
-      AND rnc.verification_status IN ('source_bound', 'verified')
+      AND rnc.verification_status = 'verified'
       AND rnc.source_locator = 'skull-king:rulebook:scoring'
+      AND rnc.metadata->>'source_rule_verification_status' IN ('source_bound', 'verified')
   ) <> 1 THEN
-    RAISE EXCEPTION 'Expected one source-bound zero-bid concept reference on the active RuleSet';
+    RAISE EXCEPTION 'Expected one verified zero-bid concept reference on the active RuleSet';
   END IF;
 END $$;
 

--- a/backend/app/db/migrations/123_link_skull_king_zero_bid_concept.sql
+++ b/backend/app/db/migrations/123_link_skull_king_zero_bid_concept.sql
@@ -1,0 +1,111 @@
+BEGIN;
+
+-- 現行Skull King RuleSetの0ビッド得点を、既存の正準Concept「ビッド」へ結ぶ。
+-- RuleNode、Claim、Evidenceがすべて確認済みの場合だけ追加する。
+
+DO $$
+DECLARE
+  v_ruleset_id uuid;
+BEGIN
+  SELECT rs.id
+    INTO v_ruleset_id
+  FROM public.rule_sets rs
+  JOIN public.games g ON g.id = rs.game_id
+  WHERE g.slug = 'skull-king'
+    AND rs.is_active = true
+    AND rs.status = 'active'
+    AND COALESCE(rs.language_code, '') = 'en'
+    AND COALESCE(rs.edition_label, '') = 'Grandpa Beck''s Games current edition'
+    AND COALESCE(rs.platform, '') = 'physical'
+    AND COALESCE(rs.revision_label, '') = 'current-web-rulebook-1764178570'
+    AND COALESCE(rs.variant_label, '') = ''
+    AND rs.version = 1
+  LIMIT 1;
+
+  IF v_ruleset_id IS NULL THEN
+    RAISE EXCEPTION 'Active current Skull King RuleSet is required before linking zero-bid concept';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.rule_nodes rn
+    JOIN public.claims c
+      ON c.claim_id = rn.source_claim_ref
+     AND c.rule_set_id = rn.rule_set_id
+     AND c.lifecycle_status = 'accepted'
+    JOIN public.evidence_bindings eb
+      ON eb.binding_id = rn.evidence_ref
+     AND eb.claim_id = c.claim_id
+     AND eb.relation = 'supports'
+    WHERE rn.rule_set_id = v_ruleset_id
+      AND rn.rule_id = 'scoring.zero-bid'
+      AND rn.source_claim_ref = 'skull-king:current:rule:scoring.zero-bid'
+      AND rn.evidence_ref = 'skull-king:current:binding:scoring.zero-bid'
+      AND rn.source_locator = 'skull-king:rulebook:scoring'
+      AND rn.verification_status IN ('source_bound', 'verified')
+      AND eb.source_id = 'publisher:grandpa-becks:skull-king:current-rulebook'
+  ) THEN
+    RAISE EXCEPTION 'Current Skull King zero-bid claim/evidence binding is required';
+  END IF;
+
+  INSERT INTO public.rule_node_concepts (
+    rule_set_id,
+    rule_id,
+    concept_id,
+    reference_kind,
+    verification_status,
+    source_url,
+    source_locator,
+    metadata
+  )
+  SELECT
+    rn.rule_set_id,
+    rn.rule_id,
+    'player-action.bid',
+    'mentions',
+    rn.verification_status,
+    rn.source_url,
+    rn.source_locator,
+    jsonb_build_object(
+      'source_claim_ref', rn.source_claim_ref,
+      'evidence_ref', rn.evidence_ref,
+      'scope', COALESCE(rn.metadata->>'scope', 'base'),
+      'condition', COALESCE(rn.metadata->'condition', 'null'::jsonb),
+      'migration', '123_link_skull_king_zero_bid_concept'
+    )
+  FROM public.rule_nodes rn
+  JOIN public.concepts c ON c.concept_id = 'player-action.bid'
+  JOIN public.claims claim
+    ON claim.claim_id = rn.source_claim_ref
+   AND claim.rule_set_id = rn.rule_set_id
+   AND claim.lifecycle_status = 'accepted'
+  JOIN public.evidence_bindings binding
+    ON binding.binding_id = rn.evidence_ref
+   AND binding.claim_id = claim.claim_id
+   AND binding.relation = 'supports'
+  WHERE rn.rule_set_id = v_ruleset_id
+    AND rn.rule_id = 'scoring.zero-bid'
+    AND rn.verification_status IN ('source_bound', 'verified')
+    AND rn.source_claim_ref IS NOT NULL
+    AND rn.evidence_ref IS NOT NULL
+  ON CONFLICT (rule_set_id, rule_id, concept_id, reference_kind) DO UPDATE SET
+    verification_status = EXCLUDED.verification_status,
+    source_url = EXCLUDED.source_url,
+    source_locator = EXCLUDED.source_locator,
+    metadata = EXCLUDED.metadata;
+
+  IF (
+    SELECT count(*)
+    FROM public.rule_node_concepts rnc
+    WHERE rnc.rule_set_id = v_ruleset_id
+      AND rnc.rule_id = 'scoring.zero-bid'
+      AND rnc.concept_id = 'player-action.bid'
+      AND rnc.reference_kind = 'mentions'
+      AND rnc.verification_status IN ('source_bound', 'verified')
+      AND rnc.source_locator = 'skull-king:rulebook:scoring'
+  ) <> 1 THEN
+    RAISE EXCEPTION 'Expected one source-bound zero-bid concept reference on the active RuleSet';
+  END IF;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Before → After
- Before: 現行Skull Kingの`scoring.zero-bid`は確認済みRuleNodeとして存在するが、`player-action.bid`へ結ばれておらず、productionの`0 bid`検索で0ビッド得点へ到達できない。
- After: 現行RuleSetの確認済みClaim/Evidenceを必須にした上で、`scoring.zero-bid`を既存Concept「ビッド」へ接続する。

## プレイヤー向け完了条件
`0 bid`で「ビッド」が検索結果に現れ、同じConceptから`scoring.zero-bid`の確認済みルールへ到達できること。

## 検証
既存`Source-bound RuleSet data contract`が新しいmigrationを2回適用する。migration自身がRuleSet、Claim、Evidence、source locator、Concept関連をfail loudlyで検証する。fixtureはCIだけに使い、本番判断はcanonical production DB/APIで行う。

Closes part of #272.