### PR TITLE
検索結果の出典を一致した確認済みルールに限定する

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -130,31 +130,53 @@ function trustedRuleReferences(entry) {
     .filter((reference) => ['verified', 'source_bound'].includes(reference.verification_status))
 }
 
+function glossaryEntrySearchText(entry) {
+  return normalizeSearchText([
+    entry.label,
+    ...(entry.aliases || []),
+    entry.definition,
+  ].filter(Boolean).join(' '))
+}
+
+function matchingRuleReferences(entry, query) {
+  const normalizedQuery = normalizeSearchText(query)
+  if (!normalizedQuery) return []
+
+  const tokens = normalizedQuery.split(' ').filter(Boolean)
+  const entrySearchText = glossaryEntrySearchText(entry)
+  return trustedRuleReferences(entry).filter((reference) => {
+    const searchable = normalizeSearchText([
+      entrySearchText,
+      reference.normalized_statement,
+      reference.player_count ? `${reference.player_count}人` : null,
+      ruleReferenceSourceLabel(reference),
+    ].filter(Boolean).join(' '))
+    return tokens.every((token) => searchable.includes(token))
+  })
+}
+
 function searchGlossary(entries, query) {
   const normalizedQuery = normalizeSearchText(query)
   if (!normalizedQuery) return []
 
   const tokens = normalizedQuery.split(' ').filter(Boolean)
   return entries.filter((entry) => {
-    const verifiedRuleText = trustedRuleReferences(entry)
-      .flatMap((reference) => [
-        reference.normalized_statement,
-        reference.player_count ? `${reference.player_count}人` : null,
-        ruleReferenceSourceLabel(reference),
-      ])
-      .filter(Boolean)
-    const searchable = normalizeSearchText([
-      entry.label,
-      ...(entry.aliases || []),
-      entry.definition,
-      ...verifiedRuleText,
-    ].filter(Boolean).join(' '))
-    return tokens.every((token) => searchable.includes(token))
+    const entrySearchText = glossaryEntrySearchText(entry)
+    if (tokens.every((token) => entrySearchText.includes(token))) return true
+    return matchingRuleReferences(entry, query).length > 0
   })
 }
 
-function glossaryResultContext(entry) {
-  const references = trustedRuleReferences(entry)
+function glossaryResultContext(entry, query) {
+  const normalizedQuery = normalizeSearchText(query)
+  const tokens = normalizedQuery.split(' ').filter(Boolean)
+  const entrySearchText = glossaryEntrySearchText(entry)
+  const referencesMatchingQuery = matchingRuleReferences(entry, query)
+  const references = referencesMatchingQuery.length > 0
+    ? referencesMatchingQuery
+    : tokens.every((token) => entrySearchText.includes(token))
+      ? trustedRuleReferences(entry)
+      : []
   const sourceLabels = [...new Set(references.map(ruleReferenceSourceLabel).filter(Boolean))]
   const playerCounts = [...new Set(references.map((reference) => reference.player_count).filter(Boolean))]
   return {
@@ -294,7 +316,7 @@ function RuleMarkdown({ markdown = '', ruleNodes = [] }) {
                 {glossaryResults.length > 0 && (
                   <ul aria-label="用語集の検索結果" style={{ margin: '0.75rem 0 0', paddingInlineStart: '1.25rem' }}>
                     {glossaryResults.map((entry) => {
-                      const context = glossaryResultContext(entry)
+                      const context = glossaryResultContext(entry, query)
                       return (
                         <li key={entry.concept_id} style={{ marginBlock: '0.6rem' }}>
                           <a href={glossaryConceptFragment(entry.concept_id)}><strong>{entry.label}</strong></a>


### PR DESCRIPTION
## 目的
ルール内検索で、検索語に一致していない別の確認済みルールの出典や人数条件を検索結果へ混ぜない。

## プレイヤー向け成功条件
Skull King の production 相当データで `FAQ 2人` を検索したとき、該当する2人戦FAQについて `出典: FAQ` と `人数条件: 2人` を表示し、同じConceptに結び付いた無関係なルールブック出典を表示しない。

## 変更
- Conceptの名称・別名・定義と、各確認済みRuleNodeを組み合わせて検索語との一致を判定
- 検索結果の出典・人数条件は、その検索語に一致した `verified` / `source_bound` RuleNodeだけから算出
- Concept名称・別名・定義だけで一致した場合は、従来どおり確認済み関連ルール全体を表示

新しいデータ源、fallback、独自辞書、workflowは追加しない。

Related: #272