### PR TITLE
production Evidence検証を実表示契約に合わせる

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -76,7 +76,6 @@ test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', as
   )
   await mermaidRule.getByText('根拠を確認', { exact: true }).click()
 
-  await expect(mermaidRule.getByText('資料: 公式FAQ', { exact: true })).toBeVisible()
   const faqLink = mermaidRule.getByRole('link', { name: "Grandpa Beck's Games（公式FAQ）", exact: true })
   await expect(faqLink).toBeVisible()
   await expectOfficialSkullKingSource(faqLink)


### PR DESCRIPTION
## 目的
canonical production の Skull King で、Claim から公式FAQのEvidenceリンクへ実際に辿れることを検証する。

## 変更
- production Playwright から、現行UIに存在しない重複表示 `資料: 公式FAQ` のassertionだけを削除
- `Grandpa Beck's Games（公式FAQ）` のリンクが表示され、公式URLであることの検証は維持
- SSR / hydrated HTML、RuleNode、overflow の既存検証も維持

## 成功条件
`Curated game release verification` が canonical production の実Chromiumで、Skull Kingの `FAQ Mermaid` → `resolution.mermaid-triad` → `根拠を確認` → `Grandpa Beck's Games（公式FAQ）` を通して成功すること。

fixtureや別workflowは追加しない。