### PR TITLE
Skull Kingの0 bid検索を現行ルール表記へ対応する

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -32,6 +32,7 @@ function normalizeSearchText(value) {
   return String(value || '')
     .normalize('NFKC')
     .toLowerCase()
+    .replace(/\bzero\b/g, '0')
     .replace(/\s+/g, ' ')
     .trim()
 }


### PR DESCRIPTION
Closes #209

## Before
production の Skull King で `0 bid` を検索しても、確認済みルール `scoring.zero-bid` に到達できない。

## 原因
現行の公式英語ルールブックは `Bidding Zero` / `bids zero` と表記している。一方、検索入力 `0 bid` は数字の `0` のため、検索層の単純な部分一致では同じ意味として扱われない。

## After
検索時だけ英単語 `zero` を数字 `0` に正規化する。正準ルール文、用語、edition/version は変更しない。

## 完了条件
- 既存の production 回帰テスト `0 bid → scoring.zero-bid → RuleNode → permalink → reload` が PASS
- 既存の `FAQ Mermaid` と `2人` の検索導線を壊さない
- exact-head CI → merge → main read-back → production 再検証まで行う