### PR TITLE
Skull Kingの0 bid検索を現行ルール表記へ対応する

### DIFF
--- a/frontend/src/components/game/RuleMarkdown.jsx
+++ b/frontend/src/components/game/RuleMarkdown.jsx
@@ -32,6 +32,7 @@ function normalizeSearchText(value) {
   return String(value || '')
     .normalize('NFKC')
     .toLowerCase()
+    .replace(/\bzero\b/g, '0')
     .replace(/\s+/g, ' ')
     .trim()
 }


### PR DESCRIPTION
Closes #209

現行公式英語ルールブックの `Bidding Zero` / `bids zero` を正準のまま保持し、検索時だけ `zero` と `0` を同値として扱います。

完了条件: exact-head CI → merge → main read-back → production の `0 bid → scoring.zero-bid → permalink → reload` PASS。