### PR TITLE
productionでRuleSet・確認状態・Evidenceを同時に検証する

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -65,8 +65,20 @@ test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', as
   expect(response.ok()).toBe(true)
   const ssrHtml = await response.text()
   expect(ssrHtml).toContain('Grandpa Beck')
+  expect(ssrHtml).toContain('内容確認状態:</strong> unknown')
+  expect(ssrHtml).toContain("版:</strong> Grandpa Beck&#x27;s Games current edition")
 
   await page.goto('/games/skull-king#rules', { waitUntil: 'networkidle' })
+
+  const trustPanel = page.getByLabel('出典・根拠')
+  await expect(trustPanel).toBeVisible()
+  await expect(trustPanel.getByText('PUBLISHER SOURCE', { exact: true })).toBeVisible()
+  await expect(trustPanel.getByText('REVIEW UNKNOWN', { exact: true })).toBeVisible()
+
+  const currentRuleset = trustPanel.getByLabel('現在のルールセット')
+  await expect(currentRuleset).toBeVisible()
+  await expect(currentRuleset.getByText('出典に結び付いたルールセット', { exact: true })).toBeVisible()
+  await expect(currentRuleset.getByText("版: Grandpa Beck's Games current edition / プラットフォーム: physical / 言語: en / 改訂: current-web-rulebook-1764178570", { exact: true })).toBeVisible()
 
   const mermaidRule = await openCanonicalRuleFromSearch(
     page,


### PR DESCRIPTION
## Before

#192 のClaim → Evidence → 公式FAQ導線はcanonical productionのChromiumで通るようになった。一方、同じ実ブラウザで「内容の確認状態」「出典の信頼状態」「現在のRuleSet」がEvidenceと同時に表示されることはrelease gateへ固定されていなかった。

## プレイヤー向け成功条件

canonical productionのSkull Kingで、利用者が同じ「出典・根拠」領域から次を同時に確認できること。

- 出版社の一次資料を使っていること
- 内容確認状態が未確認であること
- 現在の版・プラットフォーム・言語・改訂
- Claimから公式FAQのEvidenceへ辿れること

## 変更

既存 `frontend/tests/production_rule_lookup.spec.js` だけを拡張する。

- SSRで現在の版と `content_review_status=unknown` を保持していることを確認
- hydrated UIで `PUBLISHER SOURCE` と `REVIEW UNKNOWN` を確認
- hydrated UIでactive RuleSetの版・platform・language・revisionを確認
- 既存のClaim → Evidence → 公式FAQリンク検証を維持

新しいAPI、schema、workflow、fixture、retry、fallbackは追加しない。

Closes #192 when exact-head CI、merge後main、canonical production Chromiumがすべて成功した場合のみ完了扱いとする。