### PR TITLE
SSRで現行RuleSetと公式出典を確認できるようにする

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -15,6 +15,15 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://bodoge-no-mikata.vercel.app"
 
 
+class CanonicalRuleText(str):
+    """Canonical rule text with the RuleSet identity used to produce it."""
+
+    def __new__(cls, value: str, ruleset):
+        instance = super().__new__(cls, value)
+        instance.ruleset = ruleset
+        return instance
+
+
 def _replace_or_insert_tag(document: str, pattern: str, replacement: str) -> str:
     updated, count = re.subn(pattern, replacement, document, count=1, flags=re.IGNORECASE | re.DOTALL)
     if count:
@@ -122,8 +131,36 @@ async def _canonical_rule_text(slug: str) -> str | None:
             continue
         rendered = _render_projection_rules(projection)
         if rendered:
-            return rendered
+            return CanonicalRuleText(rendered, ruleset)
     return None
+
+
+def _render_ruleset_identity(canonical_rules: str | None, game: dict) -> str:
+    ruleset = getattr(canonical_rules, "ruleset", None)
+    if ruleset is None:
+        return ""
+
+    facts: list[str] = []
+    if ruleset.edition_label:
+        facts.append(f"<p><strong>版:</strong> {html.escape(str(ruleset.edition_label))}</p>")
+    if ruleset.language_code:
+        facts.append(f"<p><strong>言語:</strong> {html.escape(str(ruleset.language_code))}</p>")
+    if ruleset.platform:
+        facts.append(f"<p><strong>プラットフォーム:</strong> {html.escape(str(ruleset.platform))}</p>")
+    revision = ruleset.revision_label or ruleset.source_revision
+    if revision:
+        facts.append(f"<p><strong>改訂:</strong> {html.escape(str(revision))}</p>")
+
+    source_url = game.get("source_url") if game.get("source_trust") == "official_publisher" else None
+    if isinstance(source_url, str) and source_url.startswith(("https://", "http://")):
+        safe_url = html.escape(source_url, quote=True)
+        facts.append(
+            f'<p><strong>一次資料:</strong> <a href="{safe_url}" rel="noopener noreferrer">出版社の公式ページ</a></p>'
+        )
+
+    if not facts:
+        return ""
+    return "    <section>\n      <h2>このルール要約の対象</h2>\n      " + "\n      ".join(facts) + "\n    </section>\n"
 
 
 async def generate_seo_html(slug: str) -> str | None:
@@ -242,6 +279,7 @@ async def generate_seo_html(slug: str) -> str | None:
     safe_title = html.escape(title)
     safe_summary = html.escape(str(game.get("summary") or ""))
     safe_rules = html.escape(canonical_rules) if canonical_rules else ""
+    ruleset_identity_section = _render_ruleset_identity(canonical_rules, game)
     rules_section = ""
     if safe_rules:
         rules_section = f"""    <section>
@@ -274,6 +312,6 @@ async def generate_seo_html(slug: str) -> str | None:
       {players_info}
       {time_info}
     </section>
-{rules_section}  </article>
+{ruleset_identity_section}{rules_section}  </article>
 </div>"""
     return html_content.replace('<div id="root"></div>', ssr_content, 1)

--- a/backend/tests/test_seo_renderer_canonical_rules.py
+++ b/backend/tests/test_seo_renderer_canonical_rules.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 
 from app.services import seo_renderer
-from app.services.seo_renderer import _render_projection_rules
+from app.services.seo_renderer import CanonicalRuleText, _render_projection_rules, _render_ruleset_identity
 
 
 def _section(*texts: str):
@@ -30,6 +30,39 @@ def test_render_projection_rules_keeps_player_facing_sections():
     assert "## 終了条件・勝利" in rendered
     assert "- end rule" in rendered
     assert "## 得点" not in rendered
+
+
+def test_ruleset_identity_uses_canonical_ruleset_and_official_source_only():
+    ruleset = SimpleNamespace(
+        edition_label="Grandpa Beck's Games current edition",
+        language_code="en",
+        platform="physical",
+        revision_label="current-web-rulebook-1764178570",
+        source_revision=None,
+    )
+    canonical = CanonicalRuleText("## ゲーム進行\n- rule", ruleset)
+
+    rendered = _render_ruleset_identity(
+        canonical,
+        {
+            "source_url": "https://www.grandpabecksgames.com/pages/skull-king",
+            "source_trust": "official_publisher",
+        },
+    )
+
+    assert "このルール要約の対象" in rendered
+    assert "Grandpa Beck&#x27;s Games current edition" in rendered
+    assert "<strong>言語:</strong> en" in rendered
+    assert "<strong>プラットフォーム:</strong> physical" in rendered
+    assert "current-web-rulebook-1764178570" in rendered
+    assert 'href="https://www.grandpabecksgames.com/pages/skull-king"' in rendered
+    assert "出版社の公式ページ" in rendered
+
+    untrusted = _render_ruleset_identity(
+        canonical,
+        {"source_url": "https://example.invalid/rules", "source_trust": "community"},
+    )
+    assert "example.invalid" not in untrusted
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 目的
公開ゲームページのJavaScript実行前HTMLだけで、ルール要約がどの版・言語・プラットフォーム・改訂を対象にし、どの出版社公式ページを一次資料としているか確認できるようにします。

## 成功条件
`/games/skull-king` の公開HTMLに、既存のsource-bound RuleSetから版・言語・プラットフォーム・改訂が表示され、`source_trust=official_publisher` の既存`source_url`だけが一次資料リンクとして表示されること。

## 変更
- 既に取得しているRuleSetをcanonical rule textに保持し、追加DB readなしでSSRへ投影
- 公式出版社と確認済みの`source_url`だけを一次資料リンクとして表示
- 非公式sourceをリンクしない回帰テストを追加

Closes neither #192 nor #209; production確認後に残件を更新します。