### PR TITLE
GamePageで現在のRuleSet境界を表示する

### DIFF
--- a/.github/workflows/ui-ux-regression.yml
+++ b/.github/workflows/ui-ux-regression.yml
@@ -102,6 +102,7 @@ jobs:
           tests/performance.spec.js
           tests/game_layout.spec.js
           tests/game_page_title_trust.spec.js
+          tests/game_ruleset_context.spec.js
           tests/game_section_navigation.spec.js
           tests/mobile_game_scroll.spec.js
           tests/auth.spec.js

--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -1,3 +1,6 @@
+import { useEffect, useState } from 'react'
+import { api } from '../../lib/api'
+
 const isValidUrl = (url) => {
   if (!url || typeof url !== 'string') return false
   const trimmed = url.trim()
@@ -29,6 +32,20 @@ const sourceLabel = (sourceTrust) => {
   return '登録済み出典（未検証）'
 }
 
+const rulesetStatusLabel = (ruleset) => {
+  if (ruleset.verification_status === 'source_bound') return '出典に結び付いたルールセット'
+  if (ruleset.verification_status === 'verified') return '確認済みルールセット'
+  return '確認状態が未確定のルールセット'
+}
+
+const rulesetIdentity = (ruleset) => [
+  ruleset.edition_label ? `版: ${ruleset.edition_label}` : null,
+  ruleset.variant_label ? `バリアント: ${ruleset.variant_label}` : null,
+  ruleset.platform ? `プラットフォーム: ${ruleset.platform}` : null,
+  ruleset.language_code ? `言語: ${ruleset.language_code}` : null,
+  ruleset.revision_label ? `改訂: ${ruleset.revision_label}` : null,
+].filter(Boolean)
+
 const trackAffiliateOutbound = (gameSlug, provider) => {
   if (typeof window === 'undefined' || typeof window.va !== 'function') return
 
@@ -43,6 +60,7 @@ const trackAffiliateOutbound = (gameSlug, provider) => {
 
 export const ExternalLinks = ({ game }) => {
   const { affiliate_urls, source_url, source_trust, bgg_url, amazon_url } = game
+  const [rulesetState, setRulesetState] = useState({ status: 'loading', rulesets: [] })
   const affiliateAmazon = affiliate_urls?.amazon
   const amazon = affiliateAmazon || amazon_url
   const rakuten = affiliate_urls?.rakuten
@@ -63,10 +81,55 @@ export const ExternalLinks = ({ game }) => {
     { url: game.bga_url, label: 'Board Game Arena', class: 'bga', sponsored: false },
   ].filter((link) => isValidUrl(link.url))
 
-  if (!source && links.length === 0) return null
+  useEffect(() => {
+    let cancelled = false
+    setRulesetState({ status: 'loading', rulesets: [] })
+
+    api.get(`/api/games/${encodeURIComponent(game.slug)}/rule-sets`)
+      .then((data) => {
+        if (cancelled) return
+        const activeRulesets = data?.status === 'available'
+          ? (data.rulesets || []).filter((ruleset) => ruleset.is_active && ruleset.status === 'active')
+          : []
+        setRulesetState({ status: 'loaded', rulesets: activeRulesets })
+      })
+      .catch((error) => {
+        console.error('Failed to fetch current RuleSet context:', error)
+        if (!cancelled) setRulesetState({ status: 'error', rulesets: [] })
+      })
+
+    return () => { cancelled = true }
+  }, [game.slug])
+
+  const hasRulesetContext = rulesetState.status !== 'loaded' || rulesetState.rulesets.length > 0
+  if (!source && links.length === 0 && !hasRulesetContext) return null
 
   return (
     <div className="info-section">
+      {rulesetState.status === 'loading' && (
+        <div className="game-empty-note" role="status">現在のルールセットを確認しています...</div>
+      )}
+
+      {rulesetState.status === 'error' && (
+        <div className="game-empty-note" role="alert">現在のルールセットを確認できませんでした。</div>
+      )}
+
+      {rulesetState.status === 'loaded' && rulesetState.rulesets.length > 0 && (
+        <div aria-label="現在のルールセット">
+          <div className="game-empty-note">現在のルールセット</div>
+          <ul style={{ margin: '0 0 0.8rem', paddingInlineStart: '1.25rem' }}>
+            {rulesetState.rulesets.map((ruleset) => (
+              <li key={ruleset.ruleset_id} style={{ marginBlock: '0.35rem' }}>
+                <div>{rulesetStatusLabel(ruleset)}</div>
+                {rulesetIdentity(ruleset).length > 0 && (
+                  <div className="game-empty-note">{rulesetIdentity(ruleset).join(' / ')}</div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       {source && (
         <div aria-label="登録済み出典">
           <div className="game-empty-note">登録済み出典</div>

--- a/frontend/src/components/game/ExternalLinks.jsx
+++ b/frontend/src/components/game/ExternalLinks.jsx
@@ -60,7 +60,10 @@ const trackAffiliateOutbound = (gameSlug, provider) => {
 
 export const ExternalLinks = ({ game }) => {
   const { affiliate_urls, source_url, source_trust, bgg_url, amazon_url } = game
-  const [rulesetState, setRulesetState] = useState({ status: 'loading', rulesets: [] })
+  const [rulesetState, setRulesetState] = useState({ slug: game.slug, status: 'loading', rulesets: [] })
+  const currentRulesetState = rulesetState.slug === game.slug
+    ? rulesetState
+    : { slug: game.slug, status: 'loading', rulesets: [] }
   const affiliateAmazon = affiliate_urls?.amazon
   const amazon = affiliateAmazon || amazon_url
   const rakuten = affiliate_urls?.rakuten
@@ -83,7 +86,6 @@ export const ExternalLinks = ({ game }) => {
 
   useEffect(() => {
     let cancelled = false
-    setRulesetState({ status: 'loading', rulesets: [] })
 
     api.get(`/api/games/${encodeURIComponent(game.slug)}/rule-sets`)
       .then((data) => {
@@ -91,34 +93,34 @@ export const ExternalLinks = ({ game }) => {
         const activeRulesets = data?.status === 'available'
           ? (data.rulesets || []).filter((ruleset) => ruleset.is_active && ruleset.status === 'active')
           : []
-        setRulesetState({ status: 'loaded', rulesets: activeRulesets })
+        setRulesetState({ slug: game.slug, status: 'loaded', rulesets: activeRulesets })
       })
       .catch((error) => {
         console.error('Failed to fetch current RuleSet context:', error)
-        if (!cancelled) setRulesetState({ status: 'error', rulesets: [] })
+        if (!cancelled) setRulesetState({ slug: game.slug, status: 'error', rulesets: [] })
       })
 
     return () => { cancelled = true }
   }, [game.slug])
 
-  const hasRulesetContext = rulesetState.status !== 'loaded' || rulesetState.rulesets.length > 0
+  const hasRulesetContext = currentRulesetState.status !== 'loaded' || currentRulesetState.rulesets.length > 0
   if (!source && links.length === 0 && !hasRulesetContext) return null
 
   return (
     <div className="info-section">
-      {rulesetState.status === 'loading' && (
+      {currentRulesetState.status === 'loading' && (
         <div className="game-empty-note" role="status">現在のルールセットを確認しています...</div>
       )}
 
-      {rulesetState.status === 'error' && (
+      {currentRulesetState.status === 'error' && (
         <div className="game-empty-note" role="alert">現在のルールセットを確認できませんでした。</div>
       )}
 
-      {rulesetState.status === 'loaded' && rulesetState.rulesets.length > 0 && (
+      {currentRulesetState.status === 'loaded' && currentRulesetState.rulesets.length > 0 && (
         <div aria-label="現在のルールセット">
           <div className="game-empty-note">現在のルールセット</div>
           <ul style={{ margin: '0 0 0.8rem', paddingInlineStart: '1.25rem' }}>
-            {rulesetState.rulesets.map((ruleset) => (
+            {currentRulesetState.rulesets.map((ruleset) => (
               <li key={ruleset.ruleset_id} style={{ marginBlock: '0.35rem' }}>
                 <div>{rulesetStatusLabel(ruleset)}</div>
                 {rulesetIdentity(ruleset).length > 0 && (

--- a/frontend/tests/game_ruleset_context.spec.js
+++ b/frontend/tests/game_ruleset_context.spec.js
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test'
+
+const game = {
+  id: 'ruleset-context-game',
+  slug: 'ruleset-context-game',
+  title: 'RuleSet Context Game',
+  title_ja: 'ルールセット境界確認ゲーム',
+  summary: '現在の版と出典境界を確認します。',
+  identity_status: 'verified',
+  source_trust: 'official_publisher',
+  content_review_status: 'review_required',
+  rules_content: '## ルール\n- 確認済みです。',
+  setup_summary: null,
+  gameplay_summary: null,
+  end_game_summary: null,
+}
+
+test('現在のactive RuleSetを版・platform・language付きで表示する', async ({ page }) => {
+  await page.route('**/api/**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${game.slug}`) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === `/api/games/${game.slug}/rule-sets`) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema_version: '1.0',
+          status: 'available',
+          game_id: game.id,
+          slug: game.slug,
+          rulesets: [
+            {
+              ruleset_id: 'current-base',
+              game_id: game.id,
+              version: 1,
+              schema_version: '1.0',
+              language_code: 'en',
+              edition_label: "Grandpa Beck's Games current edition",
+              revision_label: 'current-web-rulebook-1764178570',
+              platform: 'physical',
+              status: 'active',
+              verification_status: 'source_bound',
+              is_active: true,
+              source_ids: ['publisher-rulebook'],
+            },
+            {
+              ruleset_id: 'old-edition',
+              game_id: game.id,
+              version: 1,
+              schema_version: '1.0',
+              language_code: 'en',
+              edition_label: 'Earlier edition',
+              platform: 'physical',
+              status: 'superseded',
+              verification_status: 'source_bound',
+              is_active: false,
+              source_ids: ['old-rulebook'],
+            },
+          ],
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'not found' }) })
+  })
+
+  await page.goto(`/games/${game.slug}`)
+
+  const context = page.getByLabel('現在のルールセット')
+  await expect(context).toBeVisible()
+  await expect(context.getByText('出典に結び付いたルールセット', { exact: true })).toBeVisible()
+  await expect(context.getByText("版: Grandpa Beck's Games current edition / プラットフォーム: physical / 言語: en / 改訂: current-web-rulebook-1764178570", { exact: true })).toBeVisible()
+  await expect(context.getByText('Earlier edition')).toHaveCount(0)
+  await expect(page.getByText('REVIEW REQUIRED', { exact: true })).toBeVisible()
+})
+
+test('active RuleSetが複数なら勝手に1件へ絞らず両方表示する', async ({ page }) => {
+  await page.route('**/api/**', async route => {
+    const url = new URL(route.request().url())
+    if (url.pathname === `/api/games/${game.slug}`) {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ game }) })
+      return
+    }
+    if (url.pathname === `/api/games/${game.slug}/rule-sets`) {
+      const base = {
+        game_id: game.id,
+        version: 1,
+        schema_version: '1.0',
+        language_code: 'en',
+        edition_label: 'Current edition',
+        platform: 'physical',
+        status: 'active',
+        verification_status: 'source_bound',
+        is_active: true,
+        source_ids: [],
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          schema_version: '1.0', status: 'available', game_id: game.id, slug: game.slug,
+          rulesets: [
+            { ...base, ruleset_id: 'base' },
+            { ...base, ruleset_id: 'variant', variant_label: '2-player', base_rule_set_id: 'base', relation_type: 'variant_of' },
+          ],
+        }),
+      })
+      return
+    }
+    await route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ detail: 'not found' }) })
+  })
+
+  await page.goto(`/games/${game.slug}`)
+  const context = page.getByLabel('現在のルールセット')
+  await expect(context.locator('li')).toHaveCount(2)
+  await expect(context.getByText(/バリアント: 2-player/)).toBeVisible()
+})

--- a/frontend/tests/ui_ux_regression.spec.js
+++ b/frontend/tests/ui_ux_regression.spec.js
@@ -149,6 +149,19 @@ async function mockApi(page, state) {
       return
     }
 
+    const rulesetMatch = path.match(/^\/api\/games\/([^/]+)\/rule-sets$/)
+    if (rulesetMatch && method === 'GET') {
+      const game = games.find((candidate) => candidate.slug === decodeURIComponent(rulesetMatch[1]))
+      await route.fulfill({
+        status: game ? 200 : 404,
+        contentType: 'application/json',
+        body: JSON.stringify(game
+          ? { schema_version: '1.0', status: 'not_available', game_id: game.id, slug: game.slug, rulesets: [] }
+          : { detail: 'not found' }),
+      })
+      return
+    }
+
     const gameMatch = path.match(/^\/api\/games\/([^/]+)$/)
     if (gameMatch && method === 'GET') {
       await delay(100)


### PR DESCRIPTION
Closes part of #192.

## 変更
- 既存 `/api/games/{slug}/rule-sets` を使い、GamePageの「出典・根拠」で現在のactive RuleSetを表示する
- edition / variant / platform / language / revisionを、取得できた値だけ表示する
- active RuleSetが複数ある場合は推測で1件へ絞らず全件表示する
- 取得失敗は明示し、別データへfallbackしない
- 新しいAPI・schema・source registryは追加しない

## 観測可能な成功条件
Skull King等のGamePageで、利用者がreview状態と同じ「出典・根拠」領域から現在の版・platform・languageを確認できる。

## 検証
既存Playwrightへ、active / supersededの分離と複数active RuleSetのfail-openではない表示回帰を追加した。