### PR TITLE
productionでルール深リンク再読込を検証する

### DIFF
--- a/frontend/tests/production_rule_lookup.spec.js
+++ b/frontend/tests/production_rule_lookup.spec.js
@@ -60,6 +60,22 @@ test('productionのSkull Kingで代表queryから確認済みRuleNodeと公式�
   await openCanonicalRuleFromSearch(page, 'FAQ 2人', 'two-player.tigress', 'FAQ', 2)
 })
 
+test('productionのSkull Kingでルール深リンクを直接再読込できる', async ({ page }) => {
+  const targetId = 'rule-node-scoring.zero-bid'
+  await page.goto(`/games/skull-king#${targetId}`, { waitUntil: 'networkidle' })
+
+  const target = page.locator(`#${targetId.replaceAll('.', '\\.')}`)
+  await expect(target).toBeVisible()
+  await expect(page).toHaveURL(new RegExp(`#${targetId.replaceAll('.', '\\.')}$`))
+  await expect(target).toBeFocused()
+  await expectNoPageOverflow(page)
+
+  await page.reload({ waitUntil: 'networkidle' })
+  await expect(target).toBeVisible()
+  await expect(page).toHaveURL(new RegExp(`#${targetId.replaceAll('.', '\\.')}$`))
+  await expect(target).toBeFocused()
+})
+
 test('productionのSkull KingでClaimから公式FAQのEvidenceへ辿れる', async ({ page }) => {
   const response = await page.request.get('/games/skull-king')
   expect(response.ok()).toBe(true)


### PR DESCRIPTION
## 目的
Issue #193 の残件である、production上の実ルール深リンクが直接読込と再読込で失われないことを既存production Playwright検証へ統合する。

## Before → After
- Before: 通常遷移でRuleNodeへ到達するproduction検証はあるが、`/games/skull-king#rule-node-scoring.zero-bid` の直接読込・再読込はproduction契約に固定されていない。
- After: Skull Kingの実production RuleNodeを直接開き、表示・URL fragment・keyboard focus・横overflowなしを確認し、再読込後も同じ状態を維持する。

## 変更
- 既存 `frontend/tests/production_rule_lookup.spec.js` のみ更新
- 新しいworkflow、fixture、schema、専用test runnerは追加しない

## 完了条件
- exact-head CI成功
- merge後main read-back
- production deploy後に同じproduction Playwright検証が成功

Closes part of #193