### PR TITLE
SSRに内容確認状態と登録済み出典を表示する

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -137,30 +137,37 @@ async def _canonical_rule_text(slug: str) -> str | None:
 
 def _render_ruleset_identity(canonical_rules: str | None, game: dict) -> str:
     ruleset = getattr(canonical_rules, "ruleset", None)
-    if ruleset is None:
-        return ""
-
     facts: list[str] = []
-    if ruleset.edition_label:
-        facts.append(f"<p><strong>版:</strong> {html.escape(str(ruleset.edition_label))}</p>")
-    if ruleset.language_code:
-        facts.append(f"<p><strong>言語:</strong> {html.escape(str(ruleset.language_code))}</p>")
-    if ruleset.platform:
-        facts.append(f"<p><strong>プラットフォーム:</strong> {html.escape(str(ruleset.platform))}</p>")
-    revision = ruleset.revision_label or ruleset.source_revision
-    if revision:
-        facts.append(f"<p><strong>改訂:</strong> {html.escape(str(revision))}</p>")
 
-    source_url = game.get("source_url") if game.get("source_trust") == "official_publisher" else None
+    if ruleset is not None:
+        if ruleset.edition_label:
+            facts.append(f"<p><strong>版:</strong> {html.escape(str(ruleset.edition_label))}</p>")
+        if ruleset.language_code:
+            facts.append(f"<p><strong>言語:</strong> {html.escape(str(ruleset.language_code))}</p>")
+        if ruleset.platform:
+            facts.append(f"<p><strong>プラットフォーム:</strong> {html.escape(str(ruleset.platform))}</p>")
+        revision = ruleset.revision_label or ruleset.source_revision
+        if revision:
+            facts.append(f"<p><strong>改訂:</strong> {html.escape(str(revision))}</p>")
+
+    review_status = game.get("content_review_status")
+    if review_status:
+        facts.append(f"<p><strong>内容確認状態:</strong> {html.escape(str(review_status))}</p>")
+
+    source_trust = game.get("source_trust")
+    if source_trust:
+        facts.append(f"<p><strong>出典の信頼状態:</strong> {html.escape(str(source_trust))}</p>")
+
+    source_url = game.get("source_url")
     if isinstance(source_url, str) and source_url.startswith(("https://", "http://")):
         safe_url = html.escape(source_url, quote=True)
         facts.append(
-            f'<p><strong>一次資料:</strong> <a href="{safe_url}" rel="noopener noreferrer">出版社の公式ページ</a></p>'
+            f'<p><strong>登録済み出典:</strong> <a href="{safe_url}" rel="noopener noreferrer">出典を確認</a></p>'
         )
 
     if not facts:
         return ""
-    return "    <section>\n      <h2>このルール要約の対象</h2>\n      " + "\n      ".join(facts) + "\n    </section>\n"
+    return "    <section>\n      <h2>出典・確認状態</h2>\n      " + "\n      ".join(facts) + "\n    </section>\n"
 
 
 async def generate_seo_html(slug: str) -> str | None:

--- a/backend/tests/test_seo_renderer_canonical_rules.py
+++ b/backend/tests/test_seo_renderer_canonical_rules.py
@@ -32,7 +32,7 @@ def test_render_projection_rules_keeps_player_facing_sections():
     assert "## 得点" not in rendered
 
 
-def test_ruleset_identity_uses_canonical_ruleset_and_official_source_only():
+def test_ruleset_identity_uses_canonical_ruleset_and_exact_review_source_state():
     ruleset = SimpleNamespace(
         edition_label="Grandpa Beck's Games current edition",
         language_code="en",
@@ -47,22 +47,37 @@ def test_ruleset_identity_uses_canonical_ruleset_and_official_source_only():
         {
             "source_url": "https://www.grandpabecksgames.com/pages/skull-king",
             "source_trust": "official_publisher",
+            "content_review_status": "unknown",
         },
     )
 
-    assert "このルール要約の対象" in rendered
+    assert "出典・確認状態" in rendered
     assert "Grandpa Beck&#x27;s Games current edition" in rendered
     assert "<strong>言語:</strong> en" in rendered
     assert "<strong>プラットフォーム:</strong> physical" in rendered
     assert "current-web-rulebook-1764178570" in rendered
+    assert "<strong>内容確認状態:</strong> unknown" in rendered
+    assert "<strong>出典の信頼状態:</strong> official_publisher" in rendered
     assert 'href="https://www.grandpabecksgames.com/pages/skull-king"' in rendered
-    assert "出版社の公式ページ" in rendered
+    assert "出典を確認" in rendered
 
-    untrusted = _render_ruleset_identity(
-        canonical,
-        {"source_url": "https://example.invalid/rules", "source_trust": "community"},
+
+def test_source_review_state_is_visible_without_projected_rule_text():
+    rendered = _render_ruleset_identity(
+        None,
+        {
+            "source_url": "https://ja.boardgamearena.com/gamepanel?game=pilipili",
+            "source_trust": "authorized_partner",
+            "content_review_status": "review_required",
+        },
     )
-    assert "example.invalid" not in untrusted
+
+    assert "出典・確認状態" in rendered
+    assert "<strong>内容確認状態:</strong> review_required" in rendered
+    assert "<strong>出典の信頼状態:</strong> authorized_partner" in rendered
+    assert 'href="https://ja.boardgamearena.com/gamepanel?game=pilipili"' in rendered
+    assert "出版社" not in rendered
+    assert "<strong>版:</strong>" not in rendered
 
 
 @pytest.mark.asyncio
@@ -102,5 +117,6 @@ async def test_source_bound_ssr_uses_same_neutral_summary_as_public_api(
     assert neutral in rendered
     assert 'name="description" content="「イト」の出典付きルール要約と出典情報を確認できます。"' in rendered
     assert 'itemprop="description">「イト」の出典付きルール要約と出典情報を確認できます。</p>' in rendered
+    assert "<strong>内容確認状態:</strong> review_required" in rendered
     assert "unreviewed legacy summary" not in rendered
     assert "unreviewed legacy description" not in rendered


### PR DESCRIPTION
## 目的
公開GamePageのraw HTMLでも、現在の実データにある内容確認状態・出典の信頼状態・登録済み出典を確認できるようにします。

## プレイヤー向け完了条件
- Pili Piliで `review_required` と `authorized_partner`、Board Game Arenaの登録済み出典がJavaScript実行前のHTMLに表示される
- source-boundなルール要約があるゲームでは、既存の版・言語・プラットフォーム・改訂表示を維持する
- RuleSetが複数あり単一の要約対象を確定できない場合、版を推測して表示しない
- `source_url` の存在だけで出版社確認済みと表現しない

## 変更
- 既存SSRの出典表示に `content_review_status` と `source_trust` を追加
- `source_url` は「登録済み出典」として表示し、信頼状態は別フィールドで明示
- projected rule textが無い場合も確認状態と出典は表示
- 既存testへPili Pili相当の `review_required + authorized_partner` を追加

新しいAPI、データ源、信頼分類、fallbackは追加しません。

関連: #192