### PR TITLE
GamePageの出典と信頼状態を1つの表示へ統合する

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -387,17 +387,13 @@ export default function GamePage({ slug: propSlug, initialGame }) {
         </div>
 
         <div className="game-sidebar" aria-label="補足情報">
-          <div className="pro-card" aria-label="データ信頼状態">
-            <div className="pro-card-title">TRUST &amp; PROVENANCE</div>
+          <ConceptGlossary slug={slug} onRuleNodesLoaded={setRuleNodes} />
+
+          <div className="pro-card" aria-label="出典・根拠">
+            <div className="pro-card-title">出典・根拠</div>
             <div className="game-empty-note">{identityLabel}</div>
             <div className="game-empty-note">{sourceTrustLabel}</div>
             <div className="game-empty-note">{reviewLabel}</div>
-          </div>
-
-          <ConceptGlossary slug={slug} onRuleNodesLoaded={setRuleNodes} />
-
-          <div className="pro-card">
-            <div className="pro-card-title">LINKS</div>
             <ExternalLinks game={game} />
           </div>
         </div>

--- a/frontend/tests/source_evidence_panel.spec.js
+++ b/frontend/tests/source_evidence_panel.spec.js
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 76,
+  slug: 'big-shot',
+  title: 'Big Shot',
+  title_ja: 'ビッグショット',
+  min_players: 2,
+  max_players: 4,
+  play_time: 45,
+  min_age: 10,
+  published_year: 2001,
+  summary: '土地を競り落とし、資金を管理しながら得点を競うオークションゲーム。',
+  source_url: 'https://example.com/big-shot-source',
+  source_trust: 'third_party',
+  identity_status: 'verified',
+  content_review_status: 'review_required',
+  bgg_url: 'https://boardgamegeek.com/boardgame/1/example',
+  rules_content: '# Big Shot Rules\n\nルール本文。',
+}
+
+test('出典リンクと信頼状態を同じ表示で確認できる', async ({ page }) => {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${game.slug}`) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ games: [] }) })
+  })
+
+  await page.goto('/games/big-shot')
+
+  const panel = page.getByLabel('出典・根拠')
+  await expect(panel).toHaveCount(1)
+  await expect(panel.getByText('IDENTITY VERIFIED')).toBeVisible()
+  await expect(panel.getByText('THIRD-PARTY SOURCE')).toBeVisible()
+  await expect(panel.getByText('REVIEW REQUIRED')).toBeVisible()
+  await expect(panel.getByRole('link', { name: '第三者の出典' })).toHaveAttribute('href', game.source_url)
+  await expect(panel.getByRole('link', { name: 'BoardGameGeek' })).toHaveAttribute('href', game.bgg_url)
+
+  await expect(page.getByText('TRUST & PROVENANCE')).toHaveCount(0)
+  await expect(page.getByText('LINKS', { exact: true })).toHaveCount(0)
+})


### PR DESCRIPTION
## 変更前

GamePageでは、`source_trust` / `content_review_status` と実際の `source_url` が `TRUST & PROVENANCE` と `LINKS` の別カードに分かれていました。利用者は「この出典がどの信頼状態なのか」を別々に読み合わせる必要がありました。

## 成功条件

登録済み出典を持つゲームで、利用者が1つの「出典・根拠」表示の中で、identity・source trust・review stateと実際の出典リンクを確認できること。BoardGameGeek等の便利な外部リンクは同じデータ源と誤認せず「その他のリンク」のまま区別すること。

## 変更

- `TRUST & PROVENANCE` と `LINKS` の2カードを1つの「出典・根拠」カードへ統合
- 既存 `ExternalLinks`、`source_url`、`source_trust`、`content_review_status` をそのまま再利用
- 別API・別source一覧・別workflowは追加しない
- Playwrightで、信頼状態・登録済み出典・BoardGameGeekリンクが同じ表示内にあり、旧2見出しが復活しないことを回帰テスト

## 関連

#192