### PR TITLE
production Evidence検証で非同期取得完了を待つ

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -76,7 +76,10 @@ test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', as
   )
   await mermaidRule.getByText('根拠を確認', { exact: true }).click()
 
-  const evidenceLinks = mermaidRule.locator('a[href]')
+  const evidenceList = mermaidRule.getByRole('list', { name: 'このルールの根拠' })
+  await expect(evidenceList).toBeVisible()
+
+  const evidenceLinks = evidenceList.locator('a[href]')
   let officialFaqLink = null
   for (let index = 0; index < await evidenceLinks.count(); index += 1) {
     const candidate = evidenceLinks.nth(index)


### PR DESCRIPTION
## Before

`Curated game release verification` #1007 は current main `04fee41360b64d15bf172638719c24435d6bf8b5` で2回とも失敗した。

Skull King の代表検索は成功しているが、Claim から Evidence を開くテストが `根拠を確認` をクリックした直後にリンク一覧を数えており、非同期 Evidence API の完了前に `0件` と判定していた。

## observable success condition

canonical production の Skull King で `FAQ Mermaid` → `resolution.mermaid-triad` → `根拠を確認` と進み、Evidence API が正常に完了した後の「このルールの根拠」一覧から Grandpa Beck's Games の公式URLへ到達できること。

## 変更

既存 `production_rule_lookup.spec.js` だけを変更する。

- `根拠を確認` の後、「このルールの根拠」一覧が表示されるまで待つ
- 公式URL探索範囲をそのEvidence一覧内へ限定する
- Evidence APIが失敗した場合は一覧が出ないため、そのままFAILする

retry、fallback、新しいworkflow、API、fixture、source registryは追加しない。