### PR TITLE
Supabase readの一時切断を1回だけ再試行する

### DIFF
--- a/.github/workflows/test-presentation-projection.yml
+++ b/.github/workflows/test-presentation-projection.yml
@@ -3,20 +3,24 @@ name: Presentation Projection contract
 on:
   pull_request:
     paths:
+      - "backend/app/core/read_retry.py"
       - "backend/app/models/presentation_projection.py"
       - "backend/app/services/presentation_projection.py"
       - "backend/app/routers/presentation.py"
       - "backend/app/main.py"
+      - "backend/tests/test_read_retry.py"
       - "backend/tests/test_presentation_projection.py"
       - "docs/PRESENTATION_PROJECTION_V1.md"
       - ".github/workflows/test-presentation-projection.yml"
   push:
     branches: [main]
     paths:
+      - "backend/app/core/read_retry.py"
       - "backend/app/models/presentation_projection.py"
       - "backend/app/services/presentation_projection.py"
       - "backend/app/routers/presentation.py"
       - "backend/app/main.py"
+      - "backend/tests/test_read_retry.py"
       - "backend/tests/test_presentation_projection.py"
       - "docs/PRESENTATION_PROJECTION_V1.md"
       - ".github/workflows/test-presentation-projection.yml"
@@ -40,6 +44,7 @@ jobs:
       - name: Compile projection modules
         run: >-
           uv run python -m compileall -q
+          backend/app/core/read_retry.py
           backend/app/models/presentation_projection.py
           backend/app/services/presentation_projection.py
           backend/app/routers/presentation.py
@@ -50,6 +55,7 @@ jobs:
           PYTHONPATH: backend
         run: >-
           uv run pytest -q
+          backend/tests/test_read_retry.py
           backend/tests/test_presentation_projection.py
           backend/tests/test_claim_evidence.py
           backend/tests/test_rule_graph.py

--- a/backend/app/core/read_retry.py
+++ b/backend/app/core/read_retry.py
@@ -1,8 +1,10 @@
 import logging
 import time
 from collections.abc import Callable
+from functools import partial
 from typing import ParamSpec, TypeVar
 
+import anyio
 import httpx
 
 logger = logging.getLogger("core.read_retry")
