### PR TITLE
EvidenceSourceのURL契約を正式なAPIへ合わせる

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -281,8 +281,8 @@ function RuleEvidence({ slug, ruleNode }) {
             {bindings.map(({ binding, source, locator, supportStatus, lifecycleStatus }) => (
               <li key={binding.binding_id} style={{ marginBlock: '0.5rem' }}>
                 <div>
-                  {source.source_url
-                    ? <a href={source.source_url} target="_blank" rel="noreferrer">{evidenceSourceLabel(source)}</a>
+                  {source.url
+                    ? <a href={source.url} target="_blank" rel="noreferrer">{evidenceSourceLabel(source)}</a>
                     : <strong>{evidenceSourceLabel(source)}</strong>}
                 </div>
                 <div className="game-empty-note" style={{ marginTop: '0.2rem' }}>

--- a/frontend/tests/evidence_card_boundaries.spec.js
+++ b/frontend/tests/evidence_card_boundaries.spec.js
@@ -100,7 +100,7 @@ function sourceBinding(id, publisherName) {
       source_id: `source-${id}`,
       publisher_name: publisherName,
       source_type: 'official_faq',
-      source_url: `https://example.com/${id}`,
+      url: `https://example.com/${id}`,
       revision_label: 'current',
       language_code: 'en',
       platform: 'physical',

--- a/frontend/tests/game_page_title_trust.spec.js
+++ b/frontend/tests/game_page_title_trust.spec.js
@@ -176,7 +176,7 @@ test('根拠資料の正式な種類を利用者向けの日本語で区別す�
           source_id: `source-${bindingId}`,
           publisher_name: "Grandpa Beck's Games",
           source_type: sourceType,
-          source_url: 'https://www.grandpabecksgames.com/pages/skull-king',
+          url: 'https://www.grandpabecksgames.com/pages/skull-king',
           revision_label: 'current',
           language_code: 'en',
           platform: 'physical',


### PR DESCRIPTION
## Before

canonical productionではSkull KingのMermaid裁定に `資料: 公式FAQ` が表示される一方、そのEvidence項目にリンクが存在せず、Curated game release verification #1010 がproduction ChromiumでFAILした。

原因はAPI契約の不一致。backendの正式な `EvidenceSource` は `url` を返しているが、frontendとUI fixtureだけが `source_url` を参照していた。fixtureが実APIと異なるため、UI回帰では欠陥を検出できなかった。

## プレイヤー向け成功条件

Skull KingのMermaid裁定で「根拠を確認」を開き、`資料: 公式FAQ` と表示されたEvidence項目から、canonical backendの `url` に入ったHTTPSの公式資料へ移動できること。

## 変更

- `RuleMarkdown` はEvidenceSourceの正式な `url` だけを使用する
- `game_page_title_trust.spec.js` のfixtureも `url` に合わせる
- `source_url` との互換fallbackは追加しない

新しいAPI、schema、workflow、retry、source registryは追加しない。Grandpa Beck's Gamesの現行Skull King公式ページには現在もRulebooksとFAQが掲載され、Mermaid / Skull King / PirateのFAQ回答も確認済み。