### PR TITLE
RuleSetがないゲームのclient titleを基本情報へ揃える

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -101,6 +101,7 @@ jobs:
           tests/navigation.spec.js
           tests/performance.spec.js
           tests/game_layout.spec.js
+          tests/game_page_title_trust.spec.js
           tests/game_section_navigation.spec.js
           tests/mobile_game_scroll.spec.js
           tests/auth.spec.js

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -196,7 +196,9 @@ export default function GamePage({ slug: propSlug, initialGame }) {
     legacyInfographicsSourceUrl,
   )
 
-  const pageTitle = `「${title}」のルール・インスト要約 | ボドゲのミカタ`
+  const pageTitle = rules
+    ? `「${title}」のルール・インスト要約 | ボドゲのミカタ`
+    : `「${title}」の基本情報 | ボドゲのミカタ`
   const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
   const gameUrl = `${BASE_URL}/games/${slug}`
   const imageUrl = game.image_url || `${BASE_URL}/assets/no-image.webp`

--- a/frontend/tests/game_page_title_trust.spec.js
+++ b/frontend/tests/game_page_title_trust.spec.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test'
+
+async function mockGame(page, game) {
+  await page.route('**/api/games**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${game.slug}`) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ game }),
+      })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ games: [] }),
+    })
+  })
+}
+
+test('canonical rulesがないゲームはclient側でも基本情報と表示する', async ({ page }) => {
+  const game = {
+    id: 'game-without-rules',
+    slug: 'game-without-rules',
+    title: 'Game Without Rules',
+    title_ja: 'ルール未確認ゲーム',
+    summary: '基本情報だけを確認できるゲームです。',
+    identity_status: 'verified',
+    source_trust: 'official_publisher',
+    content_review_status: 'review_required',
+    rules_content: null,
+    setup_summary: null,
+    gameplay_summary: null,
+    end_game_summary: null,
+  }
+
+  await mockGame(page, game)
+  await page.goto(`/games/${game.slug}`)
+
+  await expect(page).toHaveTitle('「ルール未確認ゲーム」の基本情報 | ボドゲのミカタ')
+})
+
+test('canonical rulesがあるゲームだけclient側でルール要約と表示する', async ({ page }) => {
+  const game = {
+    id: 'game-with-rules',
+    slug: 'game-with-rules',
+    title: 'Game With Rules',
+    title_ja: 'ルール確認済みゲーム',
+    summary: '出典付きルールを確認できるゲームです。',
+    identity_status: 'verified',
+    source_trust: 'official_publisher',
+    content_review_status: 'unknown',
+    rules_content: '## セットアップ\n- 準備します。',
+    setup_summary: null,
+    gameplay_summary: null,
+    end_game_summary: null,
+  }
+
+  await mockGame(page, game)
+  await page.goto(`/games/${game.slug}`)
+
+  await expect(page).toHaveTitle('「ルール確認済みゲーム」のルール・インスト要約 | ボドゲのミカタ')
+})


### PR DESCRIPTION
## 目的

RuleSetがないゲームで、raw HTMLは「基本情報」なのにReact起動後だけ「ルール・インスト要約」へ戻る不整合をなくす。

## 利用者向け完了条件

canonicalなルール本文がないゲームでは、初期HTML・React起動後・Web Shareのtitleが「基本情報」で一致する。canonicalなルール本文があるゲームだけ「ルール・インスト要約」と表示する。

## 変更

- `GamePage` のtitleを、公開APIが返すcanonical `rules_content` の有無から決める
- RuleSetなし／ありの両方をPlaywrightで回帰テストする
- 別のRuleSet判定、独自metadata、fallbackは追加しない

## productionのBefore確認

2026-09-02時点:

- `/api/games/big-shot`: `rules_content=null`, `source_trust=unknown`, `content_review_status=unknown`
- `/games/big-shot` raw HTML: `「ビッグショット」の基本情報 | ボドゲのミカタ`
- current React `GamePage` は `rules_content` に関係なく `「...」のルール・インスト要約` を設定していた

関連: #139, #556