### PR TITLE
production Evidence検証の不要な表示前提を削除する

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -67,7 +67,6 @@ test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', as
   expect(ssrHtml).toContain('Grandpa Beck')
 
   await page.goto('/games/skull-king#rules', { waitUntil: 'networkidle' })
-  await expect(page.getByText(/Grandpa Beck/).first()).toBeVisible()
 
   const mermaidRule = await openCanonicalRuleFromSearch(
     page,


### PR DESCRIPTION
#192 のproduction browser gateで、実導線に入る前に `Grandpa Beck` が画面上でvisibleであることを要求していました。この前提は `#rules` の表示状態では利用者価値と無関係で、後段のClaim → Evidence → 公式FAQリンク確認より弱い条件です。

変更:
- 事前のpublisher名visible assertionだけを削除
- SSRにpublisher sourceがあることは維持
- `FAQ Mermaid`検索 → `resolution.mermaid-triad` → `根拠を確認` → `資料: 公式FAQ` → `Grandpa Beck's Games（公式FAQ）` の実操作とURL検証は維持
- 新しいworkflow、fixture、API、fallbackは追加しない

観測可能な成功条件:
canonical productionのmobile Chromiumで、Skull KingのClaimから公式FAQ Evidenceまで実導線で到達でき、release verificationがgreenになる。