### PR TITLE
production Evidence検証をEvidence項目へ固定する

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -78,9 +78,11 @@ test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', as
 
   const evidenceList = mermaidRule.getByRole('list', { name: 'このルールの根拠' })
   await expect(evidenceList).toBeVisible()
-  await expect(evidenceList.getByText(/資料: 公式FAQ/).first()).toBeVisible()
 
-  const officialFaqLink = evidenceList.getByRole('link', { name: /Grandpa Beck.*公式FAQ/ }).first()
+  const officialFaqEvidence = evidenceList.getByRole('listitem').filter({ hasText: '資料: 公式FAQ' }).first()
+  await expect(officialFaqEvidence).toBeVisible()
+
+  const officialFaqLink = officialFaqEvidence.getByRole('link').first()
   await expect(officialFaqLink).toBeVisible()
   const officialFaqHref = await officialFaqLink.getAttribute('href')
   expect(officialFaqHref).toBeTruthy()


### PR DESCRIPTION
## Before

current main `be543f84c1b174a7f8b11e27008221e31b9d53f1` はVercel DeploymentとUI UX regressionが成功したが、Curated game release verification #1009 がproduction ChromiumでFAILした。

失敗点は、`資料: 公式FAQ` が表示されているにもかかわらず、同じEvidence項目のリンクを確認せず、リンク名 `/Grandpa Beck.*公式FAQ/` へ再依存していたこと。

## プレイヤー向け成功条件

Skull KingのMermaid裁定で「根拠を確認」を開き、`資料: 公式FAQ` と表示された同じEvidence項目からHTTPSの根拠リンクへ到達できること。

## 変更

既存production testのみを置換する。

- `資料: 公式FAQ` を含むEvidenceの`listitem`を取得
- その同じ項目内のリンクがvisibleでHTTPS URLを持つことを確認
- SSR / hydrated HTMLのpublisher確認、用語集のofficial source検証、overflow検証は維持

新しいworkflow、API、fixture、source registry、retry、fallbackは追加しない。