### PR TITLE
test: productionでSkull KingのEvidence導線を検証する

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -58,3 +58,28 @@ test('productionのSkull Kingで代表queryから確認済みRuleNodeと公式�
   await openCanonicalRuleFromSearch(page, 'FAQ Mermaid', 'resolution.mermaid-triad', 'FAQ')
   await openCanonicalRuleFromSearch(page, 'FAQ 2人', 'two-player.tigress', 'FAQ', 2)
 })
+
+test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', async ({ page }) => {
+  const response = await page.request.get('/games/skull-king')
+  expect(response.ok()).toBe(true)
+  const ssrHtml = await response.text()
+  expect(ssrHtml).toContain('Grandpa Beck')
+
+  await page.goto('/games/skull-king', { waitUntil: 'networkidle' })
+  await expect(page.getByText(/Grandpa Beck/).first()).toBeVisible()
+
+  const mermaid = page.getByRole('button', { name: 'Mermaid', exact: true })
+  await expect(mermaid).toBeVisible()
+  await mermaid.click()
+  await expect(page.getByText('Mermaid裁定', { exact: true })).toBeVisible()
+  await page.getByText('根拠を確認', { exact: true }).click()
+
+  await expect(page.getByText('資料: 公式FAQ', { exact: true })).toBeVisible()
+  const faqLink = page.getByRole('link', { name: "Grandpa Beck's Games（公式FAQ）", exact: true })
+  await expect(faqLink).toBeVisible()
+  await expectOfficialSkullKingSource(faqLink)
+
+  const hydratedHtml = await page.content()
+  expect(hydratedHtml).toContain('Grandpa Beck')
+  await expectNoPageOverflow(page)
+})


### PR DESCRIPTION
Closes the remaining production-browser verification gap in #192 without adding a new workflow or source authority.

- 既存 `production_rule_lookup.spec.js` を拡張
- canonical production の Skull King で Mermaid → Claim → 根拠を確認 → 公式FAQ Evidence まで Chromium で操作
- SSR response と hydration 後 DOM の両方に publisher source が存在することを確認
- 既存 `Curated game release verification` が `PLAYWRIGHT_BASE_URL` でproductionに対して実行する経路をそのまま使用
- fixture / synthetic data はproduction確認に使用しない