### PR TITLE
production検索E2Eの公式出典検証を実データに合わせる

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -2,11 +2,22 @@ import { test, expect } from '@playwright/test'
 
 const productionBaseURL = globalThis.process?.env?.PLAYWRIGHT_BASE_URL
 
+const officialSkullKingSourcePatterns = [
+  /^https:\/\/(?:www\.)?grandpabecksgames\.com\//,
+  /^https:\/\/cdn\.shopify\.com\/s\/files\/1\/0565\/3230\/4053\/files\/Skull_King_.*\.pdf(?:\?.*)?$/,
+]
+
 test.skip(!productionBaseURL, 'production URLが指定されたdeploy後検証でのみ実行する')
 
 async function expectNoPageOverflow(page) {
   const hasOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth)
   expect(hasOverflow).toBe(false)
+}
+
+async function expectOfficialSkullKingSource(sourceLink) {
+  const href = await sourceLink.getAttribute('href')
+  expect(href).toBeTruthy()
+  expect(officialSkullKingSourcePatterns.some((pattern) => pattern.test(href))).toBe(true)
 }
 
 async function openCanonicalRuleFromSearch(page, query, ruleId, expectedSource, expectedPlayerCount = null) {
@@ -25,7 +36,7 @@ async function openCanonicalRuleFromSearch(page, query, ruleId, expectedSource, 
   const glossary = page.locator('[aria-label="用語集"]')
   const sourceLink = glossary.getByRole('link', { name: '出典を確認', exact: true }).first()
   await expect(sourceLink).toBeVisible()
-  await expect(sourceLink).toHaveAttribute('href', /^https:\/\/www\.grandpabecksgames\.com\//)
+  await expectOfficialSkullKingSource(sourceLink)
 
   const ruleLink = glossary.locator(`a[href="#rule-node-${ruleId}"]`).first()
   await expect(ruleLink).toBeVisible()


### PR DESCRIPTION
Issue #272 のproduction検索E2Eで、公式Rulebookの正準URLがGrandpa Beck's GamesのShopify配布PDFであるにもかかわらず、テストが `www.grandpabecksgames.com` だけを許可して失敗していました。

変更:
- Grandpa Beck's Games本体URLに加え、現在の公式ストア固有Shopify CDN配布先を許可
- 任意のShopify URLは許可せず、store path `1/0565/3230/4053` と `Skull_King_*.pdf` に限定
- 製品コード、検索ロジック、正準データは変更しない

完了条件:
- exact-head CI green
- merge後mainのCurated game release verificationでcanonical productionに対し `0 bid` / `FAQ Mermaid` / `FAQ 2人` がChromiumで完走する
