### PR TITLE
GamePageの段階表示とkeyboard操作を回帰テストする

### DIFF
--- a/frontend/tests/game_page_title_trust.spec.js
+++ b/frontend/tests/game_page_title_trust.spec.js
@@ -70,3 +70,39 @@ test('canonical rulesがあるゲームだけclient側でルール要約と表�
   await expect(page).toHaveTitle('「ルール確認済みゲーム」のルール・インスト要約 | ボドゲのミカタ')
   await expect(page.getByRole('button', { name: '詳しいルール', exact: true })).toBeVisible()
 })
+
+test('部分的な要点だけを表示し、keyboardで同じゲームの詳細ルールへ進める', async ({ page }) => {
+  const game = {
+    id: 'game-with-partial-summary',
+    slug: 'game-with-partial-summary',
+    title: 'Game With Partial Summary',
+    title_ja: '部分要点ゲーム',
+    summary: '確認できた要点と詳細ルールを同じゲーム情報から表示します。',
+    identity_status: 'verified',
+    source_trust: 'official_publisher',
+    content_review_status: 'review_required',
+    source_url: 'https://example.com/official-rules',
+    rules_content: '## 詳細ルール\n- 確認済みの手順です。',
+    setup_summary: '確認済みの準備だけを表示します。',
+    gameplay_summary: null,
+    end_game_summary: null,
+  }
+
+  await mockGame(page, game)
+  await page.goto(`/games/${game.slug}`)
+
+  await expect(page.getByRole('button', { name: '準備・流れ・終了', exact: true })).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByText(game.setup_summary, { exact: true })).toBeVisible()
+  await expect(page.getByText('未確認です', { exact: true })).toHaveCount(0)
+  await expect(page.getByText('REVIEW REQUIRED', { exact: true })).toBeVisible()
+
+  const rulesButton = page.getByRole('button', { name: '詳しいルール', exact: true })
+  await rulesButton.focus()
+  await expect(rulesButton).toBeFocused()
+  await page.keyboard.press('Enter')
+
+  await expect(page).toHaveURL(/#rules$/)
+  await expect(rulesButton).toHaveAttribute('aria-pressed', 'true')
+  await expect(page.getByRole('heading', { name: '詳細ルール', exact: true })).toBeVisible()
+  await expect(page.getByText('REVIEW REQUIRED', { exact: true })).toBeVisible()
+})


### PR DESCRIPTION
## 目的

Issue #158 の残っていた確認項目を、既存GamePage実装と同じPlaywright回帰へ統合する。

## observable success condition

部分的なsummaryしかないゲームで、存在する要点だけが表示され、不明項目を補完せず、keyboardだけで「準備・流れ・終了」から「詳しいルール」へ移動できる。移動前後でreview状態を失わない。

## 変更

- 既存 `game_page_title_trust.spec.js` に部分summary fixtureを追加
- 欠損summaryに「未確認です」を生成しないことを検証
- native buttonへfocusしてEnterで詳細ルールへ移動できることを検証
- `REVIEW REQUIRED` が要点表示と詳細ルール表示の双方で維持されることを検証

新しいAPI、schema、workflow、独自分類は追加しない。

関連: #158