### PR TITLE
公式ルール資料のsource typeを統一する

### DIFF
--- a/backend/app/db/migrations/124_claim_evidence_source_roles.sql
+++ b/backend/app/db/migrations/124_claim_evidence_source_roles.sql
@@ -1,0 +1,38 @@
+BEGIN;
+
+-- Normalize official rule-document roles to the canonical vocabulary used by
+-- Claim / Evidence ingestion. Authority/trust remains separate in trust_metadata.
+UPDATE public.evidence_sources
+SET source_type = CASE source_type
+    WHEN 'publisher_rulebook' THEN 'rulebook'
+    WHEN 'publisher_rules_faq_page' THEN 'official_faq'
+    WHEN 'publisher_errata' THEN 'official_errata'
+    WHEN 'publisher_clarification' THEN 'official_clarification'
+    ELSE source_type
+  END,
+  updated_at = now()
+WHERE source_type IN (
+  'publisher_rulebook',
+  'publisher_rules_faq_page',
+  'publisher_errata',
+  'publisher_clarification'
+);
+
+-- Do not let future writes reintroduce the superseded aliases. Other source
+-- roles (for example product pages or platform rules) remain valid and keep
+-- their own semantics instead of being forced into an official-rule role.
+ALTER TABLE public.evidence_sources
+  DROP CONSTRAINT IF EXISTS evidence_sources_no_legacy_official_source_type;
+
+ALTER TABLE public.evidence_sources
+  ADD CONSTRAINT evidence_sources_no_legacy_official_source_type
+  CHECK (
+    source_type NOT IN (
+      'publisher_rulebook',
+      'publisher_rules_faq_page',
+      'publisher_errata',
+      'publisher_clarification'
+    )
+  );
+
+COMMIT;

--- a/backend/app/models/evidence.py
+++ b/backend/app/models/evidence.py
@@ -31,6 +31,13 @@ class EvidenceRelation(StrEnum):
     UNRESOLVED = "unresolved"
 
 
+class OfficialEvidenceSourceType(StrEnum):
+    RULEBOOK = "rulebook"
+    OFFICIAL_FAQ = "official_faq"
+    OFFICIAL_ERRATA = "official_errata"
+    OFFICIAL_CLARIFICATION = "official_clarification"
+
+
 class ClaimLifecycleStatus(StrEnum):
     UNKNOWN = "unknown"
     CANDIDATE = "candidate"


### PR DESCRIPTION
## 目的

Claim / Evidenceで、公式rulebook・公式FAQ・公式errata・公式clarificationを同じ自由文字列へ潰さず、役割を機械的に区別できるようにする。

対象Issue: #254

## 利用者に見える成功条件

Skull Kingの現行RuleSetで、Mermaid裁定やPirate能力timingの根拠がGrandpa Beck's Gamesの現行FAQへtraceできる状態を維持しつつ、そのsource typeが `official_faq` と判別できること。

## 変更

- 既存Claim / Evidence modelに次の公式資料種別を定義
  - `rulebook`
  - `official_faq`
  - `official_errata`
  - `official_clarification`
- migration 124で既存の旧名称を置換
  - `publisher_rulebook` → `rulebook`
  - `publisher_rules_faq_page` → `official_faq`
  - `publisher_errata` → `official_errata`
  - `publisher_clarification` → `official_clarification`
- 旧名称を将来のDB writeで再導入できないCHECK constraintを追加
- product pageやplatform rules等、別の意味を持つsource typeは変更しない
- source trustは引き続き`trust_metadata`等の既存契約で別管理し、source typeだけで公式性を推測しない

## 現在のproduction evidence

2026-09-03にcanonical productionを実取得した。

- active Skull King RuleSet: `6113970e-af8d-44cd-bcc7-0bad7d0b1258`
- edition: `Grandpa Beck's Games current edition`
- revision: `current-web-rulebook-1764178570`
- Mermaid + Skull King + Pirate claim: accepted / supported / projection_eligible=true
- Pirate能力timing claim: accepted / supported / projection_eligible=true
- 両claimとも `https://www.grandpabecksgames.com/pages/skull-king` のFAQ locatorへ結合済み
- 現状のFAQ source typeは `publisher_rules_faq_page` のため、本PRで `official_faq` へ正準化する

## 公式一次資料

https://www.grandpabecksgames.com/pages/skull-king

同ページで現在、rulebook download、Pirate能力timing、Mermaid裁定、Kraken裁定等を確認できる。

## 検証

既存 `Claim Evidence contract` をexact headで必須確認する。merge後はproduction evidence APIを再取得し、同じclaim/binding/locatorを維持したままsource typeだけが正準化されたことを確認する。

新しいworkflow、source registry、Skull King専用scriptは追加しない。