### PR TITLE
productionでルール検索を実ブラウザ検証する

### DIFF
--- a/.github/workflows/curated-game-release-verification.yml
+++ b/.github/workflows/curated-game-release-verification.yml
@@ -15,7 +15,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main')
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
         with:
@@ -28,3 +28,20 @@ jobs:
         env:
           PYTHONPATH: backend
         run: uv run python backend/app/scripts/curated_release_verification.py
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Install Chromium
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+      - name: Verify production rule lookup in Chromium
+        working-directory: frontend
+        env:
+          PLAYWRIGHT_BASE_URL: https://bodoge-no-mikata.vercel.app
+        run: npx playwright test tests/production_rule_lookup.spec.js --project=ux-mobile

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const productionBaseURL = process.env.PLAYWRIGHT_BASE_URL
+
 export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
@@ -7,15 +9,17 @@ export default defineConfig({
   workers: 1,
   reporter: 'line',
   use: {
-    baseURL: 'http://127.0.0.1:5173',
+    baseURL: productionBaseURL || 'http://127.0.0.1:5173',
     trace: 'retain-on-failure',
   },
-  webServer: {
-    command: 'npm run dev -- --host 127.0.0.1',
-    url: 'http://127.0.0.1:5173',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120000,
-  },
+  webServer: productionBaseURL
+    ? undefined
+    : {
+        command: 'npm run dev -- --host 127.0.0.1',
+        url: 'http://127.0.0.1:5173',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120000,
+      },
   projects: [
     {
       name: 'chromium',

--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -22,17 +22,23 @@ async function openCanonicalRuleFromSearch(page, query, ruleId, expectedSource, 
 
   await results.getByRole('link').first().click()
 
-  const ruleLink = page.locator(`[aria-label="用語集"] a[href="#rule-node-${ruleId}"]`).first()
+  const glossary = page.locator('[aria-label="用語集"]')
+  const sourceLink = glossary.getByRole('link', { name: '出典を確認', exact: true }).first()
+  await expect(sourceLink).toBeVisible()
+  await expect(sourceLink).toHaveAttribute('href', /^https:\/\/www\.grandpabecksgames\.com\//)
+
+  const ruleLink = glossary.locator(`a[href="#rule-node-${ruleId}"]`).first()
   await expect(ruleLink).toBeVisible()
   await ruleLink.click()
 
-  const target = page.locator(`#rule-node-${ruleId.replaceAll('.', '\\.')}`)
+  const escapedRuleId = ruleId.replaceAll('.', '\\.')
+  const target = page.locator(`#rule-node-${escapedRuleId}`)
   await expect(target).toBeVisible()
-  await expect(page).toHaveURL(new RegExp(`#rule-node-${ruleId.replaceAll('.', '\\.')}$`))
+  await expect(page).toHaveURL(new RegExp(`#rule-node-${escapedRuleId}$`))
   await expectNoPageOverflow(page)
 }
 
-test('productionのSkull Kingで代表queryから確認済みRuleNodeへ到達できる', async ({ page }) => {
+test('productionのSkull Kingで代表queryから確認済みRuleNodeと公式出典へ到達できる', async ({ page }) => {
   await page.goto('/games/skull-king#rules', { waitUntil: 'networkidle' })
   await expect(page.getByRole('searchbox', { name: '裁定・用語を入力' })).toBeVisible()
   await expectNoPageOverflow(page)

--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+
+const productionBaseURL = process.env.PLAYWRIGHT_BASE_URL
+
+test.skip(!productionBaseURL, 'production URLが指定されたdeploy後検証でのみ実行する')
+
+async function expectNoPageOverflow(page) {
+  const hasOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth)
+  expect(hasOverflow).toBe(false)
+}
+
+async function openCanonicalRuleFromSearch(page, query, ruleId, expectedSource, expectedPlayerCount = null) {
+  const search = page.getByRole('searchbox', { name: '裁定・用語を入力' })
+  const results = page.getByRole('list', { name: '用語集の検索結果' })
+
+  await search.fill(query)
+  await expect(results).toBeVisible()
+  await expect(results.getByText(`出典: ${expectedSource}`, { exact: true }).first()).toBeVisible()
+  if (expectedPlayerCount !== null) {
+    await expect(results.getByText(`人数条件: ${expectedPlayerCount}人`, { exact: true }).first()).toBeVisible()
+  }
+
+  await results.getByRole('link').first().click()
+
+  const ruleLink = page.locator(`[aria-label="用語集"] a[href="#rule-node-${ruleId}"]`).first()
+  await expect(ruleLink).toBeVisible()
+  await ruleLink.click()
+
+  const target = page.locator(`#rule-node-${ruleId.replaceAll('.', '\\.')}`)
+  await expect(target).toBeVisible()
+  await expect(page).toHaveURL(new RegExp(`#rule-node-${ruleId.replaceAll('.', '\\.')}$`))
+  await expectNoPageOverflow(page)
+}
+
+test('productionのSkull Kingで代表queryから確認済みRuleNodeへ到達できる', async ({ page }) => {
+  await page.goto('/games/skull-king#rules', { waitUntil: 'networkidle' })
+  await expect(page.getByRole('searchbox', { name: '裁定・用語を入力' })).toBeVisible()
+  await expectNoPageOverflow(page)
+
+  await openCanonicalRuleFromSearch(page, '0 bid', 'scoring.zero-bid', 'ルールブック')
+  await openCanonicalRuleFromSearch(page, 'FAQ Mermaid', 'resolution.mermaid-triad', 'FAQ')
+  await openCanonicalRuleFromSearch(page, 'FAQ 2人', 'two-player.tigress', 'FAQ', 2)
+})

--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-const productionBaseURL = process.env.PLAYWRIGHT_BASE_URL
+const productionBaseURL = globalThis.process?.env?.PLAYWRIGHT_BASE_URL
 
 test.skip(!productionBaseURL, 'production URLが指定されたdeploy後検証でのみ実行する')
 


### PR DESCRIPTION
Issue #272 のproduction実ブラウザ検証を既存release verificationへ統合する。

完了条件:
- Skull Kingで `0 bid`、`FAQ Mermaid`、`FAQ 2人` をcanonical productionの実データで検索できる
- 確認済みRuleNodeと公式出典へ移動できる
- 375px幅でページ全体の横方向overflowがない

新しいworkflowは作らず、既存のCurated game release verificationを使う。