### PR TITLE
ルールがないゲームの空導線を表示しない

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -50,10 +50,17 @@ function formatPlayTime(game) {
   return game.play_time != null ? `${game.play_time}m` : 'N/A'
 }
 
-function isTabAvailable(tab, { hasCoachSummary, hasInfographics }) {
+function isTabAvailable(tab, { hasCoachSummary, hasInfographics, hasRules }) {
   if (tab === 'coach') return hasCoachSummary
   if (tab === 'infographics') return hasInfographics
-  return tab === 'rules' || tab === 'graph'
+  if (tab === 'rules') return hasRules
+  return tab === 'graph'
+}
+
+function getDefaultTab({ hasCoachSummary, hasRules }) {
+  if (hasCoachSummary) return 'coach'
+  if (hasRules) return 'rules'
+  return null
 }
 
 export default function GamePage({ slug: propSlug, initialGame }) {
@@ -79,7 +86,8 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const hasCoachSummary = Boolean(
     game?.setup_summary || game?.gameplay_summary || game?.end_game_summary,
   )
-  const tabAvailability = { hasCoachSummary, hasInfographics }
+  const hasRules = Boolean(game?.rules_content?.trim())
+  const tabAvailability = { hasCoachSummary, hasInfographics, hasRules }
 
   useEffect(() => {
     const fetchData = async () => {
@@ -110,12 +118,13 @@ export default function GamePage({ slug: propSlug, initialGame }) {
 
     const syncFromLocation = () => {
       const hash = window.location.hash
+      const defaultTab = getDefaultTab(tabAvailability)
       if (!hash) {
-        setActiveTab(hasCoachSummary ? 'coach' : 'rules')
+        setActiveTab(defaultTab)
         return
       }
       if (hash.startsWith('#rule-')) {
-        setActiveTab('rules')
+        setActiveTab(hasRules ? 'rules' : defaultTab)
         return
       }
       const requestedTab = HASH_TABS[hash]
@@ -123,7 +132,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
         setActiveTab(requestedTab)
         return
       }
-      setActiveTab('rules')
+      setActiveTab(defaultTab)
     }
 
     syncFromLocation()
@@ -133,7 +142,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
       window.removeEventListener('popstate', syncFromLocation)
       window.removeEventListener('hashchange', syncFromLocation)
     }
-  }, [game, hasCoachSummary, hasInfographics])
+  }, [game, hasCoachSummary, hasInfographics, hasRules])
 
   useEffect(() => {
     if (activeTab !== 'graph') return undefined
@@ -199,7 +208,9 @@ export default function GamePage({ slug: propSlug, initialGame }) {
   const pageTitle = rules
     ? `「${title}」のルール・インスト要約 | ボドゲのミカタ`
     : `「${title}」の基本情報 | ボドゲのミカタ`
-  const description = game.summary || `「${title}」の登録済みルール要約と出典情報を確認できます。`
+  const description = game.summary || (rules
+    ? `「${title}」の登録済みルール要約と出典情報を確認できます。`
+    : `「${title}」の登録済み基本情報と出典情報を確認できます。`)
   const gameUrl = `${BASE_URL}/games/${slug}`
   const imageUrl = game.image_url || `${BASE_URL}/assets/no-image.webp`
 
@@ -266,9 +277,11 @@ export default function GamePage({ slug: propSlug, initialGame }) {
                 準備・流れ・終了
               </button>
             )}
-            <button type="button" aria-pressed={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => navigateToTab('rules')}>
-              詳しいルール
-            </button>
+            {hasRules && (
+              <button type="button" aria-pressed={activeTab === 'rules'} className={activeTab === 'rules' ? 'active' : ''} onClick={() => navigateToTab('rules')}>
+                詳しいルール
+              </button>
+            )}
             <button type="button" aria-pressed={activeTab === 'graph'} className={activeTab === 'graph' ? 'active' : ''} onClick={() => navigateToTab('graph')}>
               関連ゲーム
             </button>
@@ -280,7 +293,7 @@ export default function GamePage({ slug: propSlug, initialGame }) {
           </div>
 
           <div className="pro-main-col">
-            {activeTab === 'rules' && <RuleMarkdown markdown={rules} ruleNodes={ruleNodes} />}
+            {activeTab === 'rules' && hasRules && <RuleMarkdown markdown={rules} ruleNodes={ruleNodes} />}
 
             {activeTab === 'coach' && (
               <div className="coach-mode">

--- a/frontend/tests/game_page_title_trust.spec.js
+++ b/frontend/tests/game_page_title_trust.spec.js
@@ -39,6 +39,13 @@ test('canonical rulesがないゲームはclient側でも基本情報と表示�
   await page.goto(`/games/${game.slug}`)
 
   await expect(page).toHaveTitle('「ルール未確認ゲーム」の基本情報 | ボドゲのミカタ')
+  await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toHaveCount(0)
+  await expect(page.getByText(game.summary, { exact: true })).toBeVisible()
+  await expect(page.getByText('REVIEW REQUIRED', { exact: true })).toBeVisible()
+
+  await page.goto(`/games/${game.slug}#rules`)
+  await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toHaveCount(0)
+  await expect(page.getByText(game.summary, { exact: true })).toBeVisible()
 })
 
 test('canonical rulesがあるゲームだけclient側でルール要約と表示する', async ({ page }) => {
@@ -61,4 +68,5 @@ test('canonical rulesがあるゲームだけclient側でルール要約と表�
   await page.goto(`/games/${game.slug}`)
 
   await expect(page).toHaveTitle('「ルール確認済みゲーム」のルール・インスト要約 | ボドゲのミカタ')
+  await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toBeVisible()
 })


### PR DESCRIPTION
## 目的

canonical `rules_content` がないゲームで、空の「詳しいルール」導線を表示しない。

## Before

- `rules_content=null` でも「詳しいルール」ボタンが常時表示される
- `#rules` / `#rule-*` を開くと、存在しない詳細ルール表示へ入れる
- metadataは「基本情報」なのに、画面内導線だけがルールありのように見える

## After

- `rules_content` が空なら「詳しいルール」を表示しない
- `#rules` / `#rule-*` も存在しないルール表示へ遷移しない
- 確認済みsummaryがある場合は従来どおり「準備・流れ・終了」を初期表示する
- RuleSetがあるゲームでは詳細ルール導線を維持する
- summaryがない場合のdescriptionも「基本情報と出典情報」に合わせる

## observable success condition

RuleSetがないfixtureで、GamePageの基本情報・review状態を読める一方、「詳しいルール」ボタンがDOMに存在しない。RuleSetがあるfixtureでは同ボタンが表示される。

## 検証

既存 `game_page_title_trust.spec.js` を拡張し、既存 `UI UX regression` の明示的な実行対象のまま回帰検証する。

関連: #158