### PR TITLE
RuleNode深リンクを再読込で復元する

### DIFF
--- a/frontend/src/components/game/ConceptGlossary.jsx
+++ b/frontend/src/components/game/ConceptGlossary.jsx
@@ -59,6 +59,17 @@ function conceptIdFromHash() {
   }
 }
 
+function ruleIdFromHash() {
+  if (typeof window === 'undefined') return null
+  const prefix = '#rule-node-'
+  if (!window.location.hash.startsWith(prefix)) return null
+  try {
+    return decodeURIComponent(window.location.hash.slice(prefix.length))
+  } catch {
+    return null
+  }
+}
+
 export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
   const [entries, setEntries] = useState([])
   const [query, setQuery] = useState('')
@@ -174,23 +185,38 @@ export function ConceptGlossary({ slug, onRuleNodesLoaded }) {
   useEffect(() => {
     if (fetchStatus !== 'available') return undefined
 
-    const selectHashConcept = () => {
+    const syncHash = () => {
       const conceptId = conceptIdFromHash()
-      if (!conceptId || !entries.some((entry) => entry.concept_id === conceptId)) return
-      if (selectedId !== conceptId) selectConcept(conceptId)
-      window.requestAnimationFrame(() => {
-        const target = document.getElementById(`glossary-concept-${conceptId}`)
-        target?.scrollIntoView({ block: 'center' })
-        target?.focus({ preventScroll: true })
-      })
+      if (conceptId && entries.some((entry) => entry.concept_id === conceptId)) {
+        if (selectedId !== conceptId) selectConcept(conceptId)
+        window.requestAnimationFrame(() => {
+          const target = document.getElementById(`glossary-concept-${conceptId}`)
+          target?.scrollIntoView({ block: 'center' })
+          target?.focus({ preventScroll: true })
+        })
+        return
+      }
+
+      const ruleId = ruleIdFromHash()
+      if (!ruleId) return
+      const references = entries.flatMap((entry) =>
+        (entry.rule_references || []).filter((reference) =>
+          isVerifiedRuleReference(reference) && reference.rule_id === ruleId,
+        ),
+      )
+      if (references.length === 0) {
+        onRuleNodesLoaded?.([])
+        return
+      }
+      loadRuleDestinations({ rule_references: references })
     }
 
-    selectHashConcept()
-    window.addEventListener('hashchange', selectHashConcept)
-    window.addEventListener('popstate', selectHashConcept)
+    syncHash()
+    window.addEventListener('hashchange', syncHash)
+    window.addEventListener('popstate', syncHash)
     return () => {
-      window.removeEventListener('hashchange', selectHashConcept)
-      window.removeEventListener('popstate', selectHashConcept)
+      window.removeEventListener('hashchange', syncHash)
+      window.removeEventListener('popstate', syncHash)
     }
   }, [entries, fetchStatus, selectedId])
 

--- a/frontend/tests/canonical_glossary.spec.js
+++ b/frontend/tests/canonical_glossary.spec.js
@@ -281,4 +281,9 @@ test('確認済みRuleNodeを同じRuleSetの正準Presentation Projectionから
   const ruleNode = page.locator('#rule-node-rule-verified')
   await expect(ruleNode).toContainText('確認済みの得点ルールです。')
   await expect(ruleNode).toBeFocused()
+
+  await page.reload()
+  await expect(page).toHaveURL(/#rule-node-rule-verified$/)
+  await expect(ruleNode).toContainText('確認済みの得点ルールです。')
+  await expect(ruleNode).toBeFocused()
 })


### PR DESCRIPTION
## 目的
Issue #193 のproduction検証で、`/games/skull-king#rule-node-scoring.zero-bid` を直接開くとRuleNodeが描画されない実不具合を確認したため、既存の正準データ経路だけで深リンクを復元する。

## 原因
RuleNodeは用語集のconceptを選択したときだけ、既存のGlossary → Presentation Projectionから読み込まれていた。`#rule-node-...` のdirect loadではconcept選択がないため、RuleNodeが空のままだった。

## 変更
- `#rule-node-...` からrule_idを取得する
- 既存Glossary内の`verified` / `source_bound`参照から該当rule_idだけを選ぶ
- 既存Presentation Projectionを使ってRuleNodeを復元する
- 該当する確認済み参照がない場合は空のままにし、未確認データへfallbackしない
- 既存`canonical_glossary.spec.js`にreload回帰を統合する

新しいAPI、schema、fixture、workflowは追加しない。

## 完了条件
- exact-head CI成功
- merge後main read-back
- exact main SHAのVercel production deploy成功
- canonical productionに対するChromiumで、RuleNode direct load / reload / focusが成功

Refs #193