### PR TITLE
RuleSetがないゲームのSEO表現を基本情報へ限定する

### DIFF
--- a/backend/app/services/seo_renderer.py
+++ b/backend/app/services/seo_renderer.py
@@ -44,7 +44,10 @@ def _safe_json_script(data: dict) -> str:
     return payload.replace("&", "\\u0026").replace("<", "\\u003c").replace(">", "\\u003e")
 
 
-def _page_title(game: dict, title: str) -> str:
+def _page_title(game: dict, title: str, *, has_canonical_rules: bool) -> str:
+    if not has_canonical_rules:
+        return f"「{title}」の基本情報 | ボドゲのミカタ"
+
     structured_data = game.get("structured_data")
     has_strategy = isinstance(structured_data, dict) and bool(structured_data.get("strategy_analysis"))
     strategy_label = "・戦略" if has_strategy else ""
@@ -185,7 +188,7 @@ async def generate_seo_html(slug: str) -> str | None:
         image_url = f"{BASE_URL}{image_url}"
 
     game_url = f"{BASE_URL}/games/{slug}"
-    page_title = _page_title(game, title)
+    page_title = _page_title(game, title, has_canonical_rules=canonical_rules is not None)
     seo_description = description or f"「{title}」の登録済みルール要約と出典情報を確認できます。"
     hide_from_search = should_hide_game_from_search(game)
 

--- a/backend/tests/test_seo_renderer.py
+++ b/backend/tests/test_seo_renderer.py
@@ -8,13 +8,31 @@ from app.services import seo_renderer
 def test_page_title_omits_strategy_when_unavailable() -> None:
     game = {"structured_data": {"strategy_analysis": None}}
 
-    assert seo_renderer._page_title(game, "スカルキング") == "「スカルキング」のルール・インスト要約 | ボドゲのミカタ"
+    assert seo_renderer._page_title(
+        game,
+        "スカルキング",
+        has_canonical_rules=True,
+    ) == "「スカルキング」のルール・インスト要約 | ボドゲのミカタ"
 
 
 def test_page_title_includes_strategy_when_available() -> None:
     game = {"structured_data": {"strategy_analysis": "終盤では得点状況を見てビッドを調整する。"}}
 
-    assert seo_renderer._page_title(game, "Example") == "「Example」のルール・戦略・インスト要約 | ボドゲのミカタ"
+    assert seo_renderer._page_title(
+        game,
+        "Example",
+        has_canonical_rules=True,
+    ) == "「Example」のルール・戦略・インスト要約 | ボドゲのミカタ"
+
+
+def test_page_title_is_neutral_without_canonical_rules() -> None:
+    game = {"content_review_status": "review_required"}
+
+    assert seo_renderer._page_title(
+        game,
+        "みんなでぽんこつペイント",
+        has_canonical_rules=False,
+    ) == "「みんなでぽんこつペイント」の基本情報 | ボドゲのミカタ"
 
 
 def test_open_ended_player_count_does_not_invent_maximum() -> None:
@@ -130,6 +148,8 @@ async def test_game_ssr_replaces_metadata_escapes_content_and_omits_legacy_rules
     assert '&lt;script&gt;alert(&quot;rules&quot;)&lt;/script&gt;' not in rendered
     assert '<h2>ルール</h2>' not in rendered
     assert "\\u003cscript" in rendered
+    assert "ルール・インスト要約" not in rendered
+    assert "基本情報 | ボドゲのミカタ" in rendered
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 目的

#556 の残件として、一次資料へ結び付いた有効なRuleSetがないゲームのraw HTMLが「ルール・インスト要約」と断定しないようにする。

## Before

`minna-de-ponkotsu-paint` はproductionで `content_review_status=review_required`、詳細RuleSetなし、本文は基本情報・出典だけ、`noindex, follow` だが、`<title>` / `og:title` / `twitter:title` は「ルール・インスト要約」と表示していた。

## After

- canonical RuleSetから表示可能なルール本文を取得できた場合だけ「ルール・インスト要約」を使う
- 取得できない場合は「基本情報」とする
- 個別slug例外は作らない
- `noindex`、基本情報、出典表示は既存挙動を維持する
- 既存SEO rendererテストへ再発防止を統合する

## 成功条件

RuleSetがない `review_required` ゲームのraw production HTMLで「ルール・インスト要約」を名乗らず、基本情報・公式出典・`noindex, follow` を維持する。

Closes #556