### PR TITLE
production Evidence検証を公式URLで固定する

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -76,9 +76,21 @@ test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', as
   )
   await mermaidRule.getByText('根拠を確認', { exact: true }).click()
 
-  const faqLink = mermaidRule.getByRole('link', { name: "Grandpa Beck's Games（公式FAQ）", exact: true })
-  await expect(faqLink).toBeVisible()
-  await expectOfficialSkullKingSource(faqLink)
+  const evidenceLinks = mermaidRule.locator('a[href]')
+  let officialFaqLink = null
+  for (let index = 0; index < await evidenceLinks.count(); index += 1) {
+    const candidate = evidenceLinks.nth(index)
+    const href = await candidate.getAttribute('href')
+    if (href && officialSkullKingSourcePatterns.some((pattern) => pattern.test(href))) {
+      officialFaqLink = candidate
+      break
+    }
+  }
+
+  expect(officialFaqLink).not.toBeNull()
+  await expect(officialFaqLink).toBeVisible()
+  await expect(officialFaqLink).toContainText('Grandpa Beck')
+  await expectOfficialSkullKingSource(officialFaqLink)
 
   const hydratedHtml = await page.content()
   expect(hydratedHtml).toContain('Grandpa Beck')


### PR DESCRIPTION
#192 のproduction Chromium検証が、Evidenceの実リンクは存在していても表示名の完全一致に依存して失敗していました。

変更:
- Claimの「根拠を確認」後、RuleNode内のリンクからGrandpa Beck's Games公式URLを直接検出する
- URLが公式source patternに一致することを維持する
- リンク本文に `Grandpa Beck` が含まれることを確認する
- SSR / hydrated HTML / RuleNode / overflowの既存検証は維持する
- 新しいworkflow、API、fixture、retry、fallbackは追加しない

成功条件:
canonical productionのmobile Chromiumで、Skull Kingの `FAQ Mermaid` → `resolution.mermaid-triad` → `根拠を確認` → 公式FAQ Evidence URLまで到達し、Curated game release verificationがgreenになる。