@@ -24,3 +26,20 @@ def run_supabase_read(
         logger.warning("Supabase read transport disconnected; retrying once")
         time.sleep(retry_delay_seconds)
         return operation(*args, **kwargs)
+
+
+async def run_supabase_read_async(
+    operation: Callable[_P, _R],
+    *args: _P.args,
+    retry_delay_seconds: float = 0.1,
+    **kwargs: _P.kwargs,
+) -> _R:
+    """Run the bounded read retry outside the event loop."""
+    call = partial(
+        run_supabase_read,
+        operation,
+        *args,
+        retry_delay_seconds=retry_delay_seconds,
+        **kwargs,
+    )
+    return await anyio.to_thread.run_sync(call)

--- a/backend/app/core/read_retry.py
+++ b/backend/app/core/read_retry.py
@@ -1,0 +1,26 @@
+import logging
+import time
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+import httpx
+
+logger = logging.getLogger("core.read_retry")
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+def run_supabase_read(
+    operation: Callable[_P, _R],
+    *args: _P.args,
+    retry_delay_seconds: float = 0.1,
+    **kwargs: _P.kwargs,
+) -> _R:
+    """Retry one proven transient Supabase read transport failure, then fail loudly."""
+    try:
+        return operation(*args, **kwargs)
+    except httpx.RemoteProtocolError:
+        logger.warning("Supabase read transport disconnected; retrying once")
+        time.sleep(retry_delay_seconds)
+        return operation(*args, **kwargs)

--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -1,7 +1,7 @@
 import logging
 
 from app.core import supabase
-from app.core.read_retry import run_supabase_read
+from app.core.read_retry import run_supabase_read_async
 from app.models.concept_taxonomy import (
     Concept,
     ConceptDetailResponse,

--- a/backend/app/services/concept_taxonomy.py
+++ b/backend/app/services/concept_taxonomy.py
@@ -1,8 +1,7 @@
 import logging
 
-import anyio
-
 from app.core import supabase
+from app.core.read_retry import run_supabase_read
 from app.models.concept_taxonomy import (
     Concept,
     ConceptDetailResponse,
@@ -28,7 +27,7 @@ class ConceptTaxonomyService:
         if supabase.is_local():
             return None
         try:
-            return await anyio.to_thread.run_sync(self._load_concept, concept_id)
+            return await run_supabase_read_async(self._load_concept, concept_id)
         except Exception as exc:
             logger.exception("Concept taxonomy read failed for %s", concept_id)
             raise ConceptTaxonomyReadError(f"concept taxonomy backend failure for {concept_id}") from exc
@@ -41,7 +40,7 @@ class ConceptTaxonomyService:
         if supabase.is_local():
             return GameConceptsReadResponse(status="not_available", **base)
         try:
-            return await anyio.to_thread.run_sync(self._load_game_concepts, game, base)
+            return await run_supabase_read_async(self._load_game_concepts, game, base)
         except Exception as exc:
             logger.exception("Concept projection read failed for %s", slug)
             raise ConceptTaxonomyReadError(f"concept projection backend failure for {slug}") from exc
@@ -58,7 +57,7 @@ class ConceptTaxonomyService:
         if supabase.is_local():
             return GameGlossaryReadResponse(status="not_available", **base)
         try:
-            concepts = await anyio.to_thread.run_sync(
+            concepts = await run_supabase_read_async(
                 self._load_game_concepts,
                 game,
                 {"game_id": base["game_id"], "slug": base["slug"]},

--- a/backend/app/services/presentation_projection.py
+++ b/backend/app/services/presentation_projection.py
@@ -1,9 +1,8 @@
 import logging
 from collections import defaultdict
 
-import anyio
-
 from app.core import supabase
+from app.core.read_retry import run_supabase_read_async
 from app.models.presentation_projection import (
     GlossaryProjectionSection,
     PresentationProjectionResponse,
@@ -131,7 +130,7 @@ class PresentationProjectionService:
         if supabase.is_local():
             return self._empty_response(game, rule_set_id, language_code)
         try:
-            return await anyio.to_thread.run_sync(
+            return await run_supabase_read_async(
                 self._load_projection,
                 game,
                 rule_set_id,

--- a/backend/tests/test_read_retry.py
+++ b/backend/tests/test_read_retry.py
@@ -1,0 +1,56 @@
+import httpx
+import pytest
+
+from app.core.read_retry import run_supabase_read
+
+
+def test_supabase_read_returns_without_retry():
+    calls = 0
+
+    def operation():
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    assert run_supabase_read(operation, retry_delay_seconds=0) == "ok"
+    assert calls == 1
+
+
+def test_supabase_read_retries_remote_protocol_error_once():
+    calls = 0
+
+    def operation():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.RemoteProtocolError("Server disconnected")
+        return "ok"
+
+    assert run_supabase_read(operation, retry_delay_seconds=0) == "ok"
+    assert calls == 2
+
+
+def test_supabase_read_fails_after_one_retry():
+    calls = 0
+
+    def operation():
+        nonlocal calls
+        calls += 1
+        raise httpx.RemoteProtocolError("Server disconnected")
+
+    with pytest.raises(httpx.RemoteProtocolError, match="Server disconnected"):
+        run_supabase_read(operation, retry_delay_seconds=0)
+    assert calls == 2
+
+
+def test_supabase_read_does_not_retry_unproven_errors():
+    calls = 0
+
+    def operation():
+        nonlocal calls
+        calls += 1
+        raise ValueError("bad data")
+
+    with pytest.raises(ValueError, match="bad data"):
+        run_supabase_read(operation, retry_delay_seconds=0)
+    assert calls == 1


### PR DESCRIPTION
## Before → After
- Before: productionのSkull King Presentation Projection / Glossary readで、Supabase/PostgRESTのHTTP/2接続が一度切れると`httpx.RemoteProtocolError: Server disconnected`で公開readとrelease verificationが失敗する。
- After: canonical read全体を同じ入力で1回だけ再実行し、同じtransport errorが続けば従来どおり例外を上げてfail loudlyする。

## プレイヤー向け成功条件
canonical productionのSkull Kingルール・用語集が、一度だけの`RemoteProtocolError`では欠落せず、release verificationを完走すること。

## 制約
- retry対象は実productionで確認した`httpx.RemoteProtocolError`だけ
- 最大2試行（retry 1回）
- writeには適用しない
- `ValueError`等のデータ・実装エラーは即時失敗
- fallback、別データ源、壊れたデータの通過は追加しない

## 検証
- helper単体で通常成功、1回失敗後成功、2回失敗、対象外例外を固定
- 既存Presentation Projection / Concept taxonomy test
- exact-head CI → merge → main production verification

Refs #91