### PR TITLE
Canonical rulesから準備・流れ・終了を表示する

### DIFF
--- a/backend/app/services/player_summary.py
+++ b/backend/app/services/player_summary.py
@@ -6,9 +6,51 @@ DIRECTORY_UNVERIFIED_SUMMARY = "概要は確認中です。"
 _LEGACY_RULE_SUMMARY_FIELDS = ("setup_summary", "gameplay_summary", "end_game_summary")
 
 
+def _extract_rule_section(rules_content: str | None, heading: str) -> str | None:
+    """Project one player-facing section from canonical source-bound markdown."""
+    if not rules_content:
+        return None
+
+    marker = f"## {heading}"
+    lines = rules_content.splitlines()
+    try:
+        start = lines.index(marker) + 1
+    except ValueError:
+        return None
+
+    items: list[str] = []
+    for line in lines[start:]:
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            break
+        if not stripped:
+            continue
+        if stripped.startswith("- "):
+            stripped = stripped[2:].strip()
+        if stripped:
+            items.append(stripped)
+    return " ".join(items) or None
+
+
+def _canonical_coach_projection(rules_content: str | None) -> dict[str, str | None]:
+    setup = _extract_rule_section(rules_content, "セットアップ")
+    gameplay = _extract_rule_section(rules_content, "ゲーム進行")
+    end_condition = _extract_rule_section(rules_content, "終了条件・勝利")
+    scoring = _extract_rule_section(rules_content, "得点")
+    end_parts = [part for part in (end_condition, scoring) if part]
+    return {
+        "setup_summary": setup,
+        "gameplay_summary": gameplay,
+        "end_game_summary": " ".join(end_parts) or None,
+    }
+
+
 def project_player_summary(game: dict[str, Any], *, source_bound: bool) -> dict[str, Any]:
     """Project player-facing fields without treating legacy game-row rules as authority."""
     projected = {**game, **{field: None for field in _LEGACY_RULE_SUMMARY_FIELDS}}
+    if source_bound:
+        projected.update(_canonical_coach_projection(projected.get("rules_content")))
+
     infographics_verified = bool(
         source_bound
         and projected.get("infographics")

--- a/backend/tests/test_player_summary.py
+++ b/backend/tests/test_player_summary.py
@@ -1,20 +1,68 @@
 from app.services.player_summary import project_player_summary
 
 
-def test_source_bound_unreviewed_summary_is_neutralized():
+CANONICAL_RULES = """## セットアップ
+- 第1ラウンドは1枚ずつ配り、以後ラウンド数と同じ枚数を配る。
+- 手札を確認して、取るトリック数を同時にビッドする。
+
+## ゲーム進行
+- ディーラーの左隣から1枚出し、時計回りに続ける。
+- 全員が1枚出したら最も強いカードがトリックを取る。
+
+## 終了条件・勝利
+- 10ラウンド終了後にゲームを終える。
+
+## 得点
+- ビッドを正確に達成したかどうかで得失点する。
+"""
+
+
+def test_source_bound_unreviewed_summary_is_neutralized_and_coach_uses_canonical_rules():
     game = {
         "title": "Forest Shuffle",
         "title_ja": "フォレストシャッフル",
         "summary": "legacy summary",
         "description": "legacy description",
         "content_review_status": "unknown",
+        "rules_content": CANONICAL_RULES,
+        "setup_summary": "legacy setup",
+        "gameplay_summary": "legacy gameplay",
+        "end_game_summary": "legacy end",
     }
 
     projected = project_player_summary(game, source_bound=True)
 
     assert projected["summary"] == "「フォレストシャッフル」の出典付きルール要約と出典情報を確認できます。"
     assert projected["description"] == projected["summary"]
-    assert game["summary"] == "legacy summary"
+    assert projected["setup_summary"] == (
+        "第1ラウンドは1枚ずつ配り、以後ラウンド数と同じ枚数を配る。 "
+        "手札を確認して、取るトリック数を同時にビッドする。"
+    )
+    assert projected["gameplay_summary"] == (
+        "ディーラーの左隣から1枚出し、時計回りに続ける。 "
+        "全員が1枚出したら最も強いカードがトリックを取る。"
+    )
+    assert projected["end_game_summary"] == (
+        "10ラウンド終了後にゲームを終える。 ビッドを正確に達成したかどうかで得失点する。"
+    )
+    assert game["setup_summary"] == "legacy setup"
+
+
+def test_source_bound_without_canonical_sections_does_not_expose_legacy_rule_summaries():
+    game = {
+        "title": "Legacy Game",
+        "content_review_status": "human_reviewed",
+        "rules_content": "## その他\n- canonical text",
+        "setup_summary": "legacy setup",
+        "gameplay_summary": "legacy gameplay",
+        "end_game_summary": "legacy end",
+    }
+
+    projected = project_player_summary(game, source_bound=True)
+
+    assert projected["setup_summary"] is None
+    assert projected["gameplay_summary"] is None
+    assert projected["end_game_summary"] is None
 
 
 def test_source_bound_human_reviewed_summary_is_preserved():
@@ -23,9 +71,14 @@ def test_source_bound_human_reviewed_summary_is_preserved():
         "summary": "reviewed summary",
         "description": "reviewed description",
         "content_review_status": "human_reviewed",
+        "rules_content": CANONICAL_RULES,
     }
 
-    assert project_player_summary(game, source_bound=True) is game
+    projected = project_player_summary(game, source_bound=True)
+
+    assert projected["summary"] == "reviewed summary"
+    assert projected["description"] == "reviewed description"
+    assert projected["setup_summary"] is not None
 
 
 def test_source_bound_publisher_reviewed_summary_is_preserved():
@@ -33,17 +86,27 @@ def test_source_bound_publisher_reviewed_summary_is_preserved():
         "title": "Papayoo",
         "summary": "publisher summary",
         "content_review_status": "publisher_reviewed",
+        "rules_content": CANONICAL_RULES,
     }
 
-    assert project_player_summary(game, source_bound=True) is game
+    projected = project_player_summary(game, source_bound=True)
+
+    assert projected["summary"] == "publisher summary"
+    assert projected["gameplay_summary"] is not None
 
 
-def test_non_source_bound_legacy_summary_is_unchanged():
+def test_non_source_bound_rules_and_legacy_rule_summaries_are_hidden():
     game = {
         "title": "Legacy Game",
         "summary": "legacy summary",
         "description": "legacy description",
         "content_review_status": "unknown",
+        "rules_content": CANONICAL_RULES,
+        "setup_summary": "legacy setup",
     }
 
-    assert project_player_summary(game, source_bound=False) is game
+    projected = project_player_summary(game, source_bound=False)
+
+    assert projected["rules_content"] is None
+    assert projected["setup_summary"] is None
+    assert projected["summary"] == "legacy summary"


### PR DESCRIPTION
プレイヤーがSkull Kingの詳細ページで、source-boundなcanonical rule projectionから「準備・流れ・終了」を先に確認し、そのまま詳しいルールへ進めるようにします。

- legacy game-row summaryはauthorityとして復活させない
- canonical rules_contentの既存4セクションを一時的な表示projectionへ変換
- source-boundでない場合は従来どおりルールとlegacy summaryを公開しない
- 既存のGamePage coach UIを再利用し、新しいschema/workflow/dependencyは追加しない