### PR TITLE
根拠リンクを資料種別込みで識別できるようにする

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -219,6 +219,10 @@ function sourceTypeLabel(sourceType) {
   return SOURCE_TYPE_LABELS[sourceType] || sourceType
 }
 
+function evidenceSourceLabel(source) {
+  return `${sourceLabel(source)}（${sourceTypeLabel(source.source_type)}）`
+}
+
 function locatorLabel(locator) {
   if (!locator) return null
   return [
@@ -278,8 +282,8 @@ function RuleEvidence({ slug, ruleNode }) {
               <li key={binding.binding_id} style={{ marginBlock: '0.5rem' }}>
                 <div>
                   {source.source_url
-                    ? <a href={source.source_url} target="_blank" rel="noreferrer">{sourceLabel(source)}</a>
-                    : <strong>{sourceLabel(source)}</strong>}
+                    ? <a href={source.source_url} target="_blank" rel="noreferrer">{evidenceSourceLabel(source)}</a>
+                    : <strong>{evidenceSourceLabel(source)}</strong>}
                 </div>
                 <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>
                   資料: {sourceTypeLabel(source.source_type)}

--- a/frontend/tests/game_page_title_trust.spec.js
+++ b/frontend/tests/game_page_title_trust.spec.js
@@ -226,4 +226,20 @@ test('根拠資料の正式な種類を利用者向けの日本語で区別す�
   await expect(page.getByText('資料: 公式補足')).toBeVisible()
   await expect(page.getByText('資料: publisher_blog')).toBeVisible()
   await expect(page.getByText('資料: official_faq')).toHaveCount(0)
+
+  const officialSourceUrl = 'https://www.grandpabecksgames.com/pages/skull-king'
+  const rulebookLink = page.getByRole('link', { name: "Grandpa Beck's Games（ルールブック）", exact: true })
+  const faqLink = page.getByRole('link', { name: "Grandpa Beck's Games（公式FAQ）", exact: true })
+  const errataLink = page.getByRole('link', { name: "Grandpa Beck's Games（公式エラッタ）", exact: true })
+  const clarificationLink = page.getByRole('link', { name: "Grandpa Beck's Games（公式補足）", exact: true })
+  const unknownLink = page.getByRole('link', { name: "Grandpa Beck's Games（publisher_blog）", exact: true })
+
+  await expect(rulebookLink).toHaveAttribute('href', officialSourceUrl)
+  await expect(faqLink).toHaveAttribute('href', officialSourceUrl)
+  await expect(errataLink).toHaveAttribute('href', officialSourceUrl)
+  await expect(clarificationLink).toHaveAttribute('href', officialSourceUrl)
+  await expect(unknownLink).toHaveAttribute('href', officialSourceUrl)
+
+  await faqLink.focus()
+  await expect(faqLink).toBeFocused()
 })


### PR DESCRIPTION
## 目的

#192 の残件として、同じ出版社・同じURLにあるルールブックと公式FAQでも、利用者がリンクだけで資料種別を区別できるようにする。

## observable success condition

GamePageの「根拠を確認」で、同じ出版社URLに複数のEvidenceBindingがある場合でも、keyboard / screen readerで「出版社名（ルールブック）」「出版社名（公式FAQ）」のように各リンクを識別できること。

## 変更

- 既存Evidence APIの `source_type` を既存日本語ラベルへ変換し、source link textへ付加
- 未知の `source_type` は推測せず取得値を保持
- 既存 `game_page_title_trust.spec.js` にlink name / href / keyboard focus回帰を追加
- 新しいAPI、schema、source registry、workflowは追加しない

## 検証

既存 `UI UX regression` がこのPlaywright testを実行する。exact-head CI成功後のみmergeし、merge後はmain read-backとproductionを確認する。

Closes part of #192